### PR TITLE
feat: live day total indicator in entry modal (issue #42)

### DIFF
--- a/app.js
+++ b/app.js
@@ -310,6 +310,11 @@ function bindHeaderEvents() {
             if (this.value.length >= 2) document.getElementById(mmId).focus();
         });
     });
+
+    // Live day total update when HH/MM change in entry modal
+    ['modal-hh', 'modal-mm'].forEach(id => {
+        document.getElementById(id).addEventListener('input', updateEntryDayTotal);
+    });
 }
 
 /* ── RENDER ALL ────────────────────────────────────────── */
@@ -862,7 +867,36 @@ function openEntryModal(dayIdx, entryIdx) {
         }
     }
 
+    updateEntryDayTotal();
     entryModal.show();
+}
+
+function updateEntryDayTotal() {
+    const indicator = document.getElementById('entry-day-total');
+    const dayIdx  = parseInt(document.getElementById('modal-day-index').value);
+    const entryIdx = parseInt(document.getElementById('modal-entry-index').value);
+    if (isNaN(dayIdx) || dayIdx < 0 || !state.days[dayIdx]) { indicator.style.display = 'none'; return; }
+
+    const entries = state.days[dayIdx].entries || [];
+    const baseMins = entries.reduce((sum, e, i) => {
+        if (i === entryIdx) return sum; // exclude entry being edited
+        return sum + (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0);
+    }, 0);
+
+    const addHH = parseInt(document.getElementById('modal-hh').value) || 0;
+    const addMM = parseInt(document.getElementById('modal-mm').value) || 0;
+    const addMins = addHH * 60 + addMM;
+    const newTotalMins = baseMins + addMins;
+
+    const fmt = (mins) => `${String(Math.floor(mins / 60)).padStart(2, '0')}:${String(mins % 60).padStart(2, '0')}`;
+    const isOver = newTotalMins > (state.dailyTargetMins || 480);
+
+    indicator.style.display = 'flex';
+    indicator.innerHTML = `<i class="bi bi-clock"></i>
+        <span>${fmt(baseMins)}</span>
+        <span class="total-arrow">→</span>
+        <span class="total-new ${isOver ? 'over' : 'ok'}">${fmt(newTotalMins)}</span>
+        ${isOver ? '<span class="total-arrow">(over target)</span>' : ''}`;
 }
 
 function openEntryModalPreFilled(dayIdx, fromEntryIdx, keepField) {
@@ -894,7 +928,8 @@ function openEntryModalPreFilled(dayIdx, fromEntryIdx, keepField) {
     } else if (keepField === 'desc') {
         document.getElementById('modal-desc').value = e.desc || '';
     }
-    
+
+    updateEntryDayTotal();
     entryModal.show();
 }
 

--- a/index.html
+++ b/index.html
@@ -217,7 +217,8 @@
             </div>
           </div>
         </div>
-        <div class="modal-footer">
+        <div class="modal-footer flex-wrap gap-2">
+          <div id="entry-day-total" class="entry-day-total me-auto" style="display:none"></div>
           <button type="button" class="btn btn-outline-danger" id="btn-delete-entry" style="display:none">
             <i class="bi bi-trash me-1"></i> Delete
           </button>

--- a/styles.css
+++ b/styles.css
@@ -988,6 +988,32 @@ body::before {
   color: var(--text-primary);
 }
 
+/* ── ENTRY DAY TOTAL ── */
+.entry-day-total {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.entry-day-total .total-arrow {
+  color: var(--text-muted);
+}
+
+.entry-day-total .total-new {
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.entry-day-total .total-new.over {
+  color: var(--warning);
+}
+
+.entry-day-total .total-new.ok {
+  color: var(--success);
+}
+
 /* ── SEARCH BAR ── */
 .header-search-wrap {
   position: relative;


### PR DESCRIPTION
## Summary
- Adds a live `06:30 → 08:00` indicator in the entry modal footer
- Updates in real-time as HH/MM inputs change
- Excludes the entry being edited from the base total when in edit mode
- Turns amber when the new total would exceed the daily target

## Test plan
- [ ] Open Add Entry — indicator shows current day total → new total as you type
- [ ] Open Edit Entry — base total excludes the entry being edited
- [ ] Exceeding daily target turns the new total amber with "(over target)"
- [ ] Works on sub-entries (Add Sub-Entry via copy-to)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)