### PR TITLE
feat: weekly completion progress bar in summary panel (issue #60)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1610,9 +1610,12 @@ function updateSummary() {
     let totalMins = 0;
     let workingDays = 0;
     let totalEntries = 0;
+    let holidayCount = 0;
 
     state.days.forEach(day => {
-        if (!day.isHoliday) {
+        if (day.isHoliday) {
+            holidayCount++;
+        } else {
             const m = calcDayTotalMins(day);
             if (m > 0) workingDays++;
             totalMins += m;
@@ -1623,6 +1626,25 @@ function updateSummary() {
     animateCountUp(document.getElementById('total-hours'), totalMins, true);
     animateCountUp(document.getElementById('total-days'), workingDays, false);
     animateCountUp(document.getElementById('total-entries'), totalEntries, false);
+
+    // Weekly progress bar
+    const fill = document.getElementById('week-progress-fill');
+    if (fill) {
+        const activeDays = 5 - holidayCount;
+        if (activeDays <= 0) {
+            fill.style.width = '0%';
+            fill.classList.remove('over');
+        } else {
+            const weeklyTarget = activeDays * (state.dailyTargetMins || 480);
+            const pct = Math.min(totalMins / weeklyTarget, 1) * 100;
+            const isOver = totalMins > weeklyTarget;
+            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                fill.style.transition = 'none';
+            }
+            fill.style.width = pct.toFixed(1) + '%';
+            fill.classList.toggle('over', isOver);
+        }
+    }
 }
 
 function animateCountUp(el, targetVal, isTimeFormat = false) {

--- a/index.html
+++ b/index.html
@@ -109,7 +109,8 @@
             <!-- Totals Area inside the sidebar -->
             <h5 class="section-label mb-3"><i class="bi bi-bar-chart-line me-2"></i>Weekly Summary</h5>
             <div class="d-flex flex-column gap-3">
-              <div class="total-chip w-100 mt-0 text-center">
+              <div class="total-chip w-100 mt-0 text-center" id="total-hours-chip">
+                <div class="week-progress-fill" id="week-progress-fill"></div>
                 <span class="total-chip-label">Total Hours</span>
                 <span class="total-chip-value" id="total-hours">00:00</span>
               </div>

--- a/styles.css
+++ b/styles.css
@@ -724,6 +724,38 @@ body::before {
   border-radius: var(--radius-sm);
   padding: 10px;
   min-width: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.week-progress-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 0%;
+  background: rgba(34, 211, 160, 0.12);
+  border-radius: var(--radius-sm);
+  transition: width 0.6s ease-out, background 0.4s ease;
+  z-index: 0;
+}
+
+.week-progress-fill.over {
+  background: rgba(251, 191, 36, 0.12);
+}
+
+[data-theme="light"] .week-progress-fill {
+  background: rgba(5, 150, 105, 0.1);
+}
+
+[data-theme="light"] .week-progress-fill.over {
+  background: rgba(217, 119, 6, 0.1);
+}
+
+.total-chip-label,
+.total-chip-value {
+  position: relative;
+  z-index: 1;
 }
 
 .total-chip-label {


### PR DESCRIPTION
## Summary
Transforms the "Total Hours" chip in the Weekly Summary panel into a live progress bar — the chip's background fills left-to-right as hours are logged, with no layout changes.

- **Target**: `(5 − holidayCount) × dailyTargetMins` — leaves are excluded so they don't count against you
- **Under target**: subtle teal fill (~12% opacity), matching the circular day ring style
- **Over target**: bar locks at 100% width and shifts to a subtle amber tint
- **Animation**: `0.6s ease-out` width transition; skipped when `prefers-reduced-motion` is set
- **Dark/light mode**: handled automatically via CSS variables

Closes #60

## Test plan
- [ ] Add entries across the week — bar fills progressively
- [ ] Mark a day as holiday — target recalculates, bar adjusts
- [ ] Log over the weekly target — bar stays full, shifts to amber tint
- [ ] Toggle dark/light mode — fill color adapts correctly
- [ ] Check with `prefers-reduced-motion` — width sets instantly, no transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)