### PR TITLE
fix: replace inline onclick handlers with addEventListener + data-* attributes

### DIFF
--- a/app.js
+++ b/app.js
@@ -394,6 +394,15 @@ function buildDayCard(day, dayIdx) {
         });
     });
 
+    // Quick-add inline buttons (keep ticket / keep desc)
+    wrap.querySelectorAll('.quick-add-inline').forEach(btn => {
+        btn.addEventListener('click', e => {
+            e.stopPropagation();
+            const row = btn.closest('.entry-row');
+            openEntryModalPreFilled(parseInt(row.dataset.day), parseInt(row.dataset.entry), btn.dataset.keep);
+        });
+    });
+
     // Attach drag-and-drop
     attachDragListeners(dayIdx, wrap);
 
@@ -470,18 +479,18 @@ function buildEntriesHTML(entries, dayIdx) {
             let actDescHtml = '';
 
             if (group.type === 'normal') {
-                actTicketHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Sub-task (keep ticket)" onclick="event.stopPropagation(); openEntryModalPreFilled(${dayIdx}, ${actualOriginalIndex}, 'ticket')">
+                actTicketHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Sub-task (keep ticket)" data-keep="ticket">
                     <i class="bi bi-plus"></i> <i class="bi bi-ticket-detailed"></i>
                 </button>`;
-                actDescHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Ticket to Group (keep desc)" onclick="event.stopPropagation(); openEntryModalPreFilled(${dayIdx}, ${actualOriginalIndex}, 'desc')">
+                actDescHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Ticket to Group (keep desc)" data-keep="desc">
                     <i class="bi bi-plus"></i> <i class="bi bi-card-text"></i>
                 </button>`;
             } else if (group.type === 'ticket_group') {
-                actTicketHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Sub-task (keep ticket)" onclick="event.stopPropagation(); openEntryModalPreFilled(${dayIdx}, ${actualOriginalIndex}, 'ticket')">
+                actTicketHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Sub-task (keep ticket)" data-keep="ticket">
                     <i class="bi bi-plus"></i> <i class="bi bi-ticket-detailed"></i>
                 </button>`;
             } else if (group.type === 'desc_group') {
-                actDescHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Ticket to Group (keep desc)" onclick="event.stopPropagation(); openEntryModalPreFilled(${dayIdx}, ${actualOriginalIndex}, 'desc')">
+                actDescHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Ticket to Group (keep desc)" data-keep="desc">
                     <i class="bi bi-plus"></i> <i class="bi bi-card-text"></i>
                 </button>`;
             }


### PR DESCRIPTION
## Summary
- Removed all inline `onclick` strings from quick-add buttons in `buildEntriesHTML()`
- Button context (`ticket` / `desc`) now stored in a `data-keep` attribute
- A single delegated `addEventListener` in `buildDayCard()` handles clicks, reading `data-day` and `data-entry` from the parent `.entry-row`

## Changes
- `app.js` — `buildEntriesHTML()`: replaced 3 inline onclick handlers with `data-keep` attributes
- `app.js` — `buildDayCard()`: added delegated listener for `.quick-add-inline` buttons

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)