### PR TITLE
feat: auto-expand today's day on current week load

### DIFF
--- a/app.js
+++ b/app.js
@@ -215,10 +215,13 @@ function enforceExpandedState() {
         }
     });
     
-    // Default to Monday if no valid date found
+    // Default to today if current week, otherwise Monday
     if (!found) {
-        state.days[0].expanded = true;
-        state.lastOpenedDateByWeek[state.weekValue] = state.days[0].date;
+        const todayStr = fmtDate(new Date());
+        const todayDay = state.days.find(d => d.date === todayStr);
+        const defaultDay = todayDay || state.days[0];
+        defaultDay.expanded = true;
+        state.lastOpenedDateByWeek[state.weekValue] = defaultDay.date;
         saveState();
     }
 }


### PR DESCRIPTION
## Summary
- When no last-opened day is recorded for the selected week, the app now defaults to today's date if it falls within that week
- Falls back to Monday if today is a weekend or a different week is selected
- Existing behaviour (last-opened day persistence) is unchanged

## Changes
- `app.js` — `enforceExpandedState()`: replaced hardcoded `state.days[0]` fallback with a today-aware default

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)