### PR TITLE
feat: search and filter entries (issue #40)

### DIFF
--- a/app.js
+++ b/app.js
@@ -101,6 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initTheme();
     initSidebar();
     initUpdater();
+    initSearch();
     initScheduledTasks();
     bindHeaderEvents();
     const restored = loadState();
@@ -533,6 +534,7 @@ function buildGroups(entries) {
 
 function buildEntriesHTML(entries, dayIdx) {
     if (!entries || entries.length === 0) {
+        if (state.days[dayIdx] && state.days[dayIdx].isHoliday) return '';
         return `<div class="no-entries-msg">No entries yet. Click "Add Entry" to begin.</div>`;
     }
     
@@ -2051,6 +2053,297 @@ function applyTheme(theme) {
             if (span) span.textContent = 'Switch to Light Mode';
         }
     }
+}
+
+/* ── SEARCH ─────────────────────────────────────────────── */
+const SEARCH_PAGE_SIZE = 10;
+let advSearchResults = [];
+let advSearchPage = 0;
+let advSelectedRange = 'all';
+
+function fmtSearchDate(dateStr) {
+    const d = new Date(dateStr + 'T00:00:00');
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    return `${days[d.getDay()]} ${d.getDate()} ${months[d.getMonth()]}`;
+}
+
+function fmtTypeLabel(type) {
+    return type === 'servicedesk' ? 'Service Desk' : 'Jira';
+}
+
+function fmtHHMM(hh, mm) {
+    return `${String(hh || 0).padStart(2, '0')}:${String(mm || 0).padStart(2, '0')}`;
+}
+
+function searchCurrentWeek(query) {
+    const q = query.toLowerCase();
+    const results = [];
+    state.days.forEach((day, dayIdx) => {
+        if (!day || !day.entries) return;
+        day.entries.forEach((entry, entryIdx) => {
+            const matchTicket = entry.ticket && entry.ticket.toLowerCase().includes(q);
+            const matchType   = fmtTypeLabel(entry.type).toLowerCase().includes(q);
+            const matchDesc   = entry.desc && entry.desc.toLowerCase().includes(q);
+            if (matchTicket || matchType || matchDesc) {
+                results.push({ dateStr: day.date, dayIdx, entryIdx, entry });
+            }
+        });
+    });
+    return results;
+}
+
+function navigateToResult(dateStr, entryIdx) {
+    const weekStr = getWeekStrFromDate(new Date(dateStr + 'T00:00:00'));
+    if (weekStr !== state.weekValue) {
+        state.weekValue = weekStr;
+        document.getElementById('week-picker').value = weekStr;
+        state.days = buildWeekDays(getDateFromWeek(weekStr));
+        enforceExpandedState();
+        updateWeekDisplay();
+        saveState();
+    }
+    // Find day index for this date
+    const dayIdx = state.days.findIndex(d => d && d.date === dateStr);
+    if (dayIdx === -1) return;
+    // Expand that day
+    state.days.forEach((d, i) => { if (d) d.expanded = (i === dayIdx); });
+    state.lastOpenedDateByWeek[state.weekValue] = dateStr;
+    renderAll();
+    // After render, scroll + flash
+    setTimeout(() => {
+        const el = document.querySelector(`.entry-row[data-day="${dayIdx}"][data-entry="${entryIdx}"]`);
+        if (!el) return;
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        el.classList.add('entry-highlight-flash');
+        el.addEventListener('animationend', () => el.classList.remove('entry-highlight-flash'), { once: true });
+    }, 80);
+}
+
+function renderSearchDropdown(results, query, showAll) {
+    const dropdown = document.getElementById('search-dropdown');
+    if (!results.length) {
+        dropdown.innerHTML = '<div class="search-no-results">No results found</div>';
+        dropdown.style.display = 'block';
+        return;
+    }
+    const visible = showAll ? results : results.slice(0, 5);
+    const remaining = results.length - 5;
+    let html = '';
+    visible.forEach((r, i) => {
+        const line1 = `${escHtml(fmtSearchDate(r.dateStr))} &middot; ${escHtml(r.entry.ticket || '—')} &middot; ${escHtml(fmtTypeLabel(r.entry.type))}`;
+        const desc = r.entry.desc || '';
+        html += `<div class="search-result-item" data-idx="${i}" tabindex="-1">
+            <div class="search-result-line1">${line1}</div>
+            <div class="search-result-line2">${escHtml(desc)}</div>
+        </div>`;
+    });
+    if (!showAll && remaining > 0) {
+        html += `<div class="search-show-more" id="search-show-more">Show ${remaining} more…</div>`;
+    }
+    dropdown.innerHTML = html;
+    dropdown.style.display = 'block';
+
+    dropdown.querySelectorAll('.search-result-item').forEach((el, i) => {
+        el.addEventListener('click', () => {
+            const r = visible[i];
+            closeSearchDropdown();
+            document.getElementById('search-input').value = '';
+            navigateToResult(r.dateStr, r.entryIdx);
+        });
+    });
+    const showMoreEl = document.getElementById('search-show-more');
+    if (showMoreEl) {
+        showMoreEl.addEventListener('click', () => renderSearchDropdown(results, query, true));
+    }
+}
+
+function closeSearchDropdown() {
+    const dropdown = document.getElementById('search-dropdown');
+    dropdown.style.display = 'none';
+    dropdown.innerHTML = '';
+}
+
+function initSearch() {
+    const input = document.getElementById('search-input');
+    const dropdown = document.getElementById('search-dropdown');
+    let activeIdx = -1;
+    let lastResults = [];
+    let showingAll = false;
+
+    input.addEventListener('input', () => {
+        const q = input.value.trim();
+        activeIdx = -1;
+        showingAll = false;
+        if (q.length < 3) { closeSearchDropdown(); return; }
+        lastResults = searchCurrentWeek(q);
+        renderSearchDropdown(lastResults, q, false);
+    });
+
+    // Keyboard nav
+    input.addEventListener('keydown', (e) => {
+        const items = dropdown.querySelectorAll('.search-result-item');
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            activeIdx = Math.min(activeIdx + 1, items.length - 1);
+            items.forEach((el, i) => el.classList.toggle('active', i === activeIdx));
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            activeIdx = Math.max(activeIdx - 1, 0);
+            items.forEach((el, i) => el.classList.toggle('active', i === activeIdx));
+        } else if (e.key === 'Enter' && activeIdx >= 0) {
+            e.preventDefault();
+            items[activeIdx].click();
+        } else if (e.key === 'Escape') {
+            closeSearchDropdown();
+            input.blur();
+        }
+    });
+
+    // Close on outside click
+    document.addEventListener('click', (e) => {
+        if (!document.getElementById('search-wrap').contains(e.target)) {
+            closeSearchDropdown();
+        }
+    });
+
+    // Ctrl+F
+    document.addEventListener('keydown', (e) => {
+        if (e.ctrlKey && !e.shiftKey && e.key === 'f') {
+            e.preventDefault();
+            input.focus();
+            input.select();
+        }
+        if (e.ctrlKey && e.shiftKey && e.key === 'F') {
+            e.preventDefault();
+            openAdvancedSearch();
+        }
+    });
+
+    // Advanced search button
+    document.getElementById('btn-adv-search').addEventListener('click', () => openAdvancedSearch());
+
+    // Advanced search modal wiring
+    document.querySelectorAll('.adv-range-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.adv-range-btn').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            advSelectedRange = btn.dataset.range;
+            const customRow = document.getElementById('adv-custom-range');
+            customRow.style.display = advSelectedRange === 'custom' ? 'flex' : 'none';
+        });
+    });
+
+    document.getElementById('btn-run-adv-search').addEventListener('click', () => {
+        advSearchPage = 0;
+        advSearchResults = runAdvancedSearch();
+        renderAdvancedResults();
+    });
+}
+
+function openAdvancedSearch() {
+    // Pre-fill from basic search bar
+    const basicVal = document.getElementById('search-input').value.trim();
+    document.getElementById('adv-search-input').value = basicVal;
+    document.getElementById('adv-search-results').innerHTML = '';
+    document.getElementById('adv-search-pagination').innerHTML = '';
+    advSearchResults = [];
+    advSearchPage = 0;
+    const modal = new bootstrap.Modal(document.getElementById('advSearchModal'));
+    modal.show();
+    setTimeout(() => document.getElementById('adv-search-input').focus(), 300);
+}
+
+function runAdvancedSearch() {
+    const q = document.getElementById('adv-search-input').value.trim().toLowerCase();
+    const fieldTicket = document.getElementById('adv-field-ticket').checked;
+    const fieldType   = document.getElementById('adv-field-type').checked;
+    const fieldDesc   = document.getElementById('adv-field-desc').checked;
+
+    const today = new Date(); today.setHours(0,0,0,0);
+    const todayStr = fmtDate(today);
+
+    let fromStr = null, toStr = null;
+    if (advSelectedRange === 'today') {
+        fromStr = toStr = todayStr;
+    } else if (advSelectedRange === 'lastweek') {
+        const from = new Date(today); from.setDate(today.getDate() - 7);
+        fromStr = fmtDate(from); toStr = todayStr;
+    } else if (advSelectedRange === 'lastmonth') {
+        const from = new Date(today); from.setDate(today.getDate() - 30);
+        fromStr = fmtDate(from); toStr = todayStr;
+    } else if (advSelectedRange === 'custom') {
+        fromStr = document.getElementById('adv-from-date').value || null;
+        toStr   = document.getElementById('adv-to-date').value || null;
+    }
+
+    const results = [];
+    const allDates = Object.keys(state.allDaysByDate).sort();
+    allDates.forEach(dateStr => {
+        if (fromStr && dateStr < fromStr) return;
+        if (toStr && dateStr > toStr) return;
+        const day = state.allDaysByDate[dateStr];
+        if (!day || !day.entries) return;
+        day.entries.forEach((entry, entryIdx) => {
+            if (q) {
+                const mTicket = fieldTicket && entry.ticket && entry.ticket.toLowerCase().includes(q);
+                const mType   = fieldType   && fmtTypeLabel(entry.type).toLowerCase().includes(q);
+                const mDesc   = fieldDesc   && entry.desc && entry.desc.toLowerCase().includes(q);
+                if (!mTicket && !mType && !mDesc) return;
+            }
+            results.push({ dateStr, entryIdx, entry });
+        });
+    });
+    return results;
+}
+
+function renderAdvancedResults() {
+    const container = document.getElementById('adv-search-results');
+    const pagEl     = document.getElementById('adv-search-pagination');
+
+    if (!advSearchResults.length) {
+        container.innerHTML = '<div class="search-no-results py-3">No results found</div>';
+        pagEl.innerHTML = '';
+        return;
+    }
+
+    const totalPages = Math.ceil(advSearchResults.length / SEARCH_PAGE_SIZE);
+    const pageItems  = advSearchResults.slice(advSearchPage * SEARCH_PAGE_SIZE, (advSearchPage + 1) * SEARCH_PAGE_SIZE);
+
+    container.innerHTML = pageItems.map((r, i) => {
+        const hhmm = fmtHHMM(r.entry.hh, r.entry.mm);
+        const line1Left = `${escHtml(fmtSearchDate(r.dateStr))} &middot; ${escHtml(r.entry.ticket || '—')} &middot; ${escHtml(fmtTypeLabel(r.entry.type))}`;
+        const desc = r.entry.desc || '';
+        return `<div class="adv-result-card" data-pidx="${i}">
+            <div class="adv-result-line1">
+                <span>${line1Left}</span>
+                <span class="adv-result-hours">${hhmm}</span>
+            </div>
+            <div class="adv-result-line2">${escHtml(desc)}</div>
+        </div>`;
+    }).join('');
+
+    container.querySelectorAll('.adv-result-card').forEach((el, i) => {
+        el.addEventListener('click', () => {
+            const r = pageItems[i];
+            bootstrap.Modal.getInstance(document.getElementById('advSearchModal')).hide();
+            navigateToResult(r.dateStr, r.entryIdx);
+        });
+    });
+
+    // Pagination
+    if (totalPages <= 1) { pagEl.innerHTML = ''; return; }
+    let pagHtml = '';
+    for (let p = 0; p < totalPages; p++) {
+        pagHtml += `<button class="adv-pagination-btn${p === advSearchPage ? ' active' : ''}" data-page="${p}">${p + 1}</button>`;
+    }
+    pagEl.innerHTML = pagHtml;
+    pagEl.querySelectorAll('.adv-pagination-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            advSearchPage = parseInt(btn.dataset.page);
+            renderAdvancedResults();
+        });
+    });
 }
 
 /* ── SIDEBAR & ABOUT ───────────────────────────────────── */

--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
   <!-- HEADER -->
   <header class="app-header">
     <div class="container-fluid px-4">
-      <div class="d-flex align-items-center justify-content-between">
-        <div class="d-flex align-items-center gap-3">
+      <div class="d-flex align-items-center justify-content-between gap-3">
+        <div class="d-flex align-items-center gap-3 flex-shrink-0">
           <div class="header-logo">
             <img src="favicon.png" alt="App Icon" style="width: 100%; height: 100%; border-radius: 10px;" />
           </div>
@@ -27,7 +27,18 @@
             <p class="header-subtitle">Weekly Jira & Service Desk Time Tracking</p>
           </div>
         </div>
-        <div class="d-flex gap-2 flex-wrap">
+        <!-- SEARCH BAR -->
+        <div class="header-search-wrap" id="search-wrap">
+          <div class="header-search-inner">
+            <i class="bi bi-search search-icon"></i>
+            <input type="text" id="search-input" class="search-input" placeholder="Search this week… (Ctrl+F)" autocomplete="off" />
+            <button class="search-adv-btn" id="btn-adv-search" title="Advanced Search (Ctrl+Shift+F)">
+              <i class="bi bi-sliders2"></i>
+            </button>
+          </div>
+          <div class="search-dropdown" id="search-dropdown" style="display:none"></div>
+        </div>
+        <div class="d-flex gap-2 flex-shrink-0">
           <button class="btn btn-outline-light btn-sm px-3" id="btn-preview">
             <i class="bi bi-eye me-1"></i> Preview
           </button>
@@ -420,6 +431,68 @@
           <button type="button" class="btn btn-outline-light" id="btn-scheduled-form-cancel">Cancel</button>
           <button type="button" class="btn btn-gradient" id="btn-save-scheduled">
             <i class="bi bi-check-lg me-1"></i> Save
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ADVANCED SEARCH MODAL -->
+  <div class="modal fade" id="advSearchModal" tabindex="-1" aria-labelledby="advSearchModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content modal-dark">
+        <div class="modal-header">
+          <h5 class="modal-title" id="advSearchModalLabel"><i class="bi bi-sliders2 me-2"></i>Advanced Search</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <!-- Search field -->
+          <div class="mb-3">
+            <input type="text" id="adv-search-input" class="form-control dark-input" placeholder="Search…" autocomplete="off" />
+          </div>
+          <!-- Date range -->
+          <div class="mb-3">
+            <div class="label-text mb-2">Date Range</div>
+            <div class="d-flex gap-2 flex-wrap" id="adv-date-range-btns">
+              <button class="btn btn-sm adv-range-btn active" data-range="all">All</button>
+              <button class="btn btn-sm adv-range-btn" data-range="today">Today</button>
+              <button class="btn btn-sm adv-range-btn" data-range="lastweek">Last Week</button>
+              <button class="btn btn-sm adv-range-btn" data-range="lastmonth">Last Month</button>
+              <button class="btn btn-sm adv-range-btn" data-range="custom">Custom</button>
+            </div>
+            <div id="adv-custom-range" style="display:none; gap:8px; align-items:center; margin-top:8px; flex-wrap:wrap">
+              <input type="date" id="adv-from-date" class="form-control dark-input" style="max-width:160px" />
+              <span class="label-text">to</span>
+              <input type="date" id="adv-to-date" class="form-control dark-input" style="max-width:160px" />
+            </div>
+          </div>
+          <!-- Field toggles -->
+          <div class="mb-3">
+            <div class="label-text mb-2">Search In</div>
+            <div class="d-flex gap-3">
+              <div class="form-check mb-0">
+                <input class="form-check-input" type="checkbox" id="adv-field-ticket" checked />
+                <label class="form-check-label label-text" for="adv-field-ticket">Ticket</label>
+              </div>
+              <div class="form-check mb-0">
+                <input class="form-check-input" type="checkbox" id="adv-field-type" checked />
+                <label class="form-check-label label-text" for="adv-field-type">Type</label>
+              </div>
+              <div class="form-check mb-0">
+                <input class="form-check-input" type="checkbox" id="adv-field-desc" checked />
+                <label class="form-check-label label-text" for="adv-field-desc">Description</label>
+              </div>
+            </div>
+          </div>
+          <!-- Results -->
+          <div id="adv-search-results"></div>
+          <!-- Pagination -->
+          <div id="adv-search-pagination" class="d-flex justify-content-center gap-2 mt-3"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-gradient" id="btn-run-adv-search">
+            <i class="bi bi-search me-1"></i> Search
           </button>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -988,6 +988,225 @@ body::before {
   color: var(--text-primary);
 }
 
+/* ── SEARCH BAR ── */
+.header-search-wrap {
+  position: relative;
+  flex: 1;
+  max-width: 420px;
+}
+
+.header-search-inner {
+  display: flex;
+  align-items: center;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 10px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.header-search-inner:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.search-icon {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  flex-shrink: 0;
+  margin-right: 8px;
+}
+
+.search-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  padding: 7px 0;
+  min-width: 0;
+}
+
+.search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.search-adv-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.search-adv-btn:hover {
+  color: var(--text-primary);
+  background: rgba(255,255,255,0.06);
+}
+
+/* Search dropdown */
+.search-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background: var(--bg-card);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  z-index: 1050;
+  overflow: hidden;
+}
+
+.search-result-item {
+  padding: 10px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.12s;
+}
+
+.search-result-item:last-child {
+  border-bottom: none;
+}
+
+.search-result-item:hover, .search-result-item.active {
+  background: var(--bg-card-hover);
+}
+
+.search-result-line1 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.search-result-line2 {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
+.search-no-results, .search-show-more {
+  padding: 10px 14px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.search-show-more {
+  cursor: pointer;
+  border-top: 1px solid var(--border);
+  color: var(--accent-light);
+  transition: background 0.12s;
+}
+
+.search-show-more:hover {
+  background: var(--bg-card-hover);
+}
+
+/* Entry highlight flash */
+@keyframes entry-flash {
+  0%   { background: rgba(34, 211, 160, 0.25); border-color: var(--success); }
+  70%  { background: rgba(34, 211, 160, 0.15); border-color: var(--success); }
+  100% { background: ''; border-color: ''; }
+}
+
+.entry-highlight-flash {
+  animation: entry-flash 1.5s ease-out forwards;
+}
+
+/* Advanced search */
+.adv-range-btn {
+  background: var(--bg-input);
+  border: 1px solid var(--border-accent);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  padding: 4px 12px;
+  transition: all 0.15s;
+}
+
+.adv-range-btn:hover {
+  border-color: var(--accent-light);
+  color: var(--text-primary);
+}
+
+.adv-range-btn.active {
+  background: rgba(34, 211, 160, 0.12);
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.adv-result-card {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.adv-result-card:hover {
+  border-color: var(--border-accent);
+  background: var(--bg-card-hover);
+}
+
+.adv-result-line1 {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.adv-result-line2 {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 3px;
+}
+
+.adv-result-hours {
+  font-size: 0.75rem;
+  color: var(--success);
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.adv-pagination-btn {
+  background: var(--bg-input);
+  border: 1px solid var(--border-accent);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  border-radius: var(--radius-sm);
+  padding: 4px 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.adv-pagination-btn:hover, .adv-pagination-btn.active {
+  border-color: var(--success);
+  color: var(--success);
+  background: rgba(34, 211, 160, 0.08);
+}
+
 /* ── SCHEDULED ENTRIES ── */
 .entry-row.entry-scheduled {
   border: 1px dashed var(--border-accent) !important;


### PR DESCRIPTION
## Summary
- Search bar centered in the navbar; `Ctrl+F` focuses it
- Basic search scoped to current week, triggers at 3+ characters, searches ticket / type / description
- Dropdown shows up to 5 results with "Show X more…" expansion; keyboard nav (↑ ↓ Enter Esc)
- Clicking a result switches week if needed, expands the day accordion, scrolls to and flashes the entry
- Advanced search via `Ctrl+Shift+F` or the sliders button — date range (All / Today / Last Week / Last Month / Custom), field toggles, Search button, paginated results (10/page)
- Fix: suppress "No entries yet" message when day is marked as a holiday

## Test plan
- [ ] `Ctrl+F` focuses search bar; typing < 3 chars shows nothing, 3+ shows dropdown
- [ ] Arrow keys navigate results; Enter selects; Escape closes
- [ ] Clicking a result from a different week switches the week and highlights the entry
- [ ] `Ctrl+Shift+F` opens advanced search pre-filled with basic search text
- [ ] Date range Custom shows/hides date pickers correctly
- [ ] Pagination works when results exceed 10
- [ ] Holiday day shows no "No entries yet" message

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)