### PR TITLE
feat: copy entry to any weekday date

### DIFF
--- a/app.js
+++ b/app.js
@@ -731,12 +731,14 @@ function openEntryModal(dayIdx, entryIdx) {
     document.getElementById('modal-entry-index').value = entryIdx;
 
     const deleteBtn = document.getElementById('btn-delete-entry');
+    const copyToBtn = document.getElementById('btn-copy-to-entry');
     const title = document.getElementById('entryModalLabel');
 
     if (entryIdx === -1) {
         // Add mode
         clearEntryModal();
         deleteBtn.style.display = 'none';
+        copyToBtn.style.display = 'none';
         title.innerHTML = `<i class="bi bi-plus-circle me-2"></i>Add Entry — ${WEEK_DAYS[dayIdx]}`;
     } else {
         // Edit mode
@@ -749,6 +751,7 @@ function openEntryModal(dayIdx, entryIdx) {
         document.getElementById('modal-group-id').value = e.groupId || '';
         document.getElementById('modal-group-type-ref').value = e.groupType || '';
         deleteBtn.style.display = 'inline-flex';
+        copyToBtn.style.display = 'inline-flex';
         title.innerHTML = `<i class="bi bi-pencil-square me-2"></i>Edit Entry — ${WEEK_DAYS[dayIdx]}`;
     }
 
@@ -964,6 +967,107 @@ function showUndoToast() {
     });
 
     setTimeout(() => { document.getElementById('undo-delete-toast')?.remove(); }, 5000);
+}
+
+/* ── COPY TO ───────────────────────────────────────────── */
+let copyToModal;
+let copyToWeekMonday = null;
+let copyToSelectedDates = [];
+
+document.addEventListener('DOMContentLoaded', () => {
+    copyToModal = new bootstrap.Modal(document.getElementById('copyToModal'));
+
+    document.getElementById('btn-copy-to-entry').addEventListener('click', () => {
+        entryModal.hide();
+        copyToWeekMonday = getDateFromWeek(state.weekValue || getWeekStrFromDate(new Date()));
+        copyToSelectedDates = [];
+        renderCopyToWeek();
+        copyToModal.show();
+    });
+
+    document.getElementById('copy-to-prev-week').addEventListener('click', () => {
+        copyToWeekMonday = new Date(copyToWeekMonday);
+        copyToWeekMonday.setDate(copyToWeekMonday.getDate() - 7);
+        renderCopyToWeek();
+    });
+
+    document.getElementById('copy-to-next-week').addEventListener('click', () => {
+        copyToWeekMonday = new Date(copyToWeekMonday);
+        copyToWeekMonday.setDate(copyToWeekMonday.getDate() + 7);
+        renderCopyToWeek();
+    });
+
+    document.getElementById('btn-confirm-copy-to').addEventListener('click', executeCopyTo);
+});
+
+function renderCopyToWeek() {
+    const mon = new Date(copyToWeekMonday);
+    const fri = new Date(mon);
+    fri.setDate(mon.getDate() + 4);
+
+    document.getElementById('copy-to-week-label').textContent =
+        `${fmtDisplayDate(fmtDate(mon))} — ${fmtDisplayDate(fmtDate(fri))}`;
+
+    const container = document.getElementById('copy-to-days');
+    container.innerHTML = '';
+
+    for (let i = 0; i < 5; i++) {
+        const dt = new Date(mon);
+        dt.setDate(mon.getDate() + i);
+        const dateStr = fmtDate(dt);
+        const dayName = WEEK_DAYS[i].slice(0, 3);
+        const dayNum = dt.getDate();
+        const isSelected = copyToSelectedDates.includes(dateStr);
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = `btn copy-to-day-btn${isSelected ? ' selected' : ''}`;
+        btn.dataset.date = dateStr;
+        btn.innerHTML = `<span class="copy-day-name">${dayName}</span><span class="copy-day-num">${dayNum}</span>`;
+        btn.addEventListener('click', () => {
+            if (copyToSelectedDates.includes(dateStr)) {
+                copyToSelectedDates = copyToSelectedDates.filter(d => d !== dateStr);
+            } else {
+                copyToSelectedDates.push(dateStr);
+            }
+            renderCopyToWeek();
+        });
+        container.appendChild(btn);
+    }
+}
+
+function executeCopyTo() {
+    if (copyToSelectedDates.length === 0) {
+        showToast('Select at least one day to copy to.', 'danger');
+        return;
+    }
+
+    const dayIdx = parseInt(document.getElementById('modal-day-index').value);
+    const entryIdx = parseInt(document.getElementById('modal-entry-index').value);
+    const src = state.days[dayIdx].entries[entryIdx];
+    const entryCopy = { ticket: src.ticket, hh: src.hh, mm: src.mm, type: src.type, desc: src.desc };
+
+    copyToSelectedDates.forEach(dateStr => {
+        if (!state.allDaysByDate[dateStr]) {
+            state.allDaysByDate[dateStr] = {
+                date: dateStr, isHoliday: false,
+                holidayLabel: 'Offshore Holiday', expanded: false, entries: []
+            };
+        }
+        state.allDaysByDate[dateStr].entries.push({ ...entryCopy });
+
+        const dayInWeek = state.days.findIndex(d => d.date === dateStr);
+        if (dayInWeek !== -1) {
+            state.days[dayInWeek] = state.allDaysByDate[dateStr];
+            rerenderDayCard(dayInWeek);
+        }
+    });
+
+    saveState();
+    updateSummary();
+    copyToModal.hide();
+    showToast(`Copied to ${copyToSelectedDates.length} day${copyToSelectedDates.length > 1 ? 's' : ''}.`, 'success');
+    copyToSelectedDates = [];
 }
 
 /* ── SUMMARY TOTALS ────────────────────────────────────── */

--- a/index.html
+++ b/index.html
@@ -200,9 +200,43 @@
           <button type="button" class="btn btn-outline-danger me-auto" id="btn-delete-entry" style="display:none">
             <i class="bi bi-trash me-1"></i> Delete
           </button>
+          <button type="button" class="btn btn-outline-accent" id="btn-copy-to-entry" style="display:none">
+            <i class="bi bi-copy me-1"></i> Copy to
+          </button>
           <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Cancel</button>
           <button type="button" class="btn btn-gradient" id="btn-save-entry">
             <i class="bi bi-check-lg me-1"></i> Save Entry
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- COPY TO MODAL -->
+  <div class="modal fade" id="copyToModal" tabindex="-1" aria-labelledby="copyToModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content modal-dark">
+        <div class="modal-header">
+          <h5 class="modal-title" id="copyToModalLabel"><i class="bi bi-copy me-2"></i>Copy Entry To</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="d-flex align-items-center justify-content-between mb-3">
+            <button class="btn btn-outline-light btn-sm px-3" id="copy-to-prev-week">
+              <i class="bi bi-chevron-left"></i>
+            </button>
+            <span class="fw-semibold" id="copy-to-week-label"></span>
+            <button class="btn btn-outline-light btn-sm px-3" id="copy-to-next-week">
+              <i class="bi bi-chevron-right"></i>
+            </button>
+          </div>
+          <div class="d-flex gap-2 justify-content-center" id="copy-to-days"></div>
+          <div class="form-text text-muted text-center mt-3">Click days to select. Click again to deselect.</div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-gradient" id="btn-confirm-copy-to">
+            <i class="bi bi-check-lg me-1"></i> Copy
           </button>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -894,3 +894,44 @@ body::before {
   color: var(--text-muted) !important;
   opacity: 1;
 }
+
+/* ── COPY TO DAY PICKER ──────────────────────────────────── */
+.copy-to-day-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 64px;
+  border: 1.5px solid var(--border-accent);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  gap: 2px;
+  transition: all 0.15s ease;
+}
+
+.copy-to-day-btn:hover {
+  border-color: var(--accent-light);
+  color: var(--text-primary);
+  background: var(--bg-card-hover);
+}
+
+.copy-to-day-btn.selected {
+  border-color: var(--success);
+  background: rgba(34, 211, 160, 0.12);
+  color: var(--success);
+}
+
+.copy-day-name {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.copy-day-num {
+  font-size: 1.1rem;
+  font-weight: 700;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- Adds a **Copy to** button in the entry edit modal (hidden in add mode)
- Opens a week-based date picker with Mon–Fri day buttons and prev/next week navigation
- Multi-select — pick any number of days across any week
- Copies all entry fields (ticket, hh, mm, type, desc) to each selected day
- If target day is in the current week, its card re-renders immediately

## Changes
- `index.html` — Copy to button in entry modal footer, new Copy To modal
- `app.js` — `renderCopyToWeek()`, `executeCopyTo()`, Copy to modal init and events, `openEntryModal()` wired to show/hide button
- `styles.css` — `.copy-to-day-btn` day picker styling

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)