### PR TITLE
feat: top 5 UI animations - part 2 (issue #51)

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,8 @@ const ROMAN = ['i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x',
 const SEPARATOR = '------------------------------------------------------------------------------------------------------------------------------------------------------';
 
 /* ── STATE ─────────────────────────────────────────────── */
+let weekTransitionDir = null; // 'left' | 'right' | null
+
 let state = {
     reportTitle: 'Booked hours in Jira and Service Desk',
     employeeName: '',
@@ -266,18 +268,24 @@ function bindHeaderEvents() {
         const val = e.target.value;
         if (!val) return;
 
+        const prevWeek = state.weekValue;
         state.weekValue = val;
         state.days = buildWeekDays(getDateFromWeek(val));
         enforceExpandedState();
         updateWeekDisplay();
         saveState();
+        weekTransitionDir = prevWeek ? (val > prevWeek ? 'left' : 'right') : null;
         renderAll();
+        weekTransitionDir = null;
     });
 
     document.getElementById('btn-autofill-week').addEventListener('click', () => {
+        const prevWeek = state.weekValue;
         setCurrentWeek();
         saveState();
+        weekTransitionDir = prevWeek ? (state.weekValue > prevWeek ? 'left' : state.weekValue < prevWeek ? 'right' : null) : null;
         renderAll();
+        weekTransitionDir = null;
     });
 
     const updateTarget = () => {
@@ -333,6 +341,14 @@ function renderDays() {
     state.days.forEach((day, i) => {
         container.appendChild(buildDayCard(day, i));
     });
+    if (weekTransitionDir) {
+        container.classList.remove('week-slide-left', 'week-slide-right');
+        void container.offsetWidth;
+        container.classList.add(`week-slide-${weekTransitionDir}`);
+        container.addEventListener('animationend', () => {
+            container.classList.remove('week-slide-left', 'week-slide-right');
+        }, { once: true });
+    }
 }
 
 /* ── BUILD DAY CARD ────────────────────────────────────── */
@@ -607,8 +623,14 @@ function buildEntriesHTML(entries, dayIdx) {
 
 function rerenderDayCard(dayIdx) {
     const existing = document.getElementById(`day-card-${dayIdx}`);
+    const oldChipText = existing?.querySelector('.day-hours-total')?.textContent;
     const newCard = buildDayCard(state.days[dayIdx], dayIdx);
     existing.replaceWith(newCard);
+    const newChip = newCard.querySelector('.day-hours-total');
+    if (newChip && newChip.textContent !== oldChipText) {
+        newChip.classList.add('chip-bounce');
+        newChip.addEventListener('animationend', () => newChip.classList.remove('chip-bounce'), { once: true });
+    }
 }
 
 /* ── DRAG AND DROP (pointer-event based, no HTML5 drag API) ── */
@@ -772,13 +794,14 @@ function attachDragListeners(dayIdx, container) {
                 'width:' + rect.width + 'px',
                 'left:' + (e.clientX - offsetX) + 'px',
                 'top:' + (e.clientY - offsetY) + 'px',
-                'opacity:0.95',
+                'opacity:0.92',
                 'background:var(--bg-card)',
                 'border:1.5px solid var(--border-accent)',
                 'border-radius:8px',
-                'box-shadow:0 10px 32px rgba(0,0,0,0.6)',
+                'box-shadow:0 16px 40px rgba(0,0,0,0.7)',
                 'transition:none',
-                'cursor:grabbing'
+                'cursor:grabbing',
+                'transform:rotate(3deg) scale(1.03)'
             ].join(';');
             document.body.appendChild(ghost);
 
@@ -2071,7 +2094,9 @@ function initTheme() {
 }
 
 function applyTheme(theme) {
+    document.documentElement.classList.add('theme-transition');
     document.documentElement.setAttribute('data-theme', theme);
+    setTimeout(() => document.documentElement.classList.remove('theme-transition'), 400);
     const icon = document.getElementById('theme-icon');
     const toggleBtn = document.getElementById('btn-theme-toggle');
     

--- a/styles.css
+++ b/styles.css
@@ -1482,3 +1482,50 @@ kbd {
   color: var(--warning);
   opacity: 0.85;
 }
+
+/* ── ANIMATION PART 2 ── */
+
+/* 1. Week navigation slide */
+@keyframes weekSlideLeft {
+  from { opacity: 0; transform: translateX(32px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes weekSlideRight {
+  from { opacity: 0; transform: translateX(-32px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.week-slide-left  { animation: weekSlideLeft  0.22s ease both; }
+.week-slide-right { animation: weekSlideRight 0.22s ease both; }
+
+/* 2. Total chip bounce */
+@keyframes chipBounce {
+  0%   { transform: scale(1); }
+  35%  { transform: scale(1.18); }
+  65%  { transform: scale(0.93); }
+  100% { transform: scale(1); }
+}
+.day-hours-total.chip-bounce {
+  animation: chipBounce 0.32s ease;
+}
+
+/* 4. Theme transition — applied briefly via JS when switching */
+.theme-transition *,
+.theme-transition *::before,
+.theme-transition *::after {
+  transition:
+    background-color 0.3s ease,
+    color 0.25s ease,
+    border-color 0.3s ease,
+    box-shadow 0.3s ease !important;
+}
+
+/* 5. Modal scale entrance */
+.modal.fade .modal-dark {
+  transform: scale(0.96);
+  opacity: 0;
+  transition: transform 0.22s ease, opacity 0.2s ease;
+}
+.modal.show .modal-dark {
+  transform: scale(1);
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- **Week navigation slide** — content slides left (forward) or right (backward) when changing weeks via the date picker or "Use Current Week" button
- **Total chip bounce** — the hours chip in the day card header plays a scale bounce when its value changes after adding or deleting an entry
- **Drag ghost tilt** — dragged entry ghost rotates 3° and scales to 1.03× for a lifted-off-the-page feel
- **Theme toggle fade** — switching dark/light crossfades backgrounds, colors, and borders over 300ms via a temporary `theme-transition` class
- **Modal scale entrance** — all `.modal-dark` modals scale from 96%→100% + fade in when opening

Closes #51

## Test plan
- [ ] Change week forward/backward via picker — slides in correct direction
- [ ] Add or delete an entry — hours chip bounces on the day card header
- [ ] Drag an entry row — ghost appears tilted and slightly scaled up
- [ ] Toggle theme from sidebar — smooth crossfade, no instant snap
- [ ] Open any modal (Add Entry, Preview, Shortcuts, etc.) — scales in smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)