### PR TITLE
feat(tm-73): settings screen — full-screen modal with left nav

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -595,6 +595,11 @@
     </div>
     <div class="offcanvas-body p-0">
       <div class="sidebar-menu-list">
+        <a href="#" class="sidebar-menu-item" id="menu-settings">
+          <i class="bi bi-gear me-3"></i>
+          <span>Settings</span>
+        </a>
+        <div class="sidebar-menu-divider"></div>
         <a href="#" class="sidebar-menu-item" id="menu-starred">
           <i class="bi bi-star-fill me-3"></i>
           <span>Starred Entries</span>
@@ -660,6 +665,89 @@
             <button type="button" class="btn btn-gradient px-5" data-bs-dismiss="modal">Close</button>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- SETTINGS MODAL -->
+  <div class="modal fade" id="settingsModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-fullscreen">
+      <div class="modal-content settings-modal-content">
+
+        <!-- Header -->
+        <div class="settings-header">
+          <div class="d-flex align-items-center gap-3">
+            <i class="bi bi-gear-fill settings-header-icon"></i>
+            <span class="settings-header-title">Settings</span>
+          </div>
+          <button type="button" class="btn-close btn-close-white" id="btn-settings-close" aria-label="Close"></button>
+        </div>
+
+        <!-- Body: left nav + right content -->
+        <div class="settings-body">
+
+          <!-- Left Nav -->
+          <nav class="settings-nav">
+            <div class="settings-nav-item" data-section="general">
+              <i class="bi bi-sliders"></i>
+              <span>General</span>
+            </div>
+            <div class="settings-nav-item" data-section="appearance">
+              <i class="bi bi-palette"></i>
+              <span>Appearance</span>
+            </div>
+            <div class="settings-nav-item settings-nav-parent" data-section="management">
+              <i class="bi bi-grid"></i>
+              <span>Management</span>
+              <i class="bi bi-chevron-right settings-nav-chevron"></i>
+            </div>
+            <div class="settings-nav-sub" id="sub-management">
+              <div class="settings-nav-subitem" data-section="ticket-types">
+                <i class="bi bi-tag"></i>
+                <span>Ticket Types</span>
+              </div>
+              <div class="settings-nav-subitem" data-section="leave-types">
+                <i class="bi bi-calendar-x"></i>
+                <span>Leave Types</span>
+              </div>
+            </div>
+            <div class="settings-nav-item settings-nav-parent" data-section="developer">
+              <i class="bi bi-code-slash"></i>
+              <span>Developer</span>
+              <i class="bi bi-chevron-right settings-nav-chevron"></i>
+            </div>
+            <div class="settings-nav-sub" id="sub-developer">
+              <div class="settings-nav-subitem" data-section="error-logs">
+                <i class="bi bi-exclamation-triangle"></i>
+                <span>Error Logs</span>
+              </div>
+            </div>
+            <div class="settings-nav-item" data-section="about">
+              <i class="bi bi-info-circle"></i>
+              <span>About</span>
+            </div>
+          </nav>
+
+          <!-- Right Content -->
+          <div class="settings-content" id="settings-content"></div>
+
+        </div>
+
+        <!-- Unsaved Changes Overlay -->
+        <div class="settings-unsaved-overlay" id="settings-unsaved-overlay" style="display:none">
+          <div class="settings-unsaved-dialog">
+            <div class="d-flex align-items-center gap-2 mb-3">
+              <i class="bi bi-exclamation-triangle" style="color:var(--warning);font-size:1.1rem"></i>
+              <span class="fw-semibold" style="font-size:0.95rem;color:var(--text-primary)">Unsaved Changes</span>
+            </div>
+            <p class="settings-unsaved-msg" id="settings-unsaved-msg"></p>
+            <div class="d-flex gap-2 justify-content-end">
+              <button class="btn btn-outline-light btn-sm px-3" id="btn-settings-keep">Keep Editing</button>
+              <button class="btn btn-gradient btn-sm px-3" id="btn-settings-discard">Discard</button>
+            </div>
+          </div>
+        </div>
+
       </div>
     </div>
   </div>

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -15,6 +15,7 @@ import { initEntryModal } from './modules/entry-modal.js';
 import { initCopyTo } from './modules/copy-to.js';
 import { initReport } from './modules/report.js';
 import { bindHeaderEvents } from './modules/header.js';
+import { initSettings } from './modules/settings.js';
 import { renderAll } from './modules/render.js';
 import { state } from './modules/state.js';
 import { getWeekStrFromDate, getDateFromWeek, buildWeekDays, enforceExpandedState, updateWeekDisplay } from './modules/week.js';
@@ -24,6 +25,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
     initTheme();
     initRipple();
+    initSettings();
     initSidebar();
     initUpdater();
     initContextMenu();

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -1,0 +1,288 @@
+/* =============================================================
+   SETTINGS — full-screen modal shell, nav routing, dirty state
+   ============================================================= */
+
+/* ── SECTION METADATA ───────────────────────────────────── */
+const SECTION_META = {
+    'general':      { parent: null,         label: 'General',      isParent: false },
+    'appearance':   { parent: null,         label: 'Appearance',   isParent: false },
+    'management':   { parent: null,         label: 'Management',   isParent: true  },
+    'ticket-types': { parent: 'management', label: 'Ticket Types', isParent: false },
+    'leave-types':  { parent: 'management', label: 'Leave Types',  isParent: false },
+    'developer':    { parent: null,         label: 'Developer',    isParent: true  },
+    'error-logs':   { parent: 'developer',  label: 'Error Logs',   isParent: false },
+    'about':        { parent: null,         label: 'About',        isParent: false },
+};
+
+/* ── STATE ──────────────────────────────────────────────── */
+let currentSection = 'general';
+let dirtySection   = null;
+let _pendingTarget = null;   // section key or '__close__'
+let settingsModalInst = null;
+
+/* ── INIT ───────────────────────────────────────────────── */
+export function initSettings() {
+    const modalEl = document.getElementById('settingsModal');
+    if (!modalEl) return;
+
+    settingsModalInst = new bootstrap.Modal(modalEl, {
+        backdrop: 'static',
+        keyboard: false,
+    });
+
+    document.getElementById('btn-settings-close')
+        .addEventListener('click', attemptClose);
+
+    // Top-level nav items
+    modalEl.querySelectorAll('.settings-nav-item[data-section]').forEach(el => {
+        el.addEventListener('click', () => navigateTo(el.dataset.section));
+    });
+
+    // Sub-nav items — stop propagation so parent click doesn't also fire
+    modalEl.querySelectorAll('.settings-nav-subitem[data-section]').forEach(el => {
+        el.addEventListener('click', (e) => {
+            e.stopPropagation();
+            navigateTo(el.dataset.section);
+        });
+    });
+
+    // Unsaved overlay buttons
+    document.getElementById('btn-settings-keep')
+        .addEventListener('click', hideUnsavedOverlay);
+
+    document.getElementById('btn-settings-discard')
+        .addEventListener('click', () => {
+            const target = _pendingTarget;
+            hideUnsavedOverlay();
+            dirtySection = null;
+            if (target === '__close__') {
+                settingsModalInst.hide();
+            } else if (target) {
+                doNavigate(target);
+            }
+        });
+
+    doNavigate('general');
+}
+
+/* ── PUBLIC API ─────────────────────────────────────────── */
+export function openSettings(section = 'general') {
+    doNavigate(section);
+    settingsModalInst.show();
+}
+
+export function markDirty(section) { dirtySection = section; }
+export function clearDirty()       { dirtySection = null; }
+
+/* ── NAV ────────────────────────────────────────────────── */
+function navigateTo(section) {
+    if (dirtySection && dirtySection !== section) {
+        _pendingTarget = section;
+        showUnsavedOverlay();
+        return;
+    }
+    doNavigate(section);
+}
+
+function doNavigate(section) {
+    currentSection = section;
+    updateNav(section);
+    renderSection(section);
+}
+
+function updateNav(section) {
+    const modal = document.getElementById('settingsModal');
+    const info  = SECTION_META[section];
+
+    // Clear all active states and collapse all subs
+    modal.querySelectorAll('.settings-nav-item, .settings-nav-subitem')
+         .forEach(el => el.classList.remove('active'));
+    modal.querySelectorAll('.settings-nav-sub')
+         .forEach(el => el.classList.remove('open'));
+    modal.querySelectorAll('.settings-nav-parent')
+         .forEach(el => el.classList.remove('expanded'));
+
+    // Activate selected item
+    const activeEl = modal.querySelector(`[data-section="${section}"]`);
+    if (activeEl) activeEl.classList.add('active');
+
+    // If item is a parent → expand its own sub-nav
+    if (info?.isParent) {
+        activeEl?.classList.add('expanded');
+        modal.querySelector(`#sub-${section}`)?.classList.add('open');
+    }
+
+    // If item is a child → activate + expand parent
+    if (info?.parent) {
+        const parentEl = modal.querySelector(`.settings-nav-item[data-section="${info.parent}"]`);
+        parentEl?.classList.add('active', 'expanded');
+        modal.querySelector(`#sub-${info.parent}`)?.classList.add('open');
+    }
+}
+
+/* ── SECTION RENDERERS (shells — filled by later issues) ── */
+function renderSection(section) {
+    const el = document.getElementById('settings-content');
+    switch (section) {
+        case 'general':      return renderGeneral(el);
+        case 'appearance':   return renderAppearance(el);
+        case 'management':   return renderManagement(el);
+        case 'ticket-types': return renderTicketTypes(el);
+        case 'leave-types':  return renderLeaveTypes(el);
+        case 'developer':    return renderDeveloper(el);
+        case 'error-logs':   return renderErrorLogs(el);
+        case 'about':        return renderAbout(el);
+    }
+}
+
+function renderGeneral(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">General</h2>
+            <p class="settings-section-desc">Sheet details used in the generated timesheet report.</p>
+        </div>
+        <div class="settings-section-body">
+            <p class="settings-placeholder">Sheet Details — coming soon.</p>
+        </div>`;
+}
+
+function renderAppearance(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Appearance</h2>
+            <p class="settings-section-desc">Customize the look of the app.</p>
+        </div>
+        <div class="settings-section-body">
+            <p class="settings-placeholder">Theme settings — coming soon.</p>
+        </div>`;
+}
+
+function renderManagement(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Management</h2>
+            <p class="settings-section-desc">Configure ticket types and leave types used across the app.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="settings-mgmt-cards">
+                <div class="settings-mgmt-card" data-nav="ticket-types">
+                    <div class="settings-mgmt-card-icon">
+                        <i class="bi bi-tag-fill"></i>
+                    </div>
+                    <div class="settings-mgmt-card-body">
+                        <div class="settings-mgmt-card-title">Ticket Types</div>
+                        <div class="settings-mgmt-card-desc">Add, edit or remove ticket type options used in entries</div>
+                    </div>
+                    <i class="bi bi-chevron-right settings-mgmt-card-arrow"></i>
+                </div>
+                <div class="settings-mgmt-card" data-nav="leave-types">
+                    <div class="settings-mgmt-card-icon">
+                        <i class="bi bi-calendar-x-fill"></i>
+                    </div>
+                    <div class="settings-mgmt-card-body">
+                        <div class="settings-mgmt-card-title">Leave Types</div>
+                        <div class="settings-mgmt-card-desc">Configure holiday and leave categories for day cards</div>
+                    </div>
+                    <i class="bi bi-chevron-right settings-mgmt-card-arrow"></i>
+                </div>
+            </div>
+        </div>`;
+    el.querySelectorAll('.settings-mgmt-card[data-nav]').forEach(card => {
+        card.addEventListener('click', () => navigateTo(card.dataset.nav));
+    });
+}
+
+function renderTicketTypes(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <button class="settings-back-btn"><i class="bi bi-arrow-left"></i> Management</button>
+            <h2 class="settings-section-title">Ticket Types</h2>
+            <p class="settings-section-desc">Configure the ticket types available when adding or editing entries.</p>
+        </div>
+        <div class="settings-section-body">
+            <p class="settings-placeholder">Ticket Types — coming soon.</p>
+        </div>`;
+    el.querySelector('.settings-back-btn').addEventListener('click', () => navigateTo('management'));
+}
+
+function renderLeaveTypes(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <button class="settings-back-btn"><i class="bi bi-arrow-left"></i> Management</button>
+            <h2 class="settings-section-title">Leave Types</h2>
+            <p class="settings-section-desc">Configure leave and holiday categories for marking days.</p>
+        </div>
+        <div class="settings-section-body">
+            <p class="settings-placeholder">Leave Types — coming soon.</p>
+        </div>`;
+    el.querySelector('.settings-back-btn').addEventListener('click', () => navigateTo('management'));
+}
+
+function renderDeveloper(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Developer</h2>
+            <p class="settings-section-desc">Diagnostic tools for troubleshooting application issues.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="settings-mgmt-cards">
+                <div class="settings-mgmt-card" data-nav="error-logs">
+                    <div class="settings-mgmt-card-icon">
+                        <i class="bi bi-exclamation-triangle-fill" style="color:var(--danger)"></i>
+                    </div>
+                    <div class="settings-mgmt-card-body">
+                        <div class="settings-mgmt-card-title">Error Logs</div>
+                        <div class="settings-mgmt-card-desc">View, copy and clear application error logs</div>
+                    </div>
+                    <i class="bi bi-chevron-right settings-mgmt-card-arrow"></i>
+                </div>
+            </div>
+        </div>`;
+    el.querySelector('.settings-mgmt-card').addEventListener('click', () => navigateTo('error-logs'));
+}
+
+function renderErrorLogs(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <button class="settings-back-btn"><i class="bi bi-arrow-left"></i> Developer</button>
+            <h2 class="settings-section-title">Error Logs</h2>
+            <p class="settings-section-desc">Application error log for troubleshooting.</p>
+        </div>
+        <div class="settings-section-body">
+            <p class="settings-placeholder">Error Logs — coming soon.</p>
+        </div>`;
+    el.querySelector('.settings-back-btn').addEventListener('click', () => navigateTo('developer'));
+}
+
+function renderAbout(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">About</h2>
+            <p class="settings-section-desc">App information and release history.</p>
+        </div>
+        <div class="settings-section-body">
+            <p class="settings-placeholder">About & Changelog — coming soon.</p>
+        </div>`;
+}
+
+/* ── CLOSE / UNSAVED OVERLAY ────────────────────────────── */
+function attemptClose() {
+    if (dirtySection) {
+        _pendingTarget = '__close__';
+        showUnsavedOverlay();
+    } else {
+        settingsModalInst.hide();
+    }
+}
+
+function showUnsavedOverlay() {
+    const label = SECTION_META[dirtySection]?.label || 'this section';
+    document.getElementById('settings-unsaved-msg').textContent =
+        `You have unsaved changes in ${label}. Discard them?`;
+    document.getElementById('settings-unsaved-overlay').style.display = 'flex';
+}
+
+function hideUnsavedOverlay() {
+    document.getElementById('settings-unsaved-overlay').style.display = 'none';
+    _pendingTarget = null;
+}

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -6,17 +6,27 @@ import { saveEntry, openEntryModal } from './entry-modal.js';
 import { toggleDay, renderAll } from './render.js';
 import { changeWeekBy } from './week.js';
 import { openPreview, openDayQuickView, doPrint } from './report.js';
+import { openSettings } from './settings.js';
 
 /* ── SIDEBAR & ABOUT ────────────────────────────────────── */
 export function initSidebar() {
-    const aboutBtn = document.getElementById('menu-about');
     const sidebarEl = document.getElementById('appSidebar');
+    const aboutBtn = document.getElementById('menu-about');
     const aboutModalEl = document.getElementById('aboutModal');
 
     const closeSidebar = () => {
         const oc = bootstrap.Offcanvas.getInstance(sidebarEl);
         if (oc) oc.hide(); else new bootstrap.Offcanvas(sidebarEl).hide();
     };
+
+    const settingsBtn = document.getElementById('menu-settings');
+    if (settingsBtn) {
+        settingsBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            closeSidebar();
+            openSettings();
+        });
+    }
 
     if (aboutBtn && sidebarEl && aboutModalEl) {
         const aboutModal = new bootstrap.Modal(aboutModalEl);

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -18,3 +18,4 @@
 @import './entry-detail.css';
 @import './search.css';
 @import './animations.css';
+@import './settings.css';

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -1,0 +1,289 @@
+/* ── SETTINGS MODAL ── */
+
+#settingsModal .modal-dialog {
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+#settingsModal .modal-content {
+  height: 100%;
+  border-radius: 0;
+  border: none;
+  background: var(--bg-base);
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── HEADER ── */
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  height: 60px;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.settings-header-icon {
+  font-size: 1.1rem;
+  color: var(--accent-light);
+}
+
+.settings-header-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* ── BODY LAYOUT ── */
+
+.settings-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ── LEFT NAV ── */
+
+.settings-nav {
+  width: 220px;
+  flex-shrink: 0;
+  background: var(--bg-card);
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  padding: 12px 0;
+}
+
+.settings-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px;
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  border-left: 3px solid transparent;
+  user-select: none;
+}
+
+.settings-nav-item:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+
+.settings-nav-item.active {
+  color: var(--text-primary);
+  border-left-color: var(--success);
+  background: var(--bg-card-hover);
+}
+
+.settings-nav-item i:first-child {
+  font-size: 1rem;
+  width: 18px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.settings-nav-chevron {
+  font-size: 0.72rem !important;
+  margin-left: auto;
+  transition: transform 0.2s ease;
+}
+
+.settings-nav-parent.expanded .settings-nav-chevron {
+  transform: rotate(90deg);
+}
+
+/* ── SUB-NAV ── */
+
+.settings-nav-sub {
+  display: none;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.settings-nav-sub.open {
+  display: block;
+}
+
+.settings-nav-subitem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 20px 8px 40px;
+  font-size: 0.84rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  border-left: 3px solid transparent;
+  user-select: none;
+}
+
+.settings-nav-subitem:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-secondary);
+}
+
+.settings-nav-subitem.active {
+  color: var(--text-primary);
+  border-left-color: var(--success);
+  background: rgba(34, 211, 160, 0.05);
+}
+
+.settings-nav-subitem i {
+  font-size: 0.85rem;
+  width: 16px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+[data-theme="light"] .settings-nav-sub {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+/* ── RIGHT CONTENT ── */
+
+.settings-content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.settings-section-header {
+  padding: 32px 40px 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-section-title {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 6px;
+}
+
+.settings-section-desc {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.settings-section-body {
+  padding: 32px 40px;
+  max-width: 720px;
+}
+
+/* ── BACK BUTTON ── */
+
+.settings-back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent-light);
+  font-size: 0.82rem;
+  cursor: pointer;
+  margin-bottom: 14px;
+  transition: color 0.15s;
+}
+
+.settings-back-btn:hover {
+  color: var(--text-primary);
+}
+
+/* ── MANAGEMENT / DEVELOPER LANDING CARDS ── */
+
+.settings-mgmt-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-mgmt-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.settings-mgmt-card:hover {
+  border-color: var(--border-accent);
+  background: var(--bg-card-hover);
+}
+
+.settings-mgmt-card-icon {
+  font-size: 1.3rem;
+  width: 36px;
+  text-align: center;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.settings-mgmt-card-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.settings-mgmt-card-desc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.settings-mgmt-card-arrow {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+/* ── PLACEHOLDER ── */
+
+.settings-placeholder {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  font-style: italic;
+}
+
+/* ── UNSAVED CHANGES OVERLAY ── */
+
+.settings-unsaved-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(2px);
+}
+
+.settings-unsaved-dialog {
+  background: var(--bg-card);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius);
+  padding: 24px 28px;
+  max-width: 380px;
+  width: 100%;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
+}
+
+.settings-unsaved-msg {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0 0 16px;
+  line-height: 1.5;
+}


### PR DESCRIPTION
## Summary
- Adds dedicated Settings screen opened from a new **Settings** sidebar menu item
- Full-screen Bootstrap modal with a left nav tree and right content panel
- Left nav sections: General, Appearance, Management ▼ (Ticket Types, Leave Types), Developer ▼ (Error Logs), About
- Management and Developer expand in-place in the nav to reveal sub-items
- Landing views for Management and Developer show clickable cards to navigate to sub-sections
- Back button in sub-section headers returns to the parent landing view
- Dirty-state tracking infrastructure with an unsaved-changes overlay (Keep Editing / Discard)
- Section content is placeholder — filled by issues #74–#79

## Test plan
- [x] Build passes cleanly (26 modules)
- [x] Settings opens from sidebar menu item
- [x] All nav items navigate correctly
- [x] Management / Developer expand sub-items in nav
- [x] Management cards navigate to Ticket Types / Leave Types
- [x] Back buttons return to parent section
- [x] X button closes the modal
- [x] Visual check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)