### PR TITLE
feat: week navigation, shortcuts, and v1.4.0 bump (issue #58)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@
 'use strict';
 
 /* ── CONSTANTS ─────────────────────────────────────────── */
-const APP_VERSION = '1.3.0';
+const APP_VERSION = '1.4.0';
 
 const WEEK_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
 const ROMAN = ['i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x',
@@ -120,6 +120,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (restored && state.weekValue) {
         // Restore saved week & name into inputs
         document.getElementById('week-picker').value = state.weekValue;
+        
+        const maxWeek = getWeekStrFromDate(new Date());
+        document.getElementById('btn-next-week').disabled = (state.weekValue >= maxWeek);
+        
         state.days = buildWeekDays(getDateFromWeek(state.weekValue));
         enforceExpandedState();
         updateWeekDisplay();
@@ -278,12 +282,29 @@ function enforceExpandedState() {
     }
 }
 
+function changeWeekBy(delta) {
+    const picker = document.getElementById('week-picker');
+    if (!picker.value) return;
+
+    const mon = getDateFromWeek(picker.value);
+    mon.setDate(mon.getDate() + (delta * 7));
+    
+    const newWeekStr = getWeekStrFromDate(mon);
+    const maxWeekStr = getWeekStrFromDate(new Date());
+
+    if (newWeekStr > maxWeekStr) return;
+
+    picker.value = newWeekStr;
+    picker.dispatchEvent(new Event('change'));
+}
+
 function setCurrentWeek() {
     const today = new Date();
     const weekVal = getWeekStrFromDate(today);
 
     document.getElementById('week-picker').value = weekVal;
     state.weekValue = weekVal;
+    document.getElementById('btn-next-week').disabled = true;
     state.days = buildWeekDays(getDateFromWeek(weekVal));
     enforceExpandedState();
     updateWeekDisplay();
@@ -291,6 +312,18 @@ function setCurrentWeek() {
 
 /* ── BIND HEADER EVENTS ────────────────────────────────── */
 function bindHeaderEvents() {
+    const weekPicker = document.getElementById('week-picker');
+    weekPicker.max = getWeekStrFromDate(new Date());
+
+    document.getElementById('btn-prev-week').addEventListener('click', function() {
+        changeWeekBy(-1);
+        this.blur();
+    });
+    document.getElementById('btn-next-week').addEventListener('click', function() {
+        changeWeekBy(1);
+        this.blur();
+    });
+
     document.getElementById('report-title').addEventListener('input', e => {
         state.reportTitle = e.target.value;
         saveState();
@@ -302,17 +335,29 @@ function bindHeaderEvents() {
         saveState();
     });
 
-    document.getElementById('week-picker').addEventListener('change', e => {
+    weekPicker.addEventListener('change', e => {
         const val = e.target.value;
         if (!val) return;
 
         const prevWeek = state.weekValue;
-        state.weekValue = val;
-        state.days = buildWeekDays(getDateFromWeek(val));
+        const maxWeek = getWeekStrFromDate(new Date());
+        const safeVal = val > maxWeek ? maxWeek : val;
+
+        if (safeVal !== val) {
+            e.target.value = safeVal;
+        }
+
+        document.getElementById('btn-next-week').disabled = (safeVal >= maxWeek);
+
+        if (safeVal === prevWeek) return;
+
+        state.weekValue = safeVal;
+
+        state.days = buildWeekDays(getDateFromWeek(safeVal));
         enforceExpandedState();
         updateWeekDisplay();
         saveState();
-        weekTransitionDir = prevWeek ? (val > prevWeek ? 'left' : 'right') : null;
+        weekTransitionDir = prevWeek ? (safeVal > prevWeek ? 'left' : 'right') : null;
         renderAll();
         weekTransitionDir = null;
     });
@@ -320,6 +365,7 @@ function bindHeaderEvents() {
     document.getElementById('btn-autofill-week').addEventListener('click', () => {
         const prevWeek = state.weekValue;
         setCurrentWeek();
+        document.getElementById('btn-next-week').disabled = true;
         saveState();
         weekTransitionDir = prevWeek ? (state.weekValue > prevWeek ? 'left' : state.weekValue < prevWeek ? 'right' : null) : null;
         renderAll();
@@ -1886,12 +1932,24 @@ document.addEventListener('keydown', e => {
             if (expandedIdx !== -1) openEntryModal(expandedIdx, -1);
             break;
 
-        case 'ArrowLeft':
+        case 'ArrowUp':
+            e.preventDefault();
             if (expandedIdx > 0) toggleDay(expandedIdx - 1);
             break;
 
-        case 'ArrowRight':
+        case 'ArrowDown':
+            e.preventDefault();
             if (expandedIdx < state.days.length - 1) toggleDay(expandedIdx + 1);
+            break;
+
+        case 'ArrowLeft':
+            e.preventDefault();
+            changeWeekBy(-1);
+            break;
+
+        case 'ArrowRight':
+            e.preventDefault();
+            changeWeekBy(1);
             break;
 
         case 'p':

--- a/index.html
+++ b/index.html
@@ -78,7 +78,15 @@
 
             <div class="mb-3">
               <label class="form-label label-text">Timesheet Week</label>
-              <input type="week" id="week-picker" class="form-control dark-input" />
+              <div class="d-flex align-items-stretch gap-2 mb-2">
+                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-prev-week" title="Previous Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
+                  <i class="bi bi-chevron-left"></i>
+                </button>
+                <input type="week" id="week-picker" class="form-control dark-input m-0 flex-grow-1" />
+                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-next-week" title="Next Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
+                  <i class="bi bi-chevron-right"></i>
+                </button>
+              </div>
               <div class="form-text text-muted mt-1" id="week-display-label">Select a week</div>
             </div>
 
@@ -541,7 +549,8 @@
         <div class="modal-body">
           <div class="cheatsheet-group">
             <div class="cheatsheet-group-label">Navigation</div>
-            <div class="cheatsheet-row"><kbd>←</kbd><kbd>→</kbd> <span>Switch expanded day left / right</span></div>
+            <div class="cheatsheet-row"><kbd>↑</kbd><kbd>↓</kbd> <span>Switch expanded day up / down</span></div>
+            <div class="cheatsheet-row"><kbd>←</kbd><kbd>→</kbd> <span>Switch to previous / next week</span></div>
           </div>
           <div class="cheatsheet-group">
             <div class="cheatsheet-group-label">Entries</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timesheet-manager",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Weekly Jira & Service Desk Time Tracking Application",
   "main": "main.js",
   "scripts": {

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,15 @@
   background: rgba(0, 0, 0, 0.05) !important;
   color: var(--text-primary) !important;
 }
+[data-theme="light"] .btn-outline-accent {
+  color: var(--text-primary);
+  border-color: rgba(0, 0, 0, 0.25);
+  background: transparent;
+}
+[data-theme="light"] .btn-outline-accent:hover:not(:disabled) {
+  background: rgba(0, 0, 0, 0.05);
+  border-color: rgba(0, 0, 0, 0.35);
+}
 [data-theme="light"] .modal-dark {
   background: var(--bg-card);
 }


### PR DESCRIPTION
## Week Navigation Enhancements & Version 1.4.0 (Issue #58)

### Description
Implemented a comprehensive set of improvements to week navigation, accessibility, and UI consistency. This update also marks the transition to version 1.4.0.

### Key Changes
1. **Week Navigation UI**:
   - Added `<` (Previous) and `>` (Next) buttons surrounding the week picker for faster navigation.
   - Buttons are fixed at 42px width with centralized icons for layout stability.
2. **Future Week Restriction**:
   - Configured the native week picker's `max` attribute to prevent selecting future weeks.
   - The `Next Week` button is dynamically disabled when the user is on the current physical week.
   - Added persistent safety checks in `changeWeekBy()` to block any manual or shortcut-driven advancement into the future.
3. **Keyboard Shortcuts Refactor**:
   - **Up / Down Arrows**: Optimized for toggling expanded day accordions vertically.
   - **Left / Right Arrows**: Repurposed for navigating between weeks.
   - Updated the CheatSheet help modal to reflect new mappings.
4. **UI Refinement & Polish**:
   - Fixed alignment and sizing inconsistencies between buttons and input fields using `align-items-stretch`.
   - Resolved a visual bug in Light Mode where disabled buttons appeared enabled.
   - Improved interaction by blurring focus from navigation buttons after click to prevent lingering focus rings.
5. **Version Bump**:
   - Updated `package.json` and `app.js` constants to version **1.4.0**.

### Verification
- Tested with `npm start` across multiple week ranges.
- Confirmed strict boundary enforcement at the current week limit.
- Verified visual consistency in both dark and light modes.

Closes #58
