### PR TITLE
feat(tm-75): settings Appearance — theme toggle

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -624,10 +624,6 @@
           <i class="bi bi-clock me-3"></i>
           <span>Scheduled Tasks</span>
         </a>
-        <a href="#" class="sidebar-menu-item" id="btn-theme-toggle">
-          <i class="bi bi-moon-fill me-3" id="theme-icon"></i>
-          <span>Toggle Theme</span>
-        </a>
       </div>
       
       <div class="sidebar-footer p-3 border-top border-secondary border-opacity-25 mt-auto">

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -8,6 +8,7 @@ import { showToast } from './toast.js';
 import { updateSummary } from './summary.js';
 import { renderDays } from './render.js';
 import { escHtml } from './utils.js';
+import { applyTheme } from './theme.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -234,14 +235,36 @@ export function updateSheetDetailsDisplay() {
 }
 
 function renderAppearance(el) {
+    const currentTheme = document.documentElement.getAttribute('data-theme') || 'dark';
+
     el.innerHTML = `
         <div class="settings-section-header">
             <h2 class="settings-section-title">Appearance</h2>
             <p class="settings-section-desc">Customize the look of the app.</p>
         </div>
         <div class="settings-section-body">
-            <p class="settings-placeholder">Theme settings — coming soon.</p>
+            <div class="settings-form-group">
+                <label class="label-text">Theme</label>
+                <div class="settings-theme-options">
+                    <button class="settings-theme-btn ${currentTheme === 'dark' ? 'active' : ''}" data-theme="dark">
+                        <i class="bi bi-moon-fill"></i>
+                        <span>Dark</span>
+                    </button>
+                    <button class="settings-theme-btn ${currentTheme === 'light' ? 'active' : ''}" data-theme="light">
+                        <i class="bi bi-sun-fill"></i>
+                        <span>Light</span>
+                    </button>
+                </div>
+                <p class="form-text mt-2">Changes apply immediately.</p>
+            </div>
         </div>`;
+
+    el.querySelectorAll('.settings-theme-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            applyTheme(btn.dataset.theme);
+            localStorage.setItem('theme', btn.dataset.theme);
+        });
+    });
 }
 
 function renderManagement(el) {

--- a/src/renderer/modules/theme.js
+++ b/src/renderer/modules/theme.js
@@ -11,17 +11,6 @@ export function initTheme() {
 
     applyTheme(themeToApply);
 
-    const toggleBtn = document.getElementById('btn-theme-toggle');
-    if (toggleBtn) {
-        toggleBtn.addEventListener('click', (e) => {
-            e.preventDefault();
-            const currentTheme = document.documentElement.getAttribute('data-theme') || 'dark';
-            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-            applyTheme(newTheme);
-            localStorage.setItem('theme', newTheme);
-        });
-    }
-
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
         if (!localStorage.getItem('theme')) {
             applyTheme(e.matches ? 'dark' : 'light');
@@ -33,26 +22,9 @@ export function applyTheme(theme) {
     document.documentElement.classList.add('theme-transition');
     document.documentElement.setAttribute('data-theme', theme);
     setTimeout(() => document.documentElement.classList.remove('theme-transition'), 400);
-    const icon = document.getElementById('theme-icon');
-    const toggleBtn = document.getElementById('btn-theme-toggle');
 
-    if (theme === 'light') {
-        if (icon) {
-            icon.classList.remove('bi-moon-fill', 'bi-moon');
-            icon.classList.add('bi-sun-fill');
-        }
-        if (toggleBtn) {
-            const span = toggleBtn.querySelector('span');
-            if (span) span.textContent = 'Switch to Dark Mode';
-        }
-    } else {
-        if (icon) {
-            icon.classList.remove('bi-sun-fill', 'bi-sun');
-            icon.classList.add('bi-moon-fill');
-        }
-        if (toggleBtn) {
-            const span = toggleBtn.querySelector('span');
-            if (span) span.textContent = 'Switch to Light Mode';
-        }
-    }
+    // Update theme buttons in Settings → Appearance if visible
+    document.querySelectorAll('.settings-theme-btn').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.theme === theme);
+    });
 }

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -268,6 +268,46 @@
   padding-top: 4px;
 }
 
+/* ── THEME PICKER ── */
+
+.settings-theme-options {
+  display: flex;
+  gap: 12px;
+}
+
+.settings-theme-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 28px;
+  background: var(--bg-card);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  min-width: 100px;
+}
+
+.settings-theme-btn i {
+  font-size: 1.4rem;
+}
+
+.settings-theme-btn:hover {
+  border-color: var(--border-accent);
+  color: var(--text-primary);
+  background: var(--bg-card-hover);
+}
+
+.settings-theme-btn.active {
+  border-color: var(--success);
+  background: rgba(34, 211, 160, 0.08);
+  color: var(--success);
+}
+
 /* ── PLACEHOLDER ── */
 
 .settings-placeholder {


### PR DESCRIPTION
## Summary
- Theme toggle moved from sidebar into Settings → Appearance
- Two buttons (Dark / Light) with active state highlighting the current theme
- Theme applies immediately on click — no Save button needed
- Removed \`btn-theme-toggle\` sidebar menu item
- \`applyTheme()\` updated to reflect active state on settings buttons instead of sidebar icon

## Test plan
- [x] Build passes cleanly
- [x] Sidebar no longer has Toggle Theme item
- [x] Settings → Appearance shows Dark / Light buttons
- [x] Active button reflects current theme
- [x] Clicking switches theme instantly across the app
- [x] Visual check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)