### PR TITLE
feat: keyboard shortcut cheatsheet (issue #43)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1787,6 +1787,10 @@ document.addEventListener('keydown', e => {
                 if (day.entries && day.entries.length > 0) openDayQuickView(expandedIdx);
             }
             break;
+
+        case '?':
+            new bootstrap.Modal(document.getElementById('cheatsheetModal')).show();
+            break;
     }
 
     // Ctrl+P → print
@@ -2398,6 +2402,16 @@ function initSidebar() {
             e.preventDefault();
             closeSidebar();
             aboutModal.show();
+        });
+    }
+
+    // Keyboard Shortcuts Cheatsheet
+    const cheatsheetBtn = document.getElementById('menu-cheatsheet');
+    if (cheatsheetBtn) {
+        cheatsheetBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            closeSidebar();
+            new bootstrap.Modal(document.getElementById('cheatsheetModal')).show();
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -500,6 +500,50 @@
     </div>
   </div>
 
+  <!-- KEYBOARD SHORTCUT CHEATSHEET MODAL -->
+  <div class="modal fade" id="cheatsheetModal" tabindex="-1" aria-labelledby="cheatsheetModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-md">
+      <div class="modal-content modal-dark">
+        <div class="modal-header">
+          <h5 class="modal-title" id="cheatsheetModalLabel"><i class="bi bi-keyboard me-2"></i>Keyboard Shortcuts</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="cheatsheet-group">
+            <div class="cheatsheet-group-label">Navigation</div>
+            <div class="cheatsheet-row"><kbd>←</kbd><kbd>→</kbd> <span>Switch expanded day left / right</span></div>
+          </div>
+          <div class="cheatsheet-group">
+            <div class="cheatsheet-group-label">Entries</div>
+            <div class="cheatsheet-row"><kbd>N</kbd> <span>Add new entry to expanded day</span></div>
+            <div class="cheatsheet-row"><kbd>Enter</kbd> <span>Save entry (inside entry modal)</span></div>
+          </div>
+          <div class="cheatsheet-group">
+            <div class="cheatsheet-group-label">Views</div>
+            <div class="cheatsheet-row"><kbd>P</kbd> <span>Open TXT preview</span></div>
+            <div class="cheatsheet-row"><kbd>Q</kbd> <span>Quick-view expanded day entries</span></div>
+            <div class="cheatsheet-row"><kbd>Ctrl</kbd><kbd>P</kbd> <span>Print</span></div>
+          </div>
+          <div class="cheatsheet-group">
+            <div class="cheatsheet-group-label">Search</div>
+            <div class="cheatsheet-row"><kbd>Ctrl</kbd><kbd>F</kbd> <span>Focus search bar</span></div>
+            <div class="cheatsheet-row"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>F</kbd> <span>Advanced search</span></div>
+            <div class="cheatsheet-row"><kbd>↑</kbd><kbd>↓</kbd> <span>Navigate search results</span></div>
+            <div class="cheatsheet-row"><kbd>Enter</kbd> <span>Select search result</span></div>
+            <div class="cheatsheet-row"><kbd>Esc</kbd> <span>Close search dropdown</span></div>
+          </div>
+          <div class="cheatsheet-group">
+            <div class="cheatsheet-group-label">General</div>
+            <div class="cheatsheet-row"><kbd>?</kbd> <span>or</span> <kbd>Shift</kbd><kbd>/</kbd> <span>Open this cheatsheet</span></div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-gradient px-4" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- PRINT AREA (hidden, used for window.print) -->
   <div id="print-area" style="display:none"></div>
   
@@ -511,6 +555,10 @@
     </div>
     <div class="offcanvas-body p-0">
       <div class="sidebar-menu-list">
+        <a href="#" class="sidebar-menu-item" id="menu-cheatsheet">
+          <i class="bi bi-keyboard me-3"></i>
+          <span>Keyboard Shortcuts</span>
+        </a>
         <a href="#" class="sidebar-menu-item" id="menu-check-updates">
           <i class="bi bi-cloud-arrow-down me-3"></i>
           <span>Check for Updates</span>

--- a/styles.css
+++ b/styles.css
@@ -988,6 +988,53 @@ body::before {
   color: var(--text-primary);
 }
 
+/* ── CHEATSHEET ── */
+.cheatsheet-group {
+  margin-bottom: 16px;
+}
+
+.cheatsheet-group-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.cheatsheet-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.83rem;
+  color: var(--text-secondary);
+}
+
+.cheatsheet-row:last-child {
+  border-bottom: none;
+}
+
+.cheatsheet-row span {
+  margin-left: 4px;
+}
+
+kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-input);
+  border: 1px solid var(--border-accent);
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-size: 0.72rem;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--text-primary);
+  box-shadow: 0 1px 0 var(--border-accent);
+  white-space: nowrap;
+}
+
 /* ── ENTRY DAY TOTAL ── */
 .entry-day-total {
   font-size: 0.78rem;


### PR DESCRIPTION
## Summary
- `?` (Shift+/) opens a keyboard shortcut cheatsheet modal
- Sidebar "Keyboard Shortcuts" menu item as the primary discoverable entry point
- Shortcuts grouped by category: Navigation, Entries, Views, Search, General
- Cheatsheet shows both `?` and `Shift+/` so users understand the key combination

## Test plan
- [ ] Press `?` outside any input/modal — cheatsheet opens
- [ ] Sidebar → Keyboard Shortcuts — cheatsheet opens
- [ ] All listed shortcuts work as documented

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)