### PR TITLE
refactor(tm-65): upgrade IPC from sendSync/send to invoke/handle

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -67,33 +67,15 @@ function createWindow() {
 }
 
 // ── IPC: electron-store ──────────────────────────────────
-ipcMain.on('store-get', (event, key) => {
-  event.returnValue = store.get(key, null);
-});
-ipcMain.on('store-set', (event, key, value) => {
-  store.set(key, value);
-  event.returnValue = true;
-});
-ipcMain.on('store-delete', (event, key) => {
-  store.delete(key);
-  event.returnValue = true;
-});
-ipcMain.on('store-has', (event, key) => {
-  event.returnValue = store.has(key);
-});
+ipcMain.handle('store-get', (_event, key) => store.get(key, null));
+ipcMain.handle('store-set', (_event, key, value) => { store.set(key, value); });
+ipcMain.handle('store-delete', (_event, key) => { store.delete(key); });
+ipcMain.handle('store-has', (_event, key) => store.has(key));
 
 // ── IPC: auto-updater ────────────────────────────────────
-ipcMain.on('check-for-updates', () => {
-  autoUpdater.checkForUpdates();
-});
-
-ipcMain.on('download-update', () => {
-  autoUpdater.downloadUpdate();
-});
-
-ipcMain.on('install-update', () => {
-  autoUpdater.quitAndInstall();
-});
+ipcMain.handle('check-for-updates', () => autoUpdater.checkForUpdates());
+ipcMain.handle('download-update', () => autoUpdater.downloadUpdate());
+ipcMain.handle('install-update', () => autoUpdater.quitAndInstall());
 
 // Forward updater events to renderer
 autoUpdater.on('update-available', (info) => {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -1,16 +1,16 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronStore', {
-    get: (key) => ipcRenderer.sendSync('store-get', key),
-    set: (key, value) => ipcRenderer.sendSync('store-set', key, value),
-    delete: (key) => ipcRenderer.sendSync('store-delete', key),
-    has: (key) => ipcRenderer.sendSync('store-has', key),
+    get: (key) => ipcRenderer.invoke('store-get', key),
+    set: (key, value) => ipcRenderer.invoke('store-set', key, value),
+    delete: (key) => ipcRenderer.invoke('store-delete', key),
+    has: (key) => ipcRenderer.invoke('store-has', key),
 });
 
 contextBridge.exposeInMainWorld('updater', {
-    checkForUpdates: () => ipcRenderer.send('check-for-updates'),
-    downloadUpdate: () => ipcRenderer.send('download-update'),
-    installUpdate: () => ipcRenderer.send('install-update'),
+    checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
+    downloadUpdate: () => ipcRenderer.invoke('download-update'),
+    installUpdate: () => ipcRenderer.invoke('install-update'),
     onUpdateAvailable: (cb) => ipcRenderer.on('update-available', (_, info) => cb(info)),
     onUpdateNotAvailable: (cb) => ipcRenderer.on('update-not-available', () => cb()),
     onDownloadProgress: (cb) => ipcRenderer.on('download-progress', (_, progress) => cb(progress)),

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -43,7 +43,7 @@ let state = {
 /* ── PERSISTENCE (electron-store) ──────────────────────── */
 const LS_KEY = 'timesheetState_v1';
 
-function saveState() {
+async function saveState() {
     try {
         state.days.forEach(d => {
             if (d && d.date) state.allDaysByDate[d.date] = d;
@@ -58,25 +58,25 @@ function saveState() {
             recurringTasks: state.recurringTasks,
             dailyTargetMins: state.dailyTargetMins
         };
-        window.electronStore.set(LS_KEY, toSave);
+        await window.electronStore.set(LS_KEY, toSave);
     } catch (e) { console.warn('Could not save state', e); }
 }
 
-function loadState() {
+async function loadState() {
     try {
         // One-time migration from localStorage → electron-store
-        if (!window.electronStore.has(LS_KEY)) {
+        if (!await window.electronStore.has(LS_KEY)) {
             const raw = localStorage.getItem(LS_KEY);
             if (raw) {
                 const parsed = JSON.parse(raw);
                 if (parsed) {
-                    window.electronStore.set(LS_KEY, parsed);
+                    await window.electronStore.set(LS_KEY, parsed);
                     localStorage.removeItem(LS_KEY);
                 }
             }
         }
 
-        const saved = window.electronStore.get(LS_KEY);
+        const saved = await window.electronStore.get(LS_KEY);
         if (!saved) return false;
 
         state.reportTitle = saved.reportTitle || 'Booked hours in Jira and Service Desk';
@@ -98,7 +98,7 @@ function loadState() {
 }
 
 /* ── INIT ──────────────────────────────────────────────── */
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
     initTheme();
     initRipple();
@@ -108,7 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initSearch();
     initScheduledTasks();
     bindHeaderEvents();
-    const restored = loadState();
+    const restored = await loadState();
 
     // Always apply these inputs if we have them in state, regardless of whether a week was previously saved or not
     document.getElementById('report-title').value = state.reportTitle || '';


### PR DESCRIPTION
## Summary
- Replaces `ipcMain.on` + `event.returnValue` with `ipcMain.handle` in main process
- Replaces `ipcRenderer.sendSync` with `ipcRenderer.invoke` in preload (returns a Promise)
- Replaces `ipcRenderer.send` with `ipcRenderer.invoke` for updater fire-and-forget calls
- `saveState` and `loadState` in renderer are now `async`; `DOMContentLoaded` `await`s `loadState`

## Test plan
- [x] `npm run build` passes cleanly
- [x] `npm start` — existing data loads correctly, save/edit entries persist

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)