### PR TITLE
feat: replace native confirm() with Bootstrap modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -983,19 +983,28 @@ function saveEntryInternal() {
         const targetH = Math.floor(state.dailyTargetMins / 60);
         const targetM = state.dailyTargetMins % 60;
         const targetLabel = targetM > 0 ? `${targetH}h ${targetM}m` : `${targetH}h`;
-        const confirmHigh = confirm(`This entry will bring your total logged time for the day to over ${targetLabel} (${totalH}h ${totalM}m). Are you sure you want to log this much time?`);
-        if (!confirmHigh) return false;
+        showConfirm(
+            `This entry will bring your total for the day to ${totalH}h ${totalM}m — over the ${targetLabel} target. Continue?`,
+            () => commitEntry(dayIdx, entryIdx)
+        );
+        return false; // halt here; commitEntry will handle the rest if confirmed
     }
 
+    commitEntry(dayIdx, entryIdx);
+    return true;
+}
+
+function commitEntry(dayIdx, entryIdx) {
     const groupId = document.getElementById('modal-group-id').value;
     const groupType = document.getElementById('modal-group-type-ref').value;
+    const tkt = document.getElementById('modal-ticket').value.trim();
+    const hh = parseInt(document.getElementById('modal-hh').value) || 0;
+    const mm = parseInt(document.getElementById('modal-mm').value) || 0;
+    const type = document.getElementById('modal-type').value;
+    const desc = document.getElementById('modal-desc').value.trim();
 
     const entry = { ticket: tkt, hh, mm, type, desc };
-
-    if (groupId) {
-        entry.groupId = groupId;
-        entry.groupType = groupType;
-    }
+    if (groupId) { entry.groupId = groupId; entry.groupType = groupType; }
 
     if (entryIdx === -1) {
         state.days[dayIdx].entries.push(entry);
@@ -1009,7 +1018,7 @@ function saveEntryInternal() {
     rerenderDayCard(dayIdx);
     updateSummary();
     saveState();
-    return true;
+    entryModal.hide();
 }
 
 function saveEntry() {
@@ -1659,6 +1668,18 @@ function doPrint() {
 }
 
 /* ── TOAST ─────────────────────────────────────────────── */
+let confirmModal;
+function showConfirm(message, onYes) {
+    if (!confirmModal) confirmModal = new bootstrap.Modal(document.getElementById('confirmModal'));
+    document.getElementById('confirm-modal-message').textContent = message;
+    const yesBtn = document.getElementById('btn-confirm-yes');
+    const noBtn = document.getElementById('btn-confirm-no');
+    const cleanup = () => { yesBtn.onclick = null; noBtn.onclick = null; };
+    yesBtn.onclick = () => { confirmModal.hide(); cleanup(); onYes(); };
+    noBtn.onclick = () => { confirmModal.hide(); cleanup(); };
+    confirmModal.show();
+}
+
 function showToast(msg, type = 'success') {
     let container = document.querySelector('.toast-container');
     if (!container) {

--- a/index.html
+++ b/index.html
@@ -339,6 +339,22 @@
     </div>
   </div>
 
+  <!-- CONFIRM DIALOG MODAL -->
+  <div class="modal fade" id="confirmModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-sm">
+      <div class="modal-content modal-dark">
+        <div class="modal-body pt-4 pb-2 px-4 text-center">
+          <i class="bi bi-exclamation-triangle fs-2 mb-3 d-block" style="color:var(--warning)"></i>
+          <p id="confirm-modal-message" style="font-size:0.9rem"></p>
+        </div>
+        <div class="modal-footer justify-content-center border-0 pb-4 gap-2">
+          <button type="button" class="btn btn-outline-light px-4" id="btn-confirm-no">Cancel</button>
+          <button type="button" class="btn btn-gradient px-4" id="btn-confirm-yes">Continue</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- SCHEDULED TASKS LIST MODAL -->
   <div class="modal fade" id="scheduledModal" tabindex="-1" aria-labelledby="scheduledModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-scrollable">


### PR DESCRIPTION
Closes #31

## Summary
- Added `showConfirm(message, onYes)` reusable utility backed by a Bootstrap modal
- Over-target warning no longer blocks the Electron renderer process
- Split `saveEntryInternal` into validate + `commitEntry` for clean confirm flow
- Modal themed dark/light, consistent with the rest of the app

## Test plan
- [ ] Add entries exceeding daily target → Bootstrap modal appears (not OS dialog)
- [ ] Click Cancel → entry form stays open, nothing saved
- [ ] Click Continue → entry saved normally
- [ ] Works in both dark and light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)