### PR TITLE
feat: HH to MM auto-advance on all time inputs

### DIFF
--- a/app.js
+++ b/app.js
@@ -302,6 +302,18 @@ function bindHeaderEvents() {
     document.getElementById('btn-save-entry').addEventListener('click', saveEntry);
     document.getElementById('btn-delete-entry').addEventListener('click', deleteEntry);
     document.getElementById('btn-make-regular').addEventListener('click', makeRegularEntry);
+
+    // HH → MM auto-advance for all time input pairs
+    [
+        ['modal-hh',          'modal-mm'],
+        ['recurring-hh',      'recurring-mm'],
+        ['scheduled-form-hh', 'scheduled-form-mm'],
+        ['target-hh',         'target-mm'],
+    ].forEach(([hhId, mmId]) => {
+        document.getElementById(hhId).addEventListener('input', function () {
+            if (this.value.length >= 2) document.getElementById(mmId).focus();
+        });
+    });
 }
 
 /* ── RENDER ALL ────────────────────────────────────────── */


### PR DESCRIPTION
Closes #30

## Summary
When the user types a 2-digit value in any HH field, focus automatically moves to the paired MM field.

## Affected pairs
- Add / Edit Entry modal (`modal-hh` → `modal-mm`)
- Recurring Task form (`recurring-hh` → `recurring-mm`)
- Scheduled Task form (`scheduled-form-hh` → `scheduled-form-mm`)
- Daily Target in Sheet Details (`target-hh` → `target-mm`)

## Test plan
- [ ] Type `07` in entry modal HH → focus jumps to MM
- [ ] Type `5` then Tab → normal tab navigation to MM
- [ ] Same behaviour in recurring, scheduled, and daily target forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)