### PR TITLE
feat: configurable daily target with circular progress ring

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,8 @@
 'use strict';
 
 /* ── CONSTANTS ─────────────────────────────────────────── */
+const APP_VERSION = '1.2.0';
+
 const WEEK_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
 const ROMAN = ['i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x',
     'xi', 'xii', 'xiii', 'xiv', 'xv', 'xvi', 'xvii', 'xviii', 'xix', 'xx'];
@@ -20,7 +22,8 @@ let state = {
     allDaysByDate: {}, // Map of 'YYYY-MM-DD' to day object
     days: [],          // array of 5 active day objects mapping to current week
     lastOpenedDateByWeek: {}, // map of 'YYYY-Www' to 'YYYY-MM-DD'
-    recurringTasks: [] // array of recurring task rules
+    recurringTasks: [],  // array of recurring task rules
+    dailyTargetMins: 480 // daily target in minutes (default 8h)
 };
 
 /* day object shape:
@@ -64,7 +67,8 @@ function saveState() {
             weekValue: state.weekValue,
             allDaysByDate: state.allDaysByDate,
             lastOpenedDateByWeek: state.lastOpenedDateByWeek,
-            recurringTasks: state.recurringTasks
+            recurringTasks: state.recurringTasks,
+            dailyTargetMins: state.dailyTargetMins
         };
         localStorage.setItem(LS_KEY, JSON.stringify(toSave));
     } catch (e) { console.warn('Could not save to localStorage', e); }
@@ -83,6 +87,7 @@ function loadState() {
         state.allDaysByDate = saved.allDaysByDate || {};
         state.lastOpenedDateByWeek = saved.lastOpenedDateByWeek || {};
         state.recurringTasks = saved.recurringTasks || [];
+        state.dailyTargetMins = saved.dailyTargetMins || 480;
 
         // Backwards compatibility migration
         if (saved.days && Array.isArray(saved.days)) {
@@ -98,6 +103,7 @@ function loadState() {
 
 /* ── INIT ──────────────────────────────────────────────── */
 document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
     initTheme();
     initSidebar();
     initScheduledTasks();
@@ -107,6 +113,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Always apply these inputs if we have them in state, regardless of whether a week was previously saved or not
     document.getElementById('report-title').value = state.reportTitle || '';
     document.getElementById('emp-name').value = state.employeeName || '';
+    const tgt = state.dailyTargetMins || 480;
+    document.getElementById('target-hh').value = Math.floor(tgt / 60);
+    document.getElementById('target-mm').value = tgt % 60;
 
     if (restored && state.weekValue) {
         // Restore saved week & name into inputs
@@ -274,6 +283,18 @@ function bindHeaderEvents() {
         renderAll();
     });
 
+    const updateTarget = () => {
+        const hh = parseInt(document.getElementById('target-hh').value) || 0;
+        const mm = parseInt(document.getElementById('target-mm').value) || 0;
+        const mins = hh * 60 + mm;
+        if (mins < 1) return;
+        state.dailyTargetMins = mins;
+        renderDays();
+        saveState();
+    };
+    document.getElementById('target-hh').addEventListener('change', updateTarget);
+    document.getElementById('target-mm').addEventListener('change', updateTarget);
+
     document.getElementById('btn-preview').addEventListener('click', openPreview);
     document.getElementById('btn-print').addEventListener('click', doPrint);
     document.getElementById('btn-copy-txt').addEventListener('click', copyTxt);
@@ -301,6 +322,65 @@ function renderDays() {
 }
 
 /* ── BUILD DAY CARD ────────────────────────────────────── */
+function buildProgressRing(dayNumber, totalMins, isHoliday) {
+    const targetMins = state.dailyTargetMins || 480;
+    const r = 16;
+    const circ = +(2 * Math.PI * r).toFixed(2); // 100.53
+    const pct = isHoliday ? 0 : Math.min(totalMins / targetMins, 1);
+    const offset = +(circ * (1 - pct)).toFixed(2);
+
+    let strokeColor, trackColor, textColor;
+    if (isHoliday) {
+        strokeColor = 'var(--warning)';
+        trackColor = 'rgba(251,191,36,0.15)';
+        textColor = 'var(--warning)';
+    } else if (pct === 0) {
+        strokeColor = 'transparent';
+        trackColor = 'var(--border)';
+        textColor = 'var(--text-secondary)';
+    } else if (pct < 0.8) {
+        strokeColor = 'var(--warning)';
+        trackColor = 'var(--border)';
+        textColor = 'var(--text-secondary)';
+    } else if (pct < 1) {
+        strokeColor = 'var(--success)';
+        trackColor = 'var(--border)';
+        textColor = 'var(--text-secondary)';
+    } else {
+        strokeColor = '#4ade80';
+        trackColor = 'rgba(74,222,128,0.12)';
+        textColor = '#4ade80';
+    }
+
+    let tooltip = '';
+    if (!isHoliday) {
+        const remaining = targetMins - totalMins;
+        if (totalMins === 0) {
+            const th = Math.floor(targetMins / 60), tm = targetMins % 60;
+            tooltip = tm > 0 ? `${th}h ${tm}m remaining` : `${th}h remaining`;
+        } else if (remaining > 0) {
+            const rh = Math.floor(remaining / 60), rm = remaining % 60;
+            tooltip = rm > 0 ? `${rh}h ${rm}m remaining` : `${rh}h remaining`;
+        } else if (remaining === 0) {
+            tooltip = 'Target met!';
+        } else {
+            const oh = Math.floor(-remaining / 60), om = (-remaining) % 60;
+            tooltip = om > 0 ? `${oh}h ${om}m over target` : `${oh}h over target`;
+        }
+    }
+
+    return `<div class="day-progress-ring" title="${tooltip}">
+      <svg width="38" height="38" viewBox="0 0 38 38">
+        <circle cx="19" cy="19" r="${r}" fill="none" style="stroke:${trackColor}" stroke-width="3"/>
+        <circle cx="19" cy="19" r="${r}" fill="none" style="stroke:${strokeColor}"
+          stroke-width="3" stroke-dasharray="${circ}" stroke-dashoffset="${offset}"
+          stroke-linecap="round" transform="rotate(-90 19 19)"/>
+        <text x="19" y="19" text-anchor="middle" dominant-baseline="central"
+          style="font-size:11px;font-weight:700;fill:${textColor};font-family:inherit">${dayNumber}</text>
+      </svg>
+    </div>`;
+}
+
 function buildDayCard(day, dayIdx) {
     const dayName = WEEK_DAYS[dayIdx];
     const displayDate = fmtDisplayDate(day.date);
@@ -325,7 +405,7 @@ function buildDayCard(day, dayIdx) {
     wrap.innerHTML = `
     <div class="day-card-header" data-day="${dayIdx}">
       <div class="day-badge">
-        <div class="day-number${day.isHoliday ? ' holiday' : ''}">${dayIdx + 1}</div>
+        ${buildProgressRing(dayIdx + 1, totalMins, day.isHoliday)}
         <div>
           <div class="day-name">${dayName}${isWeekend ? ' <span class="badge bg-secondary" style="font-size:0.6rem">Weekend</span>' : ''}</div>
           <div class="day-date">${displayDate}</div>
@@ -885,10 +965,13 @@ function saveEntryInternal() {
         });
     }
 
-    if (totalMinsForDay > 8 * 60) {
+    if (totalMinsForDay > state.dailyTargetMins) {
         const totalH = Math.floor(totalMinsForDay / 60);
         const totalM = totalMinsForDay % 60;
-        const confirmHigh = confirm(`This entry will bring your total logged time for the day to over 8 hours (${totalH}h ${totalM}m). Are you sure you want to log this much time?`);
+        const targetH = Math.floor(state.dailyTargetMins / 60);
+        const targetM = state.dailyTargetMins % 60;
+        const targetLabel = targetM > 0 ? `${targetH}h ${targetM}m` : `${targetH}h`;
+        const confirmHigh = confirm(`This entry will bring your total logged time for the day to over ${targetLabel} (${totalH}h ${totalM}m). Are you sure you want to log this much time?`);
         if (!confirmHigh) return false;
     }
 

--- a/index.html
+++ b/index.html
@@ -75,6 +75,16 @@
               <i class="bi bi-calendar-week me-1"></i> Use Current Week
             </button>
 
+            <div class="mb-3 mt-3">
+              <label class="form-label label-text">Daily Target</label>
+              <div class="d-flex align-items-center gap-2">
+                <input type="number" id="target-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="08" style="max-width:64px" />
+                <span class="label-text">hrs</span>
+                <input type="number" id="target-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" style="max-width:64px" />
+                <span class="label-text">min</span>
+              </div>
+            </div>
+
             <hr class="border-secondary my-4 opacity-25">
 
             <!-- Totals Area inside the sidebar -->
@@ -432,7 +442,7 @@
       <div class="sidebar-footer p-3 border-top border-secondary border-opacity-25 mt-auto">
         <div class="d-flex align-items-center gap-2 text-muted-v" style="font-size: 0.8rem;">
           <i class="bi bi-cpu"></i>
-          <span>v1.1.0 — Desktop App</span>
+          <span>v<span class="app-version"></span> — Desktop App</span>
         </div>
       </div>
     </div>
@@ -447,7 +457,7 @@
             <img src="favicon.png" alt="App Logo" style="width: 80px; height: 80px; border-radius: 20px; box-shadow: 0 10px 30px rgba(0,0,0,0.5);">
           </div>
           <h3 class="mb-1">Timesheet Manager</h3>
-          <p class="text-accent mb-2">v1.1.0</p>
+          <p class="text-accent mb-2">v<span class="app-version"></span></p>
           <p class="text-muted-v mb-4" style="font-size: 0.9rem;">Developed by <span class="text-white fw-bold">Veera Bharath</span></p>
           <div class="text-start mb-4">
             <p class="text-muted mb-2">Developed for seamless Jira & Service Desk time tracking.</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timesheet-manager",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Weekly Jira & Service Desk Time Tracking Application",
   "main": "main.js",
   "scripts": {

--- a/styles.css
+++ b/styles.css
@@ -89,11 +89,7 @@
   background: var(--bg-base);
   color: var(--text-primary);
 }
-[data-theme="light"] .day-number {
-  background: rgba(0, 0, 0, 0.04);
-  color: var(--text-primary);
-  border-color: rgba(0, 0, 0, 0.1);
-}
+
 [data-theme="light"] .day-card-header {
   background: rgba(0, 0, 0, 0.02);
 }
@@ -346,25 +342,13 @@ body::before {
   gap: 12px;
 }
 
-.day-number {
-  width: 38px;
-  height: 38px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, rgba(180, 180, 180, 0.12), rgba(180, 180, 180, 0.04));
-  border: 1px solid rgba(160, 160, 160, 0.25);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  font-size: 0.9rem;
-  color: #c8c8c8;
+.day-progress-ring {
   flex-shrink: 0;
+  cursor: default;
 }
 
-.day-number.holiday {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.2), rgba(251, 191, 36, 0.05));
-  border-color: rgba(251, 191, 36, 0.3);
-  color: var(--warning);
+.day-progress-ring svg {
+  display: block;
 }
 
 .day-name {


### PR DESCRIPTION
Closes #27

## Summary
- **Daily Target** (HH + MM) input added to Sheet Details panel, default 8h 00m
- Stored as `dailyTargetMins` in state/localStorage; replaces hardcoded `8 * 60` in over-limit warning
- **SVG circular progress ring** replaces the static day-number badge on each day card
- Day number stays as text inside the ring — no visual disruption when empty
- Ring color reflects completion positively: gray → amber → teal → green
- Hover tooltip shows `Xh Ym remaining` / `Target met!` / `Xh Ym over target`
- Holiday days show yellow-tinted ring with no progress fill
- Changing daily target rerenders all 5 rings instantly
- `APP_VERSION` constant defined once in `app.js` — sidebar footer and About modal populated dynamically
- Version bumped to `1.2.0` in `app.js`, `index.html`, and `package.json`

## Test plan
- [ ] Default rings show gray (empty) on load
- [ ] Add entries → ring fills amber → teal at 80% → green at 100%
- [ ] Hover ring → tooltip shows correct remaining/over time
- [ ] Change daily target → all rings update instantly
- [ ] Set 7h 30m target → warning triggers at correct threshold
- [ ] Holiday day → yellow ring, no progress
- [ ] Sidebar footer shows `v1.2.0`
- [ ] About modal shows `v1.2.0`
- [ ] Light mode: rings visible and correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)