### PR TITLE
feat: recurring tasks

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,8 @@ let state = {
     weekValue: '',   // e.g. "2026-W11"
     allDaysByDate: {}, // Map of 'YYYY-MM-DD' to day object
     days: [],          // array of 5 active day objects mapping to current week
-    lastOpenedDateByWeek: {} // map of 'YYYY-Www' to 'YYYY-MM-DD'
+    lastOpenedDateByWeek: {}, // map of 'YYYY-Www' to 'YYYY-MM-DD'
+    recurringTasks: [] // array of recurring task rules
 };
 
 /* day object shape:
@@ -62,7 +63,8 @@ function saveState() {
             employeeName: state.employeeName,
             weekValue: state.weekValue,
             allDaysByDate: state.allDaysByDate,
-            lastOpenedDateByWeek: state.lastOpenedDateByWeek
+            lastOpenedDateByWeek: state.lastOpenedDateByWeek,
+            recurringTasks: state.recurringTasks
         };
         localStorage.setItem(LS_KEY, JSON.stringify(toSave));
     } catch (e) { console.warn('Could not save to localStorage', e); }
@@ -80,6 +82,7 @@ function loadState() {
         state.weekValue = saved.weekValue || '';
         state.allDaysByDate = saved.allDaysByDate || {};
         state.lastOpenedDateByWeek = saved.lastOpenedDateByWeek || {};
+        state.recurringTasks = saved.recurringTasks || [];
 
         // Backwards compatibility migration
         if (saved.days && Array.isArray(saved.days)) {
@@ -187,6 +190,7 @@ function buildWeekDays(monDt) {
         }
         currentDt.setDate(currentDt.getDate() + 1);
     }
+    populateRecurringForWeek(monDt);
     return days;
 }
 
@@ -502,6 +506,7 @@ function buildEntriesHTML(entries, dayIdx) {
       ${ticketHtml}
       <span class="entry-hours">${hhmm}</span>
       ${isSd ? '<span class="entry-type-badge">Service Desk</span>' : ''}
+      ${e.recurringId ? '<span class="entry-recurring-badge" title="Recurring task"><i class="bi bi-arrow-repeat"></i></span>' : ''}
       ${descHtml}
       <div class="entry-actions ms-auto d-flex align-items-center gap-2">
         ${actTicketHtml}
@@ -886,6 +891,8 @@ function saveEntryInternal() {
     if (entryIdx === -1) {
         state.days[dayIdx].entries.push(entry);
     } else {
+        const existing = state.days[dayIdx].entries[entryIdx];
+        if (existing && existing.recurringId) entry.recurringId = existing.recurringId;
         state.days[dayIdx].entries[entryIdx] = entry;
     }
     
@@ -1068,6 +1075,235 @@ function executeCopyTo() {
     copyToModal.hide();
     showToast(`Copied to ${copyToSelectedDates.length} day${copyToSelectedDates.length > 1 ? 's' : ''}.`, 'success');
     copyToSelectedDates = [];
+}
+
+/* ── RECURRING TASKS ───────────────────────────────────── */
+const RECURRING_DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+const DAY_IDX_TO_NAME = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri' };
+
+function populateRecurringForWeek(monDt) {
+    if (!state.recurringTasks || state.recurringTasks.length === 0) return;
+    for (let i = 0; i < 5; i++) {
+        const dt = new Date(monDt);
+        dt.setDate(monDt.getDate() + i);
+        const dateStr = fmtDate(dt);
+        const dayName = RECURRING_DAY_NAMES[i];
+        const day = state.allDaysByDate[dateStr];
+        if (!day) continue;
+        state.recurringTasks.forEach(rule => {
+            if (!rule.days.includes(dayName)) return;
+            const exists = day.entries.some(e => e.recurringId === rule.id);
+            if (!exists) {
+                day.entries.push({ ticket: rule.ticket, hh: rule.hh, mm: rule.mm, type: rule.type, desc: rule.desc, recurringId: rule.id });
+            }
+        });
+    }
+}
+
+function updateRecurringEntriesFromToday(rule) {
+    const todayStr = fmtDate(new Date());
+    Object.keys(state.allDaysByDate).forEach(dateStr => {
+        if (dateStr < todayStr) return;
+        const dt = new Date(dateStr + 'T00:00:00');
+        const dayName = DAY_IDX_TO_NAME[dt.getDay()];
+        if (!dayName) return;
+        const day = state.allDaysByDate[dateStr];
+        const idx = day.entries.findIndex(e => e.recurringId === rule.id);
+        if (rule.days.includes(dayName)) {
+            if (idx !== -1) {
+                day.entries[idx] = { ...day.entries[idx], ticket: rule.ticket, hh: rule.hh, mm: rule.mm, type: rule.type, desc: rule.desc };
+            }
+        } else if (idx !== -1) {
+            day.entries.splice(idx, 1);
+        }
+    });
+}
+
+function deleteRecurringEntriesFromToday(ruleId) {
+    const rule = state.recurringTasks.find(r => r.id === ruleId);
+    const ruleTicket = rule ? rule.ticket : null;
+    const currentWeekMonday = fmtDate(getDateFromWeek(state.weekValue || getWeekStrFromDate(new Date())));
+    Object.keys(state.allDaysByDate).forEach(dateStr => {
+        if (dateStr < currentWeekMonday) return;
+        const day = state.allDaysByDate[dateStr];
+        day.entries = day.entries.filter(e => {
+            if (e.recurringId === ruleId) return false;
+            if (e.recurringId && ruleTicket && e.ticket === ruleTicket) return false;
+            return true;
+        });
+    });
+}
+
+let recurringModal;
+let recurringFormModal;
+
+document.addEventListener('DOMContentLoaded', () => {
+    recurringModal = new bootstrap.Modal(document.getElementById('recurringModal'));
+    recurringFormModal = new bootstrap.Modal(document.getElementById('recurringFormModal'));
+
+    document.getElementById('menu-recurring').addEventListener('click', e => {
+        e.preventDefault();
+        document.querySelector('#appSidebar .btn-close')?.click();
+        setTimeout(() => {
+            renderRecurringList();
+            recurringModal.show();
+        }, 300);
+    });
+
+    document.getElementById('btn-add-recurring').addEventListener('click', () => {
+        recurringModal.hide();
+        setTimeout(() => openRecurringForm(null), 300);
+    });
+
+    document.getElementById('btn-recurring-form-close').addEventListener('click', () => {
+        recurringFormModal.hide();
+        setTimeout(() => { renderRecurringList(); recurringModal.show(); }, 300);
+    });
+
+    document.getElementById('btn-recurring-form-cancel').addEventListener('click', () => {
+        recurringFormModal.hide();
+        setTimeout(() => { renderRecurringList(); recurringModal.show(); }, 300);
+    });
+
+    document.getElementById('btn-save-recurring').addEventListener('click', saveRecurringRule);
+
+    // Day toggle buttons
+    document.querySelectorAll('.recurring-day-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            btn.classList.toggle('selected');
+            syncAllDaysCheckbox();
+        });
+    });
+
+    document.getElementById('recurring-all-days').addEventListener('change', e => {
+        document.querySelectorAll('.recurring-day-btn').forEach(btn => {
+            btn.classList.toggle('selected', e.target.checked);
+        });
+    });
+});
+
+function syncAllDaysCheckbox() {
+    const all = document.querySelectorAll('.recurring-day-btn');
+    const selected = document.querySelectorAll('.recurring-day-btn.selected');
+    document.getElementById('recurring-all-days').checked = all.length === selected.length;
+}
+
+function renderRecurringList() {
+    const container = document.getElementById('recurring-list');
+    if (!state.recurringTasks || state.recurringTasks.length === 0) {
+        container.innerHTML = `<p class="text-muted text-center py-4">No recurring tasks yet. Click "Add Recurring Task" to create one.</p>`;
+        return;
+    }
+    container.innerHTML = state.recurringTasks.map(rule => `
+    <div class="recurring-rule-card mb-3">
+      <div class="d-flex align-items-start justify-content-between gap-2">
+        <div class="flex-fill">
+          <div class="d-flex align-items-center gap-2 mb-1">
+            <span class="entry-ticket ${rule.type === 'servicedesk' ? 'servicedesk' : ''}">${escHtml(rule.ticket || '—')}</span>
+            <span class="entry-hours">${String(rule.hh || 0).padStart(2,'0')}:${String(rule.mm || 0).padStart(2,'0')}</span>
+            ${rule.type === 'servicedesk' ? '<span class="entry-type-badge">Service Desk</span>' : ''}
+          </div>
+          <div class="text-muted" style="font-size:0.85rem">${escHtml(rule.desc || '')}</div>
+          <div class="d-flex gap-1 mt-2">
+            ${RECURRING_DAY_NAMES.map(d => `<span class="recurring-day-chip${rule.days.includes(d) ? ' active' : ''}">${d}</span>`).join('')}
+          </div>
+        </div>
+        <div class="d-flex gap-2">
+          <button class="btn btn-sm btn-outline-light" data-rule-id="${rule.id}" data-action="edit" title="Edit">
+            <i class="bi bi-pencil-square"></i>
+          </button>
+          <button class="btn btn-sm btn-outline-danger" data-rule-id="${rule.id}" data-action="delete" title="Delete">
+            <i class="bi bi-trash"></i>
+          </button>
+        </div>
+      </div>
+    </div>`).join('');
+
+    container.querySelectorAll('[data-action="edit"]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const rule = state.recurringTasks.find(r => r.id === btn.dataset.ruleId);
+            if (rule) { recurringModal.hide(); setTimeout(() => openRecurringForm(rule), 300); }
+        });
+    });
+    container.querySelectorAll('[data-action="delete"]').forEach(btn => {
+        btn.addEventListener('click', () => deleteRecurringRule(btn.dataset.ruleId));
+    });
+}
+
+function openRecurringForm(rule) {
+    document.getElementById('recurring-form-id').value = rule ? rule.id : '';
+    document.getElementById('recurring-ticket').value = rule ? rule.ticket : '';
+    document.getElementById('recurring-hh').value = rule ? rule.hh : '';
+    document.getElementById('recurring-mm').value = rule ? String(rule.mm || 0).padStart(2, '0') : '00';
+    document.getElementById('recurring-type').value = rule ? rule.type : 'jira';
+    document.getElementById('recurring-desc').value = rule ? rule.desc : '';
+    document.getElementById('recurringFormTitle').innerHTML =
+        `<i class="bi bi-arrow-repeat me-2"></i>${rule ? 'Edit' : 'Add'} Recurring Task`;
+
+    document.querySelectorAll('.recurring-day-btn').forEach(btn => {
+        btn.classList.toggle('selected', rule ? rule.days.includes(btn.dataset.day) : false);
+    });
+    syncAllDaysCheckbox();
+
+    [document.getElementById('recurring-ticket'), document.getElementById('recurring-desc'),
+     document.getElementById('recurring-hh'), document.getElementById('recurring-mm')]
+        .forEach(el => el.classList.remove('is-invalid'));
+
+    recurringFormModal.show();
+}
+
+function saveRecurringRule() {
+    const ticket = document.getElementById('recurring-ticket').value.trim();
+    const hh = parseInt(document.getElementById('recurring-hh').value) || 0;
+    const mm = parseInt(document.getElementById('recurring-mm').value) || 0;
+    const type = document.getElementById('recurring-type').value;
+    const desc = document.getElementById('recurring-desc').value.trim();
+    const selectedDays = [...document.querySelectorAll('.recurring-day-btn.selected')].map(b => b.dataset.day);
+
+    let hasError = false;
+    [document.getElementById('recurring-ticket'), document.getElementById('recurring-desc'),
+     document.getElementById('recurring-hh'), document.getElementById('recurring-mm')]
+        .forEach(el => el.classList.remove('is-invalid'));
+
+    if (!ticket) { document.getElementById('recurring-ticket').classList.add('is-invalid'); hasError = true; }
+    if (!desc) { document.getElementById('recurring-desc').classList.add('is-invalid'); hasError = true; }
+    if (hh === 0 && mm === 0) {
+        document.getElementById('recurring-hh').classList.add('is-invalid');
+        document.getElementById('recurring-mm').classList.add('is-invalid');
+        hasError = true;
+    }
+    if (selectedDays.length === 0) { showToast('Select at least one day.', 'danger'); hasError = true; }
+    if (hasError) return;
+
+    const existingId = document.getElementById('recurring-form-id').value;
+    if (existingId) {
+        const rule = state.recurringTasks.find(r => r.id === existingId);
+        if (rule) {
+            Object.assign(rule, { ticket, hh, mm, type, desc, days: selectedDays });
+            updateRecurringEntriesFromToday(rule);
+        }
+    } else {
+        const rule = { id: 'rec_' + Date.now(), ticket, hh, mm, type, desc, days: selectedDays };
+        state.recurringTasks.push(rule);
+        populateRecurringForWeek(getDateFromWeek(state.weekValue || getWeekStrFromDate(new Date())));
+    }
+
+    saveState();
+    state.days.forEach((_, i) => rerenderDayCard(i));
+    updateSummary();
+    recurringFormModal.hide();
+    setTimeout(() => { renderRecurringList(); recurringModal.show(); }, 300);
+    showToast('Recurring task saved.', 'success');
+}
+
+function deleteRecurringRule(ruleId) {
+    deleteRecurringEntriesFromToday(ruleId);
+    state.recurringTasks = state.recurringTasks.filter(r => r.id !== ruleId);
+    saveState();
+    state.days.forEach((_, i) => rerenderDayCard(i));
+    updateSummary();
+    renderRecurringList();
+    showToast('Recurring task deleted.', 'success');
 }
 
 /* ── SUMMARY TOTALS ────────────────────────────────────── */

--- a/index.html
+++ b/index.html
@@ -243,6 +243,89 @@
     </div>
   </div>
 
+  <!-- RECURRING TASKS LIST MODAL -->
+  <div class="modal fade" id="recurringModal" tabindex="-1" aria-labelledby="recurringModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content modal-dark">
+        <div class="modal-header">
+          <h5 class="modal-title" id="recurringModalLabel"><i class="bi bi-arrow-repeat me-2"></i>Recurring Tasks</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div id="recurring-list"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-gradient" id="btn-add-recurring">
+            <i class="bi bi-plus-circle me-1"></i> Add Recurring Task
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- RECURRING TASK FORM MODAL -->
+  <div class="modal fade" id="recurringFormModal" tabindex="-1" aria-labelledby="recurringFormTitle" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content modal-dark">
+        <div class="modal-header">
+          <h5 class="modal-title" id="recurringFormTitle"><i class="bi bi-arrow-repeat me-2"></i>Add Recurring Task</h5>
+          <button type="button" class="btn-close btn-close-white" id="btn-recurring-form-close"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" id="recurring-form-id" />
+          <div class="row g-3">
+            <div class="col-12 col-lg-5">
+              <label class="form-label label-text">Ticket / Reference ID</label>
+              <input type="text" id="recurring-ticket" class="form-control dark-input" placeholder="e.g. JIRA-123 or #123" />
+            </div>
+            <div class="col-6 col-md-3 col-lg-2">
+              <label class="form-label label-text">Hours (HH)</label>
+              <input type="number" id="recurring-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="00" />
+            </div>
+            <div class="col-6 col-md-3 col-lg-2">
+              <label class="form-label label-text">Minutes (MM)</label>
+              <input type="number" id="recurring-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" />
+            </div>
+            <div class="col-12 col-md-6 col-lg-3">
+              <label class="form-label label-text">Type</label>
+              <select id="recurring-type" class="form-select dark-input">
+                <option value="jira">Jira</option>
+                <option value="servicedesk">Service Desk</option>
+              </select>
+            </div>
+            <div class="col-12">
+              <label class="form-label label-text">Description</label>
+              <textarea id="recurring-desc" class="form-control dark-input" rows="2" placeholder="Brief description of work done..."></textarea>
+            </div>
+            <div class="col-12">
+              <label class="form-label label-text d-block mb-2">Repeat on</label>
+              <div class="d-flex align-items-center gap-3 flex-wrap">
+                <div class="form-check mb-0">
+                  <input class="form-check-input" type="checkbox" id="recurring-all-days" />
+                  <label class="form-check-label label-text" for="recurring-all-days">All weekdays</label>
+                </div>
+                <div class="d-flex gap-2">
+                  <button type="button" class="btn recurring-day-btn" data-day="Mon">Mon</button>
+                  <button type="button" class="btn recurring-day-btn" data-day="Tue">Tue</button>
+                  <button type="button" class="btn recurring-day-btn" data-day="Wed">Wed</button>
+                  <button type="button" class="btn recurring-day-btn" data-day="Thu">Thu</button>
+                  <button type="button" class="btn recurring-day-btn" data-day="Fri">Fri</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-light" id="btn-recurring-form-cancel">Cancel</button>
+          <button type="button" class="btn btn-gradient" id="btn-save-recurring">
+            <i class="bi bi-check-lg me-1"></i> Save
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- PRINT AREA (hidden, used for window.print) -->
   <div id="print-area" style="display:none"></div>
   
@@ -257,6 +340,10 @@
         <a href="#" class="sidebar-menu-item" id="menu-about">
           <i class="bi bi-info-circle me-3"></i>
           <span>About Timesheet Manager</span>
+        </a>
+        <a href="#" class="sidebar-menu-item" id="menu-recurring">
+          <i class="bi bi-arrow-repeat me-3"></i>
+          <span>Recurring Tasks</span>
         </a>
         <a href="#" class="sidebar-menu-item" id="btn-theme-toggle">
           <i class="bi bi-moon-fill me-3" id="theme-icon"></i>

--- a/styles.css
+++ b/styles.css
@@ -935,3 +935,59 @@ body::before {
   font-weight: 700;
   line-height: 1;
 }
+
+/* ── RECURRING TASKS ─────────────────────────────────────── */
+.recurring-day-btn {
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1.5px solid var(--border-accent);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  transition: all 0.15s ease;
+}
+
+.recurring-day-btn:hover {
+  border-color: var(--accent-light);
+  color: var(--text-primary);
+}
+
+.recurring-day-btn.selected {
+  border-color: var(--success);
+  background: rgba(34, 211, 160, 0.12);
+  color: var(--success);
+}
+
+.entry-recurring-badge {
+  font-size: 0.7rem;
+  color: var(--success);
+  opacity: 0.8;
+}
+
+.recurring-rule-card {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+}
+
+.recurring-day-chip {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--bg-card);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+
+.recurring-day-chip.active {
+  background: rgba(34, 211, 160, 0.12);
+  color: var(--success);
+  border-color: var(--success);
+}
+
+#recurring-list .text-muted {
+  color: var(--text-secondary) !important;
+}


### PR DESCRIPTION
## Summary
- New **Recurring Tasks** item in sidebar menu opens a list/form modal
- Each rule defines ticket, time, type, description and repeat days (specific or all Mon–Fri)
- Recurring entries auto-populate when a week is loaded; marked with a ↻ badge
- Editing an instance → affects only that day (rule unchanged)
- Editing the rule → updates entries from today onward, past entries untouched
- Deleting the rule → removes entries from current week onward (including same-ticket orphans), previous weeks untouched
- Dark mode visibility fixed for empty state hint and rule descriptions

## Changes
- `index.html` — sidebar item, recurring list modal, recurring form modal
- `app.js` — state + persistence, `populateRecurringForWeek()`, `updateRecurringEntriesFromToday()`, `deleteRecurringEntriesFromToday()`, full modal init/render/save/delete logic, recurring badge in entry rows, `recurringId` preserved on instance edits
- `styles.css` — day toggle buttons, recurring badge, rule card, day chips, dark mode fixes

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)