### PR TITLE
feat: persist window size and position between sessions

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,14 +1,35 @@
-const { app, BrowserWindow, Menu, shell, ipcMain } = require('electron');
+const { app, BrowserWindow, Menu, shell, ipcMain, screen } = require('electron');
 const path = require('path');
 const Store = require('electron-store');
 
 const store = new Store();
+const WINDOW_BOUNDS_KEY = 'windowBounds';
+
+function getValidBounds() {
+  const saved = store.get(WINDOW_BOUNDS_KEY);
+  if (!saved) return null;
+
+  // Check saved bounds are within at least one connected display
+  const displays = screen.getAllDisplays();
+  const onScreen = displays.some(d => {
+    const { x, y, width, height } = d.workArea;
+    return (
+      saved.x >= x && saved.x < x + width &&
+      saved.y >= y && saved.y < y + height
+    );
+  });
+
+  return onScreen ? saved : null;
+}
 
 function createWindow() {
-  // Create the browser window.
+  const savedBounds = getValidBounds();
+
   const mainWindow = new BrowserWindow({
-    width: 1366,
-    height: 768,
+    width: savedBounds ? savedBounds.width : 1366,
+    height: savedBounds ? savedBounds.height : 768,
+    x: savedBounds ? savedBounds.x : undefined,
+    y: savedBounds ? savedBounds.y : undefined,
     minWidth: 800,
     minHeight: 600,
     icon: path.join(__dirname, 'favicon.png'),
@@ -17,6 +38,11 @@ function createWindow() {
       contextIsolation: true,
       preload: path.join(__dirname, 'preload.js')
     }
+  });
+
+  // Save window bounds on close
+  mainWindow.on('close', () => {
+    store.set(WINDOW_BOUNDS_KEY, mainWindow.getBounds());
   });
 
   // Handle external links safely
@@ -56,22 +82,14 @@ ipcMain.on('store-has', (event, key) => {
   event.returnValue = store.has(key);
 });
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
   createWindow();
 
   app.on('activate', function () {
-    // On macOS it's common to re-create a window in the app when the
-    // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
 });
 
-// Quit when all windows are closed, except on macOS. There, it's common
-// for applications and their menu bar to stay active until the user quits
-// explicitly with Cmd + Q.
 app.on('window-all-closed', function () {
   if (process.platform !== 'darwin') app.quit();
 });


### PR DESCRIPTION
Closes #32

## Summary
- Window bounds (x, y, width, height) saved to electron-store on close
- Restored on next launch if the position falls within a connected display
- Falls back to default 1366×768 centered if no saved bounds or monitor layout has changed (e.g. secondary display disconnected)

## Test plan
- [ ] Resize and move window, close, reopen → opens in same position and size
- [ ] Disconnect secondary monitor, reopen → falls back to default size/position

🤖 Generated with [Claude Code](https://claude.com/claude-code)