### PR TITLE
feat: top 5 UI animations - part 1 (issue #49)

### DIFF
--- a/app.js
+++ b/app.js
@@ -550,7 +550,8 @@ function buildEntriesHTML(entries, dayIdx) {
     const groups = buildGroups(entries);
 
     let htmlFragments = [];
-    
+    let rowIndex = 0;
+
     groups.forEach((group, gi) => {
         const roman = ROMAN[gi] + '.';
 
@@ -583,8 +584,9 @@ function buildEntriesHTML(entries, dayIdx) {
             const starClass = e.starred ? 'starred' : '';
             const starIcon  = e.starred ? 'bi-star-fill' : 'bi-star';
 
+            const rowI = rowIndex++;
             htmlFragments.push(`
-    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
+    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
       <span class="drag-handle" title="Drag to reorder"><i class="bi bi-grip-vertical"></i></span>
       <span class="entry-num entry-num-roman">${rStr}</span>
       ${ticketHtml}
@@ -802,9 +804,19 @@ function toggleDay(dayIdx) {
         saveState();
         rerenderDayCard(dayIdx);
     } else {
-        // Close the day
-        state.days[dayIdx].expanded = false;
-        rerenderDayCard(dayIdx);
+        // Animate close, then rerender collapsed
+        const body = document.getElementById(`day-body-${dayIdx}`);
+        if (body) {
+            body.classList.add('collapsing');
+            setTimeout(() => {
+                state.days[dayIdx].expanded = false;
+                rerenderDayCard(dayIdx);
+            }, 200);
+        } else {
+            state.days[dayIdx].expanded = false;
+            rerenderDayCard(dayIdx);
+        }
+        saveState();
     }
 }
 
@@ -1712,10 +1724,15 @@ function showToast(msg, type = 'success') {
       <div class="d-flex align-items-center gap-2 px-3 py-2">
         <i class="bi ${icons[type] || icons.info}" style="color:${colors[type] || colors.info}"></i>
         <span style="font-size:0.85rem">${msg}</span>
-        <button type="button" class="btn-close btn-close-white ms-auto" style="font-size:0.6rem" onclick="document.getElementById('${id}').remove()"></button>
+        <button type="button" class="btn-close btn-close-white ms-auto" style="font-size:0.6rem" onclick="(function(el){el.classList.add('toast-hiding');setTimeout(()=>el.remove(),200);})(document.getElementById('${id}'))"></button>
       </div>
     </div>`);
-    setTimeout(() => { const el = document.getElementById(id); if (el) el.remove(); }, 3000);
+    setTimeout(() => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.classList.add('toast-hiding');
+        setTimeout(() => el.remove(), 200);
+    }, 3000);
 }
 
 /* ── UTILS ─────────────────────────────────────────────── */
@@ -2105,12 +2122,16 @@ function showEntryContextMenu(row, x, y) {
     document.getElementById('ctx-star-label').textContent = entry.starred ? 'Unstar' : 'Star';
     document.getElementById('ctx-star').querySelector('i').className = entry.starred ? 'bi bi-star-fill' : 'bi bi-star';
 
-    // Position menu
+    // Position and show menu with pop animation
+    menu.classList.remove('ctx-open');
     menu.style.display = 'block';
     const mw = menu.offsetWidth, mh = menu.offsetHeight;
     const vw = window.innerWidth, vh = window.innerHeight;
     menu.style.left = (x + mw > vw ? x - mw : x) + 'px';
     menu.style.top  = (y + mh > vh ? y - mh : y) + 'px';
+    // Force reflow so re-adding the class re-triggers the animation
+    void menu.offsetWidth;
+    menu.classList.add('ctx-open');
 }
 
 function hideContextMenu() {
@@ -2245,6 +2266,11 @@ function toggleEntryStarred(dayIdx, entryIdx, btnEl) {
     btnEl.classList.toggle('starred', entry.starred);
     btnEl.querySelector('i').className = entry.starred ? 'bi bi-star-fill' : 'bi bi-star';
     btnEl.title = entry.starred ? 'Unstar' : 'Star';
+    // Pulse animation
+    btnEl.classList.remove('star-pulse');
+    void btnEl.offsetWidth; // reflow to re-trigger
+    btnEl.classList.add('star-pulse');
+    setTimeout(() => btnEl.classList.remove('star-pulse'), 300);
     // Also sync to allDaysByDate
     const dateStr = state.days[dayIdx].date;
     if (state.allDaysByDate[dateStr]) {
@@ -2680,7 +2706,14 @@ function initUpdater() {
     });
 
     window.updater.onError(() => {
-        showToast('Failed to download update.', 'danger');
+        if (manualUpdateCheck) {
+            showToast('Update check failed.', 'danger');
+            manualUpdateCheck = false;
+        } else if (downloadToastId) {
+            document.getElementById(downloadToastId)?.remove();
+            downloadToastId = null;
+            showToast('Failed to download update.', 'danger');
+        }
     });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -413,10 +413,26 @@ body::before {
 
 .day-card-body {
   padding: 16px 20px;
+  animation: slideDown 0.25s ease both;
+}
+
+.day-card-body.collapsing {
+  animation: slideUp 0.22s ease forwards;
+  pointer-events: none;
 }
 
 .day-card-body.collapsed {
   display: none;
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes slideUp {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(-10px); }
 }
 
 /* ── HOLIDAY TOGGLE ── */
@@ -784,6 +800,21 @@ body::before {
   border: 1px solid var(--border);
   color: var(--text-primary);
   border-radius: var(--radius-sm);
+  animation: toastSlideIn 0.25s ease both;
+}
+
+.toast-custom.toast-hiding {
+  animation: toastSlideOut 0.2s ease forwards;
+}
+
+@keyframes toastSlideIn {
+  from { opacity: 0; transform: translateX(50px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes toastSlideOut {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(50px); }
 }
 
 /* ── SIDEBAR (OFFCANVAS) ── */
@@ -1017,6 +1048,16 @@ body::before {
   color: var(--warning);
 }
 
+.entry-btn-star.star-pulse {
+  animation: starPulse 0.3s ease;
+}
+
+@keyframes starPulse {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.6); }
+  100% { transform: scale(1); }
+}
+
 /* ── CONTEXT MENU ── */
 .entry-context-menu {
   position: fixed;
@@ -1028,6 +1069,16 @@ body::before {
   min-width: 200px;
   padding: 4px 0;
   user-select: none;
+  transform-origin: top left;
+}
+
+.entry-context-menu.ctx-open {
+  animation: ctxPop 0.1s ease forwards;
+}
+
+@keyframes ctxPop {
+  from { opacity: 0; transform: scale(0.94) translateY(-4px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
 }
 
 .ctx-item {
@@ -1315,6 +1366,17 @@ kbd {
 
 .search-show-more:hover {
   background: var(--bg-card-hover);
+}
+
+/* Entry row staggered entrance */
+@keyframes entrySlideIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.entry-row {
+  animation: entrySlideIn 0.18s ease both;
+  animation-delay: calc(var(--i, 0) * 28ms);
 }
 
 /* Entry highlight flash */


### PR DESCRIPTION
## Summary
- **Accordion slide** — day card body slides down on expand, animates up before collapsing
- **Entry row stagger** — rows cascade in with fade+translateY, 28ms delay per row via `--i` CSS variable
- **Context menu pop** — scale(0.94)+translateY pop animation on every open; reflow trick re-triggers on repeated right-clicks
- **Star pulse** — scale burst (1→1.6→1, 300ms) on star toggle for tactile feedback
- **Toast slide-in/out** — toasts slide in from right on appear; slide back out before removal (both auto-dismiss and ✕ button)

Also fixes updater error handling: check failures now show "Update check failed." instead of the download-specific message.

Closes #49

## Test plan
- [ ] Open/close day cards — smooth slide both directions
- [ ] Add entries and switch weeks — rows stagger in
- [ ] Right-click entry repeatedly — pop animation re-triggers each time
- [ ] Star and unstar an entry — pulse visible on the star icon
- [ ] Trigger any toast — slides in from right, slides out on dismiss and auto-expire
- [ ] Click "Check for Updates" with no network — shows "Update check failed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)