### PR TITLE
feat(tm-74): settings General — sheet details section

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -64,16 +64,21 @@
         <!-- Week Range & Employee Info -->
         <div class="card glass-card mb-4 position-sticky" style="top: 85px;">
           <div class="card-body">
-            <h5 class="section-label"><i class="bi bi-person-badge me-2"></i>Sheet Details</h5>
-
-            <div class="mb-3">
-              <label class="form-label label-text">Report Title</label>
-              <input type="text" id="report-title" class="form-control dark-input" placeholder="Report Title" />
+            <div class="d-flex align-items-center justify-content-between mb-3">
+              <h5 class="section-label mb-0"><i class="bi bi-person-badge me-2"></i>Sheet Details</h5>
+              <button class="btn btn-sm btn-outline-accent px-2 py-1" id="btn-edit-sheet-details" title="Edit in Settings">
+                <i class="bi bi-pencil" style="font-size:0.8rem"></i>
+              </button>
             </div>
 
             <div class="mb-3">
-              <label class="form-label label-text">Employee Name</label>
-              <input type="text" id="emp-name" class="form-control dark-input" placeholder="e.g. John Doe" />
+              <div class="label-text">Report Title</div>
+              <div class="sheet-detail-value" id="display-report-title">—</div>
+            </div>
+
+            <div class="mb-3">
+              <div class="label-text">Employee Name</div>
+              <div class="sheet-detail-value" id="display-emp-name">—</div>
             </div>
 
             <div class="mb-3">
@@ -95,13 +100,8 @@
             </button>
 
             <div class="mb-3 mt-3">
-              <label class="form-label label-text">Daily Target</label>
-              <div class="d-flex align-items-center gap-2">
-                <input type="number" id="target-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="08" style="max-width:64px" />
-                <span class="label-text">hrs</span>
-                <input type="number" id="target-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" style="max-width:64px" />
-                <span class="label-text">min</span>
-              </div>
+              <div class="label-text">Daily Target</div>
+              <div class="sheet-detail-value" id="display-daily-target">—</div>
             </div>
 
             <hr class="border-secondary my-4 opacity-25">

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -15,7 +15,7 @@ import { initEntryModal } from './modules/entry-modal.js';
 import { initCopyTo } from './modules/copy-to.js';
 import { initReport } from './modules/report.js';
 import { bindHeaderEvents } from './modules/header.js';
-import { initSettings } from './modules/settings.js';
+import { initSettings, updateSheetDetailsDisplay } from './modules/settings.js';
 import { renderAll } from './modules/render.js';
 import { state } from './modules/state.js';
 import { getWeekStrFromDate, getDateFromWeek, buildWeekDays, enforceExpandedState, updateWeekDisplay } from './modules/week.js';
@@ -39,11 +39,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const restored = await loadState();
 
-    document.getElementById('report-title').value = state.reportTitle || '';
-    document.getElementById('emp-name').value = state.employeeName || '';
-    const tgt = state.dailyTargetMins || 480;
-    document.getElementById('target-hh').value = Math.floor(tgt / 60);
-    document.getElementById('target-mm').value = tgt % 60;
+    updateSheetDetailsDisplay();
 
     if (restored && state.weekValue) {
         document.getElementById('week-picker').value = state.weekValue;

--- a/src/renderer/modules/header.js
+++ b/src/renderer/modules/header.js
@@ -5,6 +5,7 @@ import { updateSummary } from './summary.js';
 import { renderAll, renderDays, setWeekTransitionDir } from './render.js';
 import { openPreview, doPrint, copyTxt, downloadTxt } from './report.js';
 import { saveEntry, deleteEntry, makeRegularEntry, updateEntryDayTotal } from './entry-modal.js';
+import { openSettings } from './settings.js';
 
 export function bindHeaderEvents() {
     const weekPicker = document.getElementById('week-picker');
@@ -19,15 +20,8 @@ export function bindHeaderEvents() {
         this.blur();
     });
 
-    document.getElementById('report-title').addEventListener('input', e => {
-        state.reportTitle = e.target.value;
-        saveState();
-    });
-
-    document.getElementById('emp-name').addEventListener('input', e => {
-        state.employeeName = e.target.value.trim();
-        updateSummary();
-        saveState();
+    document.getElementById('btn-edit-sheet-details').addEventListener('click', () => {
+        openSettings('general');
     });
 
     weekPicker.addEventListener('change', e => {
@@ -66,18 +60,6 @@ export function bindHeaderEvents() {
         setWeekTransitionDir(null);
     });
 
-    const updateTarget = () => {
-        const hh = parseInt(document.getElementById('target-hh').value) || 0;
-        const mm = parseInt(document.getElementById('target-mm').value) || 0;
-        const mins = hh * 60 + mm;
-        if (mins < 1) return;
-        state.dailyTargetMins = mins;
-        renderDays();
-        saveState();
-    };
-    document.getElementById('target-hh').addEventListener('change', updateTarget);
-    document.getElementById('target-mm').addEventListener('change', updateTarget);
-
     document.getElementById('btn-preview').addEventListener('click', openPreview);
     document.getElementById('btn-print').addEventListener('click', doPrint);
     document.getElementById('btn-copy-txt').addEventListener('click', copyTxt);
@@ -90,7 +72,6 @@ export function bindHeaderEvents() {
         ['modal-hh',          'modal-mm'],
         ['recurring-hh',      'recurring-mm'],
         ['scheduled-form-hh', 'scheduled-form-mm'],
-        ['target-hh',         'target-mm'],
     ].forEach(([hhId, mmId]) => {
         document.getElementById(hhId).addEventListener('input', function () {
             if (this.value.length >= 2) document.getElementById(mmId).focus();

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -14,8 +14,6 @@ let weekTransitionDir = null;
 export function setWeekTransitionDir(v) { weekTransitionDir = v; }
 
 export function renderAll() {
-    if (state.reportTitle) document.getElementById('report-title').value = state.reportTitle;
-    if (state.employeeName) document.getElementById('emp-name').value = state.employeeName;
     renderDays();
     updateSummary();
 }

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -2,6 +2,13 @@
    SETTINGS — full-screen modal shell, nav routing, dirty state
    ============================================================= */
 
+import { state } from './state.js';
+import { saveState } from './store.js';
+import { showToast } from './toast.js';
+import { updateSummary } from './summary.js';
+import { renderDays } from './render.js';
+import { escHtml } from './utils.js';
+
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
     'general':      { parent: null,         label: 'General',      isParent: false },
@@ -136,14 +143,94 @@ function renderSection(section) {
 }
 
 function renderGeneral(el) {
+    const tgt = state.dailyTargetMins || 480;
+    const hhVal = Math.floor(tgt / 60);
+    const mmVal = tgt % 60;
+
     el.innerHTML = `
         <div class="settings-section-header">
             <h2 class="settings-section-title">General</h2>
             <p class="settings-section-desc">Sheet details used in the generated timesheet report.</p>
         </div>
         <div class="settings-section-body">
-            <p class="settings-placeholder">Sheet Details — coming soon.</p>
+            <div class="settings-form">
+                <div class="settings-form-group">
+                    <label class="label-text" for="settings-report-title">Report Title</label>
+                    <input type="text" id="settings-report-title" class="form-control dark-input"
+                        placeholder="e.g. Booked hours in Jira and Service Desk"
+                        value="${escHtml(state.reportTitle || '')}" />
+                </div>
+                <div class="settings-form-group">
+                    <label class="label-text" for="settings-emp-name">Employee Name</label>
+                    <input type="text" id="settings-emp-name" class="form-control dark-input"
+                        placeholder="e.g. John Doe"
+                        value="${escHtml(state.employeeName || '')}" />
+                </div>
+                <div class="settings-form-group">
+                    <label class="label-text">Daily Target</label>
+                    <div class="d-flex align-items-center gap-2">
+                        <input type="number" id="settings-target-hh" class="form-control dark-input text-center"
+                            min="0" max="23" placeholder="08" value="${hhVal}" style="max-width:64px" />
+                        <span class="label-text">hrs</span>
+                        <input type="number" id="settings-target-mm" class="form-control dark-input text-center"
+                            min="0" max="59" placeholder="00" value="${mmVal}" style="max-width:64px" />
+                        <span class="label-text">min</span>
+                    </div>
+                </div>
+                <div class="settings-form-actions">
+                    <button class="btn btn-gradient px-4" id="btn-save-general">
+                        <i class="bi bi-check-lg me-1"></i> Save
+                    </button>
+                </div>
+            </div>
         </div>`;
+
+    // Mark dirty on any change
+    const markGeneralDirty = () => markDirty('general');
+    el.querySelector('#settings-report-title').addEventListener('input', markGeneralDirty);
+    el.querySelector('#settings-emp-name').addEventListener('input', markGeneralDirty);
+    el.querySelector('#settings-target-hh').addEventListener('input', markGeneralDirty);
+    el.querySelector('#settings-target-mm').addEventListener('input', markGeneralDirty);
+
+    // HH auto-advance to MM
+    el.querySelector('#settings-target-hh').addEventListener('input', function () {
+        if (this.value.length >= 2) el.querySelector('#settings-target-mm').focus();
+    });
+
+    // Save
+    el.querySelector('#btn-save-general').addEventListener('click', () => {
+        const title = el.querySelector('#settings-report-title').value.trim();
+        const name  = el.querySelector('#settings-emp-name').value.trim();
+        const hh    = parseInt(el.querySelector('#settings-target-hh').value) || 0;
+        const mm    = parseInt(el.querySelector('#settings-target-mm').value) || 0;
+        const mins  = hh * 60 + mm;
+
+        state.reportTitle    = title;
+        state.employeeName   = name;
+        state.dailyTargetMins = mins > 0 ? mins : 480;
+
+        saveState();
+        updateSummary();
+        renderDays();
+        updateSheetDetailsDisplay();
+        clearDirty();
+        showToast('Sheet details saved.', 'success');
+    });
+}
+
+/* ── SHEET DETAILS DISPLAY (main page read-only panel) ───── */
+export function updateSheetDetailsDisplay() {
+    const titleEl  = document.getElementById('display-report-title');
+    const nameEl   = document.getElementById('display-emp-name');
+    const targetEl = document.getElementById('display-daily-target');
+
+    if (titleEl)  titleEl.textContent  = state.reportTitle  || '—';
+    if (nameEl)   nameEl.textContent   = state.employeeName || '—';
+    if (targetEl) {
+        const hh = Math.floor(state.dailyTargetMins / 60);
+        const mm = state.dailyTargetMins % 60;
+        targetEl.textContent = `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`;
+    }
 }
 
 function renderAppearance(el) {

--- a/src/renderer/styles/cards.css
+++ b/src/renderer/styles/cards.css
@@ -220,6 +220,15 @@
   to   { opacity: 0; transform: translateY(-10px); }
 }
 
+/* ── SHEET DETAIL READ-ONLY DISPLAY ── */
+
+.sheet-detail-value {
+  font-size: 0.88rem;
+  color: var(--text-primary);
+  padding: 5px 0;
+  word-break: break-word;
+}
+
 /* ── HOLIDAY TOGGLE ── */
 
 .holiday-check-wrap {

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -250,6 +250,24 @@
   flex-shrink: 0;
 }
 
+/* ── SETTINGS FORM ── */
+
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.settings-form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-form-actions {
+  padding-top: 4px;
+}
+
 /* ── PLACEHOLDER ── */
 
 .settings-placeholder {


### PR DESCRIPTION
## Summary
- Sheet Details panel on main page is now read-only (Report Title, Employee Name, Daily Target shown as plain text)
- Edit icon (✏) in panel header deep-links to Settings → General
- Settings → General has editable form with Save button and dirty-state tracking
- Saving updates the main page display, persists to electron-store, and re-renders days with the new target
- Fixed `render.js` which still referenced the removed `#report-title` and `#emp-name` inputs (was causing days not to load)

## Test plan
- [x] Build passes cleanly
- [x] Days load correctly on startup
- [x] Sheet Details panel shows read-only values
- [x] ✏ button opens Settings → General with fields pre-filled
- [x] Editing and saving updates the main page display
- [x] Unsaved changes overlay appears when navigating away without saving
- [x] Visual check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)