### PR TITLE
feat: right-click context menu and starred entries (issue #47)

### DIFF
--- a/app.js
+++ b/app.js
@@ -101,6 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initTheme();
     initSidebar();
     initUpdater();
+    initContextMenu();
     initSearch();
     initScheduledTasks();
     bindHeaderEvents();
@@ -486,20 +487,23 @@ function buildDayCard(day, dayIdx) {
     const addBtn = wrap.querySelector('.add-entry-btn');
     if (addBtn) addBtn.addEventListener('click', () => openEntryModal(dayIdx, -1));
 
-    // Entry row click (edit)
+    // Entry row: double-click → edit
     wrap.querySelectorAll('.entry-row').forEach(row => {
-        row.addEventListener('click', e => {
-            if (e.target.closest('.drag-handle')) return;
+        row.addEventListener('dblclick', e => {
+            if (e.target.closest('.drag-handle') || e.target.closest('.entry-btn-eye') || e.target.closest('.entry-btn-star')) return;
             openEntryModal(parseInt(row.dataset.day), parseInt(row.dataset.entry));
         });
-    });
 
-    // Quick-add inline buttons (keep ticket / keep desc)
-    wrap.querySelectorAll('.quick-add-inline').forEach(btn => {
-        btn.addEventListener('click', e => {
+        // Right-click → context menu
+        row.addEventListener('contextmenu', e => {
+            e.preventDefault();
+            showEntryContextMenu(row, e.clientX, e.clientY);
+        });
+
+        // Star button → toggle
+        row.querySelector('.entry-btn-star').addEventListener('click', e => {
             e.stopPropagation();
-            const row = btn.closest('.entry-row');
-            openEntryModalPreFilled(parseInt(row.dataset.day), parseInt(row.dataset.entry), btn.dataset.keep);
+            toggleEntryStarred(parseInt(row.dataset.day), parseInt(row.dataset.entry), e.currentTarget);
         });
     });
 
@@ -576,28 +580,11 @@ function buildEntriesHTML(entries, dayIdx) {
                 descHtml = `<span class="entry-desc text-muted entry-grouped-hint">↳ Grouped below</span>`;
             }
 
-            let actTicketHtml = '';
-            let actDescHtml = '';
-
-            if (group.type === 'normal') {
-                actTicketHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Sub-task (keep ticket)" data-keep="ticket">
-                    <i class="bi bi-plus"></i> <i class="bi bi-ticket-detailed"></i>
-                </button>`;
-                actDescHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Ticket to Group (keep desc)" data-keep="desc">
-                    <i class="bi bi-plus"></i> <i class="bi bi-card-text"></i>
-                </button>`;
-            } else if (group.type === 'ticket_group') {
-                actTicketHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Sub-task (keep ticket)" data-keep="ticket">
-                    <i class="bi bi-plus"></i> <i class="bi bi-ticket-detailed"></i>
-                </button>`;
-            } else if (group.type === 'desc_group') {
-                actDescHtml = `<button type="button" class="btn btn-sm py-0 px-2 quick-add-inline" title="Add Ticket to Group (keep desc)" data-keep="desc">
-                    <i class="bi bi-plus"></i> <i class="bi bi-card-text"></i>
-                </button>`;
-            }
+            const starClass = e.starred ? 'starred' : '';
+            const starIcon  = e.starred ? 'bi-star-fill' : 'bi-star';
 
             htmlFragments.push(`
-    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}">
+    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
       <span class="drag-handle" title="Drag to reorder"><i class="bi bi-grip-vertical"></i></span>
       <span class="entry-num entry-num-roman">${rStr}</span>
       ${ticketHtml}
@@ -606,10 +593,8 @@ function buildEntriesHTML(entries, dayIdx) {
       ${e.recurringId ? '<span class="entry-recurring-badge" title="Recurring task"><i class="bi bi-arrow-repeat"></i></span>' : ''}
       ${e.isScheduled ? '<span class="entry-scheduled-badge" title="Scheduled task"><i class="bi bi-clock"></i></span>' : ''}
       ${descHtml}
-      <div class="entry-actions ms-auto d-flex align-items-center gap-2">
-        ${actTicketHtml}
-        ${actDescHtml}
-        <span class="entry-edit-hint ms-2"><i class="bi bi-pencil-square"></i></span>
+      <div class="ms-auto d-flex align-items-center gap-1">
+        <button class="entry-btn-star ${starClass}" title="${e.starred ? 'Unstar' : 'Star'}"><i class="bi ${starIcon}"></i></button>
       </div>
     </div>`);
         });
@@ -2094,6 +2079,216 @@ function applyTheme(theme) {
     }
 }
 
+/* ── CONTEXT MENU ───────────────────────────────────────── */
+let ctxTarget = null; // { dayIdx, entryIdx, row }
+
+function showEntryContextMenu(row, x, y) {
+    ctxTarget = {
+        dayIdx:   parseInt(row.dataset.day),
+        entryIdx: parseInt(row.dataset.entry),
+        groupType: row.dataset.groupType,
+        row
+    };
+    const entry = state.days[ctxTarget.dayIdx]?.entries[ctxTarget.entryIdx];
+    if (!entry) return;
+
+    const menu = document.getElementById('entry-context-menu');
+
+    // Show/hide conditional items
+    document.getElementById('ctx-sub-ticket').style.display =
+        (ctxTarget.groupType === 'normal' || ctxTarget.groupType === 'ticket_group') ? 'flex' : 'none';
+    document.getElementById('ctx-sub-desc').style.display =
+        (ctxTarget.groupType === 'normal' || ctxTarget.groupType === 'desc_group') ? 'flex' : 'none';
+    document.getElementById('ctx-make-regular').style.display = entry.isScheduled ? 'flex' : 'none';
+
+    // Star label
+    document.getElementById('ctx-star-label').textContent = entry.starred ? 'Unstar' : 'Star';
+    document.getElementById('ctx-star').querySelector('i').className = entry.starred ? 'bi bi-star-fill' : 'bi bi-star';
+
+    // Position menu
+    menu.style.display = 'block';
+    const mw = menu.offsetWidth, mh = menu.offsetHeight;
+    const vw = window.innerWidth, vh = window.innerHeight;
+    menu.style.left = (x + mw > vw ? x - mw : x) + 'px';
+    menu.style.top  = (y + mh > vh ? y - mh : y) + 'px';
+}
+
+function hideContextMenu() {
+    document.getElementById('entry-context-menu').style.display = 'none';
+    ctxTarget = null;
+}
+
+function initContextMenu() {
+    document.getElementById('ctx-edit').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx } = ctxTarget;
+        hideContextMenu();
+        openEntryModal(dayIdx, entryIdx);
+    });
+
+    document.getElementById('ctx-duplicate').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx } = ctxTarget;
+        hideContextMenu();
+        const original = state.days[dayIdx].entries[entryIdx];
+        const copy = { ...original, starred: false };
+        state.days[dayIdx].entries.splice(entryIdx + 1, 0, copy);
+        rerenderDayCard(dayIdx);
+        saveState();
+    });
+
+    document.getElementById('ctx-copy-to').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx } = ctxTarget;
+        hideContextMenu();
+        document.getElementById('modal-day-index').value = dayIdx;
+        document.getElementById('modal-entry-index').value = entryIdx;
+        document.getElementById('btn-copy-to-entry').click();
+    });
+
+    document.getElementById('ctx-sub-ticket').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx } = ctxTarget;
+        hideContextMenu();
+        openEntryModalPreFilled(dayIdx, entryIdx, 'ticket');
+    });
+
+    document.getElementById('ctx-sub-desc').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx } = ctxTarget;
+        hideContextMenu();
+        openEntryModalPreFilled(dayIdx, entryIdx, 'desc');
+    });
+
+    document.getElementById('ctx-make-regular').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx } = ctxTarget;
+        hideContextMenu();
+        document.getElementById('modal-day-index').value = dayIdx;
+        document.getElementById('modal-entry-index').value = entryIdx;
+        makeRegularEntry();
+    });
+
+    document.getElementById('ctx-star').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx, row } = ctxTarget;
+        hideContextMenu();
+        toggleEntryStarred(dayIdx, entryIdx, row.querySelector('.entry-btn-star'));
+    });
+
+    document.getElementById('ctx-delete').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx } = ctxTarget;
+        hideContextMenu();
+        document.getElementById('modal-day-index').value = dayIdx;
+        document.getElementById('modal-entry-index').value = entryIdx;
+        deleteEntry();
+    });
+
+    // Close on outside click or Escape
+    document.addEventListener('click', (e) => {
+        if (!document.getElementById('entry-context-menu').contains(e.target)) hideContextMenu();
+        if (!document.getElementById('entry-quick-view').contains(e.target) &&
+            !e.target.closest('.entry-btn-eye')) hideQuickView();
+    });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') { hideContextMenu(); hideQuickView(); }
+    });
+}
+
+/* ── QUICK VIEW ─────────────────────────────────────────── */
+let quickViewVisible = false;
+
+function showEntryQuickView(dayIdx, entryIdx, btnEl) {
+    const qv = document.getElementById('entry-quick-view');
+    // Toggle off if same button clicked again
+    if (quickViewVisible && qv.dataset.for === `${dayIdx}-${entryIdx}`) {
+        qv.style.display = 'none';
+        quickViewVisible = false;
+        return;
+    }
+    const entry = state.days[dayIdx]?.entries[entryIdx];
+    if (!entry) return;
+
+    const typeLabel = entry.type === 'servicedesk' ? 'Service Desk' : 'Jira';
+    const hhmm = `${String(entry.hh || 0).padStart(2,'0')}:${String(entry.mm || 0).padStart(2,'0')}`;
+
+    qv.innerHTML = `
+        <div class="qv-row"><span class="qv-label">Ticket</span><span class="qv-value">${escHtml(entry.ticket || '—')}</span></div>
+        <div class="qv-row"><span class="qv-label">Type</span><span class="qv-value">${escHtml(typeLabel)}</span></div>
+        <div class="qv-row"><span class="qv-label">Time</span><span class="qv-value">${hhmm}</span></div>
+        <div class="qv-row"><span class="qv-label">Desc</span><span class="qv-desc">${escHtml(entry.desc || '—')}</span></div>`;
+    qv.dataset.for = `${dayIdx}-${entryIdx}`;
+
+    // Position near button
+    const rect = btnEl.getBoundingClientRect();
+    qv.style.display = 'block';
+    const qvw = qv.offsetWidth, qvh = qv.offsetHeight;
+    const top = rect.bottom + 6 + qvh > window.innerHeight ? rect.top - qvh - 6 : rect.bottom + 6;
+    const left = Math.min(rect.left, window.innerWidth - qvw - 8);
+    qv.style.top  = top + 'px';
+    qv.style.left = left + 'px';
+    quickViewVisible = true;
+}
+
+function hideQuickView() {
+    document.getElementById('entry-quick-view').style.display = 'none';
+    quickViewVisible = false;
+}
+
+/* ── STAR ───────────────────────────────────────────────── */
+function toggleEntryStarred(dayIdx, entryIdx, btnEl) {
+    const entry = state.days[dayIdx]?.entries[entryIdx];
+    if (!entry) return;
+    entry.starred = !entry.starred;
+    // Update button UI without full rerender
+    btnEl.classList.toggle('starred', entry.starred);
+    btnEl.querySelector('i').className = entry.starred ? 'bi bi-star-fill' : 'bi bi-star';
+    btnEl.title = entry.starred ? 'Unstar' : 'Star';
+    // Also sync to allDaysByDate
+    const dateStr = state.days[dayIdx].date;
+    if (state.allDaysByDate[dateStr]) {
+        state.allDaysByDate[dateStr].entries[entryIdx] = entry;
+    }
+    saveState();
+}
+
+function renderStarredList() {
+    const container = document.getElementById('starred-list');
+    const results = [];
+    Object.keys(state.allDaysByDate).sort().forEach(dateStr => {
+        const day = state.allDaysByDate[dateStr];
+        if (!day?.entries) return;
+        day.entries.forEach((entry, entryIdx) => {
+            if (entry.starred) results.push({ dateStr, entryIdx, entry });
+        });
+    });
+
+    if (!results.length) {
+        container.innerHTML = '<div class="search-no-results py-4">No starred entries yet.</div>';
+        return;
+    }
+
+    container.innerHTML = results.map((r, i) => {
+        const hhmm = `${String(r.entry.hh || 0).padStart(2,'0')}:${String(r.entry.mm || 0).padStart(2,'0')}`;
+        const typeLabel = r.entry.type === 'servicedesk' ? 'Service Desk' : 'Jira';
+        return `<div class="adv-result-card" data-sidx="${i}">
+            <div class="adv-result-line1">
+                <span>${escHtml(fmtSearchDate(r.dateStr))} &middot; ${escHtml(r.entry.ticket || '—')} &middot; ${escHtml(typeLabel)}</span>
+                <span class="adv-result-hours">${hhmm}</span>
+            </div>
+            <div class="adv-result-line2">${escHtml(r.entry.desc || '')}</div>
+        </div>`;
+    }).join('');
+
+    container.querySelectorAll('.adv-result-card').forEach((el, i) => {
+        el.addEventListener('click', () => {
+            bootstrap.Modal.getInstance(document.getElementById('starredModal'))?.hide();
+            navigateToResult(results[i].dateStr, results[i].entryIdx);
+        });
+    });
+}
+
 /* ── SEARCH ─────────────────────────────────────────────── */
 const SEARCH_PAGE_SIZE = 10;
 let advSearchResults = [];
@@ -2402,6 +2597,17 @@ function initSidebar() {
             e.preventDefault();
             closeSidebar();
             aboutModal.show();
+        });
+    }
+
+    // Starred Entries
+    const starredBtn = document.getElementById('menu-starred');
+    if (starredBtn) {
+        starredBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            closeSidebar();
+            renderStarredList();
+            new bootstrap.Modal(document.getElementById('starredModal')).show();
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -438,6 +438,36 @@
     </div>
   </div>
 
+  <!-- ENTRY CONTEXT MENU -->
+  <div id="entry-context-menu" class="entry-context-menu" style="display:none">
+    <div class="ctx-item" id="ctx-edit"><i class="bi bi-pencil-square"></i> Edit</div>
+    <div class="ctx-item" id="ctx-duplicate"><i class="bi bi-copy"></i> Duplicate</div>
+    <div class="ctx-item" id="ctx-copy-to"><i class="bi bi-calendar-plus"></i> Copy To</div>
+    <div class="ctx-item ctx-sub-ticket" id="ctx-sub-ticket" style="display:none"><i class="bi bi-ticket-detailed"></i> Add Sub-entry (same ticket)</div>
+    <div class="ctx-item ctx-sub-desc" id="ctx-sub-desc" style="display:none"><i class="bi bi-card-text"></i> Add Sub-entry (same desc)</div>
+    <div class="ctx-item ctx-make-regular" id="ctx-make-regular" style="display:none"><i class="bi bi-calendar-check"></i> Make Regular</div>
+    <div class="ctx-divider"></div>
+    <div class="ctx-item" id="ctx-star"><i class="bi bi-star"></i> <span id="ctx-star-label">Star</span></div>
+    <div class="ctx-divider"></div>
+    <div class="ctx-item ctx-danger" id="ctx-delete"><i class="bi bi-trash"></i> Delete</div>
+  </div>
+
+  <!-- ENTRY QUICK VIEW -->
+  <div id="entry-quick-view" class="entry-quick-view" style="display:none"></div>
+
+  <!-- STARRED ENTRIES MODAL -->
+  <div class="modal fade" id="starredModal" tabindex="-1" aria-labelledby="starredModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content modal-dark">
+        <div class="modal-header">
+          <h5 class="modal-title" id="starredModalLabel"><i class="bi bi-star-fill me-2"></i>Starred Entries</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body" id="starred-list"></div>
+      </div>
+    </div>
+  </div>
+
   <!-- ADVANCED SEARCH MODAL -->
   <div class="modal fade" id="advSearchModal" tabindex="-1" aria-labelledby="advSearchModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-scrollable">
@@ -555,6 +585,10 @@
     </div>
     <div class="offcanvas-body p-0">
       <div class="sidebar-menu-list">
+        <a href="#" class="sidebar-menu-item" id="menu-starred">
+          <i class="bi bi-star-fill me-3"></i>
+          <span>Starred Entries</span>
+        </a>
         <a href="#" class="sidebar-menu-item" id="menu-cheatsheet">
           <i class="bi bi-keyboard me-3"></i>
           <span>Keyboard Shortcuts</span>

--- a/styles.css
+++ b/styles.css
@@ -988,6 +988,135 @@ body::before {
   color: var(--text-primary);
 }
 
+/* ── ENTRY ROW BUTTONS ── */
+.entry-btn-eye,
+.entry-btn-star {
+  background: none;
+  border: none;
+  padding: 3px 5px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  transition: color 0.15s, background 0.15s;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.entry-btn-eye:hover {
+  color: var(--text-primary);
+  background: rgba(255,255,255,0.06);
+}
+
+.entry-btn-star:hover {
+  color: var(--warning);
+  background: rgba(251,191,36,0.08);
+}
+
+.entry-btn-star.starred {
+  color: var(--warning);
+}
+
+/* ── CONTEXT MENU ── */
+.entry-context-menu {
+  position: fixed;
+  z-index: 9999;
+  background: var(--bg-card);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  min-width: 200px;
+  padding: 4px 0;
+  user-select: none;
+}
+
+.ctx-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  font-size: 0.83rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.ctx-item:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+
+.ctx-item i {
+  width: 16px;
+  text-align: center;
+  opacity: 0.7;
+}
+
+.ctx-item.ctx-danger {
+  color: var(--danger);
+}
+
+.ctx-item.ctx-danger:hover {
+  background: rgba(248,113,113,0.08);
+  color: var(--danger);
+}
+
+.ctx-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+/* ── ENTRY QUICK VIEW ── */
+.entry-quick-view {
+  position: fixed;
+  z-index: 9998;
+  background: var(--bg-card);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+  padding: 12px 14px;
+  min-width: 240px;
+  max-width: 320px;
+  font-size: 0.82rem;
+}
+
+.qv-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 6px;
+  align-items: flex-start;
+}
+
+.qv-row:last-child {
+  margin-bottom: 0;
+}
+
+.qv-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  min-width: 60px;
+  flex-shrink: 0;
+  padding-top: 1px;
+}
+
+.qv-value {
+  color: var(--text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  word-break: break-word;
+}
+
+.qv-desc {
+  font-family: inherit;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  word-break: break-word;
+}
+
 /* ── CHEATSHEET ── */
 .cheatsheet-group {
   margin-bottom: 16px;


### PR DESCRIPTION
## Summary
- Right-click on any entry row opens a context menu: Edit, Duplicate, Copy To, Add Sub-entry (same ticket / same desc), Make Regular (scheduled only), Star/Unstar, Delete
- Double-click row opens edit modal; single click does nothing
- Star icon on each row — outline when unstarred, filled yellow when starred — toggles without full rerender
- Sidebar "Starred Entries" lists all starred entries across all stored weeks; clicking one navigates to that week, expands the day, and highlights the entry
- Removed inline edit hint and quick-add inline buttons from entry rows

## Test plan
- [ ] Right-click entry → context menu appears at cursor
- [ ] Edit opens modal; Duplicate clones entry below; Delete removes entry
- [ ] Copy To opens the copy-to week picker modal
- [ ] Star/Unstar toggles the star icon on the row
- [ ] Add Sub-entry options only appear for grouped entries
- [ ] Make Regular only appears for scheduled entries
- [ ] Sidebar Starred Entries shows all starred entries; clicking navigates + highlights
- [ ] Double-click row opens edit modal
- [ ] Single click does nothing

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)