### PR TITLE
feat: in-app auto-updater via electron-updater (issue #37)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@
 'use strict';
 
 /* ── CONSTANTS ─────────────────────────────────────────── */
-const APP_VERSION = '1.2.0';
+const APP_VERSION = '1.3.0';
 
 const WEEK_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
 const ROMAN = ['i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x',
@@ -100,6 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
     initTheme();
     initSidebar();
+    initUpdater();
     initScheduledTasks();
     bindHeaderEvents();
     const restored = loadState();
@@ -2058,24 +2059,123 @@ function initSidebar() {
     const sidebarEl = document.getElementById('appSidebar');
     const aboutModalEl = document.getElementById('aboutModal');
 
+    const closeSidebar = () => {
+        const oc = bootstrap.Offcanvas.getInstance(sidebarEl);
+        if (oc) oc.hide(); else new bootstrap.Offcanvas(sidebarEl).hide();
+    };
+
     if (aboutBtn && sidebarEl && aboutModalEl) {
         const aboutModal = new bootstrap.Modal(aboutModalEl);
-        
         aboutBtn.addEventListener('click', (e) => {
             e.preventDefault();
-            
-            // Close sidebar
-            const offcanvasInstance = bootstrap.Offcanvas.getInstance(sidebarEl);
-            if (offcanvasInstance) {
-                offcanvasInstance.hide();
-            } else {
-                // fallback if instance not found (though it should be)
-                const oc = new bootstrap.Offcanvas(sidebarEl);
-                oc.hide();
-            }
-            
-            // Show About Modal
+            closeSidebar();
             aboutModal.show();
         });
     }
+
+    // Check for Updates
+    const updateBtn = document.getElementById('menu-check-updates');
+    if (updateBtn) {
+        updateBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            closeSidebar();
+            showToast('Checking for updates…', 'info');
+            manualUpdateCheck = true;
+            window.updater.checkForUpdates();
+        });
+    }
+}
+
+/* ── AUTO-UPDATER ───────────────────────────────────────── */
+let manualUpdateCheck = false;
+
+function initUpdater() {
+    if (!window.updater) return;
+
+    let downloadToastId = null;
+
+    window.updater.onUpdateAvailable((info) => {
+        manualUpdateCheck = false;
+        showUpdateToast(
+            `v${info.version} is available.`,
+            'Download',
+            () => {
+                downloadToastId = showProgressToast('Downloading update… 0%');
+                window.updater.downloadUpdate();
+            }
+        );
+    });
+
+    window.updater.onUpdateNotAvailable(() => {
+        if (manualUpdateCheck) showToast('You\'re on the latest version.', 'success');
+        manualUpdateCheck = false;
+    });
+
+    window.updater.onDownloadProgress((progress) => {
+        const pct = Math.round(progress.percent);
+        if (downloadToastId) {
+            const el = document.getElementById(downloadToastId + '-msg');
+            if (el) el.textContent = `Downloading update… ${pct}%`;
+        }
+    });
+
+    window.updater.onUpdateDownloaded((info) => {
+        if (downloadToastId) {
+            document.getElementById(downloadToastId)?.remove();
+            downloadToastId = null;
+        }
+        showUpdateToast(
+            `v${info.version} ready to install.`,
+            'Restart & Install',
+            () => window.updater.installUpdate()
+        );
+    });
+
+    window.updater.onError(() => {
+        showToast('Failed to download update.', 'danger');
+    });
+}
+
+function showUpdateToast(message, actionLabel, onAction) {
+    let container = document.querySelector('.toast-container');
+    if (!container) {
+        container = document.createElement('div');
+        container.className = 'toast-container';
+        document.body.appendChild(container);
+    }
+    const id = 'toast-update-' + Date.now();
+    container.insertAdjacentHTML('beforeend', `
+    <div id="${id}" class="toast toast-custom show align-items-center" role="alert" style="min-width:300px">
+      <div class="d-flex align-items-center gap-2 px-3 py-2">
+        <i class="bi bi-cloud-arrow-down" style="color:var(--success)"></i>
+        <span style="font-size:0.85rem;flex:1">${escHtml(message)}</span>
+        <button type="button" class="btn btn-sm btn-gradient ms-auto py-0 px-2" style="font-size:0.75rem" id="${id}-action">${escHtml(actionLabel)}</button>
+        <button type="button" class="btn btn-sm btn-outline-light py-0 px-2" style="font-size:0.75rem" id="${id}-dismiss">✕</button>
+      </div>
+    </div>`);
+    document.getElementById(`${id}-action`).addEventListener('click', () => {
+        document.getElementById(id)?.remove();
+        onAction();
+    });
+    document.getElementById(`${id}-dismiss`).addEventListener('click', () => {
+        document.getElementById(id)?.remove();
+    });
+}
+
+function showProgressToast(initialMessage) {
+    let container = document.querySelector('.toast-container');
+    if (!container) {
+        container = document.createElement('div');
+        container.className = 'toast-container';
+        document.body.appendChild(container);
+    }
+    const id = 'toast-progress-' + Date.now();
+    container.insertAdjacentHTML('beforeend', `
+    <div id="${id}" class="toast toast-custom show align-items-center" role="alert" style="min-width:300px">
+      <div class="d-flex align-items-center gap-2 px-3 py-2">
+        <i class="bi bi-cloud-arrow-down" style="color:var(--info)"></i>
+        <span id="${id}-msg" style="font-size:0.85rem;flex:1">${escHtml(initialMessage)}</span>
+      </div>
+    </div>`);
+    return id;
 }

--- a/index.html
+++ b/index.html
@@ -437,6 +437,10 @@
     </div>
     <div class="offcanvas-body p-0">
       <div class="sidebar-menu-list">
+        <a href="#" class="sidebar-menu-item" id="menu-check-updates">
+          <i class="bi bi-cloud-arrow-down me-3"></i>
+          <span>Check for Updates</span>
+        </a>
         <a href="#" class="sidebar-menu-item" id="menu-about">
           <i class="bi bi-info-circle me-3"></i>
           <span>About Timesheet Manager</span>

--- a/main.js
+++ b/main.js
@@ -1,15 +1,19 @@
 const { app, BrowserWindow, Menu, shell, ipcMain, screen } = require('electron');
 const path = require('path');
 const Store = require('electron-store');
+const { autoUpdater } = require('electron-updater');
 
 const store = new Store();
 const WINDOW_BOUNDS_KEY = 'windowBounds';
+
+// Disable auto-download — we control when to download
+autoUpdater.autoDownload = false;
+autoUpdater.autoInstallOnAppQuit = true;
 
 function getValidBounds() {
   const saved = store.get(WINDOW_BOUNDS_KEY);
   if (!saved) return null;
 
-  // Check saved bounds are within at least one connected display
   const displays = screen.getAllDisplays();
   const onScreen = displays.some(d => {
     const { x, y, width, height } = d.workArea;
@@ -22,10 +26,12 @@ function getValidBounds() {
   return onScreen ? saved : null;
 }
 
+let mainWindow;
+
 function createWindow() {
   const savedBounds = getValidBounds();
 
-  const mainWindow = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     width: savedBounds ? savedBounds.width : 1366,
     height: savedBounds ? savedBounds.height : 768,
     x: savedBounds ? savedBounds.x : undefined,
@@ -40,12 +46,10 @@ function createWindow() {
     }
   });
 
-  // Save window bounds on close
   mainWindow.on('close', () => {
     store.set(WINDOW_BOUNDS_KEY, mainWindow.getBounds());
   });
 
-  // Handle external links safely
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith('https:') || url.startsWith('http:')) {
       shell.openExternal(url);
@@ -53,37 +57,68 @@ function createWindow() {
     return { action: 'deny' };
   });
 
-  // Remove the default menu bar to keep the clean UI design
   Menu.setApplicationMenu(null);
-
-  // Load the index.html of the app.
   mainWindow.loadFile('index.html');
-
-  // Open the DevTools if needed (commented out for production)
-  // mainWindow.webContents.openDevTools();
 }
 
-// IPC handlers for electron-store
+// ── IPC: electron-store ──────────────────────────────────
 ipcMain.on('store-get', (event, key) => {
   event.returnValue = store.get(key, null);
 });
-
 ipcMain.on('store-set', (event, key, value) => {
   store.set(key, value);
   event.returnValue = true;
 });
-
 ipcMain.on('store-delete', (event, key) => {
   store.delete(key);
   event.returnValue = true;
 });
-
 ipcMain.on('store-has', (event, key) => {
   event.returnValue = store.has(key);
 });
 
+// ── IPC: auto-updater ────────────────────────────────────
+ipcMain.on('check-for-updates', () => {
+  autoUpdater.checkForUpdates();
+});
+
+ipcMain.on('download-update', () => {
+  autoUpdater.downloadUpdate();
+});
+
+ipcMain.on('install-update', () => {
+  autoUpdater.quitAndInstall();
+});
+
+// Forward updater events to renderer
+autoUpdater.on('update-available', (info) => {
+  mainWindow.webContents.send('update-available', info);
+});
+
+autoUpdater.on('update-not-available', () => {
+  mainWindow.webContents.send('update-not-available');
+});
+
+autoUpdater.on('download-progress', (progress) => {
+  mainWindow.webContents.send('download-progress', progress);
+});
+
+autoUpdater.on('update-downloaded', (info) => {
+  mainWindow.webContents.send('update-downloaded', info);
+});
+
+autoUpdater.on('error', (err) => {
+  mainWindow.webContents.send('update-error', err.message);
+});
+
+// ── App lifecycle ────────────────────────────────────────
 app.whenReady().then(() => {
   createWindow();
+
+  // Check for updates silently after window is ready
+  mainWindow.webContents.once('did-finish-load', () => {
+    autoUpdater.checkForUpdates();
+  });
 
   app.on('activate', function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
-        "electron-store": "^8.2.0"
+        "electron-store": "^8.2.0",
+        "electron-updater": "^6.8.3"
       },
       "devDependencies": {
         "electron": "^41.0.0",
@@ -1175,7 +1176,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assert-plus": {
@@ -1379,7 +1379,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -1899,7 +1898,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2412,6 +2410,69 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/electron-winstaller": {
@@ -3027,7 +3088,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -3362,7 +3422,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3436,7 +3495,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -3457,6 +3515,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -3776,7 +3847,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -4470,7 +4540,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
       "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -4879,6 +4948,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timesheet-manager",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Weekly Jira & Service Desk Time Tracking Application",
   "main": "main.js",
   "scripts": {
@@ -27,6 +27,11 @@
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true
+    },
+    "publish": {
+      "provider": "github",
+      "owner": "veera-bharath",
+      "repo": "Timesheet-Manager"
     }
   },
   "devDependencies": {
@@ -34,6 +39,7 @@
     "electron-builder": "^26.8.1"
   },
   "dependencies": {
-    "electron-store": "^8.2.0"
+    "electron-store": "^8.2.0",
+    "electron-updater": "^6.8.3"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -6,3 +6,14 @@ contextBridge.exposeInMainWorld('electronStore', {
     delete: (key) => ipcRenderer.sendSync('store-delete', key),
     has: (key) => ipcRenderer.sendSync('store-has', key),
 });
+
+contextBridge.exposeInMainWorld('updater', {
+    checkForUpdates: () => ipcRenderer.send('check-for-updates'),
+    downloadUpdate: () => ipcRenderer.send('download-update'),
+    installUpdate: () => ipcRenderer.send('install-update'),
+    onUpdateAvailable: (cb) => ipcRenderer.on('update-available', (_, info) => cb(info)),
+    onUpdateNotAvailable: (cb) => ipcRenderer.on('update-not-available', () => cb()),
+    onDownloadProgress: (cb) => ipcRenderer.on('download-progress', (_, progress) => cb(progress)),
+    onUpdateDownloaded: (cb) => ipcRenderer.on('update-downloaded', (_, info) => cb(info)),
+    onError: (cb) => ipcRenderer.on('update-error', (_, msg) => cb(msg)),
+});


### PR DESCRIPTION
## Summary
- Adds `electron-updater` with silent startup check and manual "Check for Updates" from sidebar
- Update available → persistent toast with Download button; progress updates a single toast in place; on completion shows Restart & Install toast
- Startup check is silent (no toast unless update found); "You're on the latest version" only shows on manual check
- Generic error toast on download failure (no raw error message exposed)
- Bumps version to 1.3.0

## Test plan
- [ ] Install v1.2.0 build locally, open app — no toast on startup when already latest
- [ ] With v1.3.0 on GitHub Releases, open v1.2.0 app — update available toast appears automatically
- [ ] Click Download — single progress toast updates in place, then Restart & Install toast appears
- [ ] Click "Check for Updates" manually when on latest — shows "You're on the latest version" toast

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)