### PR TITLE
feat(tm-76): settings Management — configurable ticket types

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -214,10 +214,7 @@
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
-              <select id="modal-type" class="form-select dark-input">
-                <option value="jira">Jira</option>
-                <option value="servicedesk">Service Desk</option>
-              </select>
+              <select id="modal-type" class="form-select dark-input"></select>
             </div>
             <div class="col-12">
               <label class="form-label label-text">Description</label>
@@ -323,10 +320,7 @@
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
-              <select id="recurring-type" class="form-select dark-input">
-                <option value="jira">Jira</option>
-                <option value="servicedesk">Service Desk</option>
-              </select>
+              <select id="recurring-type" class="form-select dark-input"></select>
             </div>
             <div class="col-12">
               <label class="form-label label-text">Description</label>
@@ -426,10 +420,7 @@
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
-              <select id="scheduled-form-type" class="form-select dark-input">
-                <option value="jira">Jira</option>
-                <option value="servicedesk">Service Desk</option>
-              </select>
+              <select id="scheduled-form-type" class="form-select dark-input"></select>
             </div>
             <div class="col-12">
               <label class="form-label label-text">Description</label>

--- a/src/renderer/modules/context-menu.js
+++ b/src/renderer/modules/context-menu.js
@@ -1,6 +1,7 @@
 import { state } from './state.js';
 import { saveState } from './store.js';
 import { escHtml } from './utils.js';
+import { getTypeLabel } from './ticket-types.js';
 // Circular — resolved at call time
 import { rerenderDayCard } from './render.js';
 import { openEntryModal, openEntryModalPreFilled, makeRegularEntry, deleteEntry } from './entry-modal.js';
@@ -134,7 +135,7 @@ export function showEntryQuickView(dayIdx, entryIdx, btnEl) {
     const entry = state.days[dayIdx]?.entries[entryIdx];
     if (!entry) return;
 
-    const typeLabel = entry.type === 'servicedesk' ? 'Service Desk' : 'Jira';
+    const typeLabel = getTypeLabel(entry.type);
     const hhmm = `${String(entry.hh || 0).padStart(2,'0')}:${String(entry.mm || 0).padStart(2,'0')}`;
 
     qv.innerHTML = `

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -2,6 +2,7 @@ import { state, WEEK_DAYS } from './state.js';
 import { saveState } from './store.js';
 import { showToast, showConfirm } from './toast.js';
 import { updateSummary } from './summary.js';
+import { populateTypeSelect } from './ticket-types.js';
 // Circular — resolved at call time
 import { rerenderDayCard, renderAll } from './render.js';
 
@@ -32,7 +33,7 @@ export function openEntryModal(dayIdx, entryIdx) {
         document.getElementById('modal-ticket').value = e.ticket || '';
         document.getElementById('modal-hh').value = e.hh ?? 0;
         document.getElementById('modal-mm').value = String(e.mm ?? 0).padStart(2, '0');
-        document.getElementById('modal-type').value = e.type || 'jira';
+        populateTypeSelect(document.getElementById('modal-type'), e.type || state.ticketTypes[0]?.id || 'jira');
         document.getElementById('modal-desc').value = e.desc || '';
         document.getElementById('modal-group-id').value = e.groupId || '';
         document.getElementById('modal-group-type-ref').value = e.groupType || '';
@@ -104,7 +105,7 @@ export function openEntryModalPreFilled(dayIdx, fromEntryIdx, keepField) {
 
     if (keepField === 'ticket') {
         document.getElementById('modal-ticket').value = e.ticket || '';
-        document.getElementById('modal-type').value = e.type || 'jira';
+        populateTypeSelect(document.getElementById('modal-type'), e.type || state.ticketTypes[0]?.id || 'jira');
     } else if (keepField === 'desc') {
         document.getElementById('modal-desc').value = e.desc || '';
     }
@@ -117,7 +118,7 @@ export function clearEntryModal() {
     document.getElementById('modal-ticket').value = '';
     document.getElementById('modal-hh').value = '';
     document.getElementById('modal-mm').value = '00';
-    document.getElementById('modal-type').value = 'jira';
+    populateTypeSelect(document.getElementById('modal-type'), state.ticketTypes[0]?.id || 'jira');
     document.getElementById('modal-desc').value = '';
     document.getElementById('modal-group-id').value = '';
     document.getElementById('modal-group-type-ref').value = '';

--- a/src/renderer/modules/recurring.js
+++ b/src/renderer/modules/recurring.js
@@ -2,6 +2,7 @@ import { state, RECURRING_DAY_NAMES, DAY_IDX_TO_NAME } from './state.js';
 import { saveState } from './store.js';
 import { showToast } from './toast.js';
 import { escHtml, fmtDate } from './utils.js';
+import { getTypeById, populateTypeSelect } from './ticket-types.js';
 import { getDateFromWeek, getWeekStrFromDate } from './week.js';
 // Circular — resolved at call time
 import { rerenderDayCard } from './render.js';
@@ -119,14 +120,18 @@ function renderRecurringList() {
         container.innerHTML = `<p class="text-muted text-center py-4">No recurring tasks yet. Click "Add Recurring Task" to create one.</p>`;
         return;
     }
-    container.innerHTML = state.recurringTasks.map(rule => `
+    container.innerHTML = state.recurringTasks.map(rule => {
+        const rTypeObj = getTypeById(rule.type);
+        const rColor   = rTypeObj ? rTypeObj.color : '#c8c8c8';
+        const rBadge   = rTypeObj?.hasPrefix ? `<span class="entry-type-badge">${escHtml(rTypeObj.label)}</span>` : '';
+        return `
     <div class="recurring-rule-card mb-3">
       <div class="d-flex align-items-start justify-content-between gap-2">
         <div class="flex-fill">
           <div class="d-flex align-items-center gap-2 mb-1">
-            <span class="entry-ticket ${rule.type === 'servicedesk' ? 'servicedesk' : ''}">${escHtml(rule.ticket || '—')}</span>
+            <span class="entry-ticket" style="color:${rColor}">${escHtml(rule.ticket || '—')}</span>
             <span class="entry-hours">${String(rule.hh || 0).padStart(2,'0')}:${String(rule.mm || 0).padStart(2,'0')}</span>
-            ${rule.type === 'servicedesk' ? '<span class="entry-type-badge">Service Desk</span>' : ''}
+            ${rBadge}
           </div>
           <div class="text-muted" style="font-size:0.85rem">${escHtml(rule.desc || '')}</div>
           <div class="d-flex gap-1 mt-2">
@@ -142,7 +147,8 @@ function renderRecurringList() {
           </button>
         </div>
       </div>
-    </div>`).join('');
+    </div>`;
+    }).join('');
 
     container.querySelectorAll('[data-action="edit"]').forEach(btn => {
         btn.addEventListener('click', () => {
@@ -160,7 +166,7 @@ function openRecurringForm(rule) {
     document.getElementById('recurring-ticket').value = rule ? rule.ticket : '';
     document.getElementById('recurring-hh').value = rule ? rule.hh : '';
     document.getElementById('recurring-mm').value = rule ? String(rule.mm || 0).padStart(2, '0') : '00';
-    document.getElementById('recurring-type').value = rule ? rule.type : 'jira';
+    populateTypeSelect(document.getElementById('recurring-type'), rule ? rule.type : (state.ticketTypes[0]?.id || 'jira'));
     document.getElementById('recurring-desc').value = rule ? rule.desc : '';
     document.getElementById('recurringFormTitle').innerHTML =
         `<i class="bi bi-arrow-repeat me-2"></i>${rule ? 'Edit' : 'Add'} Recurring Task`;

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -8,6 +8,7 @@ import { showEntryContextMenu } from './context-menu.js';
 import { toggleEntryStarred } from './star.js';
 import { openDayQuickView } from './report.js';
 import { showEntryQuickView } from './context-menu.js';
+import { getTypeById } from './ticket-types.js';
 
 let weekTransitionDir = null;
 
@@ -140,13 +141,16 @@ export function buildEntriesHTML(entries, dayIdx) {
             const rStr = isFirst ? roman : '';
 
             let tktStr = (e.ticket || '');
-            let ticketHtml = `<span class="entry-ticket ${e.type === 'servicedesk' ? 'servicedesk' : ''}">${escHtml(tktStr || '—')}</span>`;
+            const typeObj = getTypeById(e.type);
+            const ticketColor = typeObj ? typeObj.color : '#c8c8c8';
+            let ticketHtml = `<span class="entry-ticket" style="color:${ticketColor}">${escHtml(tktStr || '—')}</span>`;
             if (group.type === 'ticket_group' && !isFirst) {
                 ticketHtml = `<span class="entry-ticket text-muted entry-grouped-hint">${escHtml(tktStr || '—')}</span>`;
             }
 
             const hhmm = `${String(e.hh || 0).padStart(2, '0')}:${String(e.mm || 0).padStart(2, '0')}`;
-            const isSd = e.type === 'servicedesk';
+            const showBadge = typeObj?.hasPrefix === true;
+            const badgeLabel = showBadge ? typeObj.label : '';
 
             let showDesc = true;
             if (group.type === 'desc_group' && !isLast) {
@@ -168,7 +172,7 @@ export function buildEntriesHTML(entries, dayIdx) {
       <span class="entry-num entry-num-roman">${rStr}</span>
       ${ticketHtml}
       <span class="entry-hours">${hhmm}</span>
-      ${isSd ? '<span class="entry-type-badge">Service Desk</span>' : ''}
+      ${showBadge ? `<span class="entry-type-badge">${escHtml(badgeLabel)}</span>` : ''}
       ${e.recurringId ? '<span class="entry-recurring-badge" title="Recurring task"><i class="bi bi-arrow-repeat"></i></span>' : ''}
       ${e.isScheduled ? '<span class="entry-scheduled-badge" title="Scheduled task"><i class="bi bi-clock"></i></span>' : ''}
       ${descHtml}

--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -4,6 +4,7 @@ import { escHtml, fmtDate, fmtDisplayDate, padTicket } from './utils.js';
 import { getDateFromWeek } from './week.js';
 import { calcDayTotalMins } from './summary.js';
 import { minsToHHMM } from './utils.js';
+import { getTypeById } from './ticket-types.js';
 // Circular — resolved at call time
 import { buildGroups } from './render.js';
 
@@ -57,10 +58,12 @@ export function generateTxt() {
                         const ticket = padTicket(tktStr);
 
                         const hhmm = `${String(e.hh || 0).padStart(2, '0')}:${String(e.mm || 0).padStart(2, '0')}`;
-                        const sdTag = e.type === 'servicedesk' ? '(Service desk) ' : '';
+                        const eTypeObj = getTypeById(e.type);
+                        const sdTag = eTypeObj?.prefixText || '';
 
                         let desc = e.desc || '';
-                        if (sdTag && desc.toLowerCase().startsWith('(service desk)')) {
+                        // Legacy: strip manually typed "(Service desk)" prefix from older entries
+                        if (e.type === 'servicedesk' && desc.toLowerCase().startsWith('(service desk)')) {
                             desc = desc.substring(15).trim();
                             if (desc.startsWith('-')) desc = desc.substring(1).trim();
                         }

--- a/src/renderer/modules/scheduled.js
+++ b/src/renderer/modules/scheduled.js
@@ -2,6 +2,7 @@ import { state } from './state.js';
 import { saveState } from './store.js';
 import { showToast } from './toast.js';
 import { escHtml, fmtDate } from './utils.js';
+import { getTypeById, populateTypeSelect } from './ticket-types.js';
 // Circular — resolved at call time
 import { rerenderDayCard } from './render.js';
 import { updateSummary } from './summary.js';
@@ -77,7 +78,9 @@ function renderScheduledList() {
         const dt = new Date(dateStr + 'T00:00:00');
         const dateLabel = dt.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' });
         const hhmm = `${String(entry.hh || 0).padStart(2, '0')}:${String(entry.mm || 0).padStart(2, '0')}`;
-        const isSd = entry.type === 'servicedesk';
+        const entryTypeObj = getTypeById(entry.type);
+        const isSd = entryTypeObj?.hasPrefix === true;
+        const sdLabel = isSd ? entryTypeObj.label : '';
         const isPast = dateStr <= fmtDate(new Date());
         html += `
         <div class="recurring-rule-card mb-2${isPast ? ' opacity-50' : ''}">
@@ -90,7 +93,7 @@ function renderScheduledList() {
               <div class="d-flex align-items-center gap-2 flex-wrap">
                 <span class="fw-semibold" style="font-size:0.9rem">${escHtml(entry.ticket || '—')}</span>
                 <span class="text-muted" style="font-size:0.8rem">${hhmm}</span>
-                ${isSd ? '<span class="entry-type-badge">Service Desk</span>' : ''}
+                ${isSd ? `<span class="entry-type-badge">${escHtml(sdLabel)}</span>` : ''}
               </div>
               <div class="text-muted mt-1" style="font-size:0.8rem">${escHtml(entry.desc || '')}</div>
             </div>
@@ -132,7 +135,7 @@ function openScheduledForm() {
     document.getElementById('scheduled-form-ticket').classList.remove('is-invalid');
     document.getElementById('scheduled-form-hh').value = '';
     document.getElementById('scheduled-form-mm').value = '00';
-    document.getElementById('scheduled-form-type').value = 'jira';
+    populateTypeSelect(document.getElementById('scheduled-form-type'), state.ticketTypes[0]?.id || 'jira');
     document.getElementById('scheduled-form-desc').value = '';
     document.getElementById('scheduled-form-desc').classList.remove('is-invalid');
     scheduledFormModal.show();

--- a/src/renderer/modules/search.js
+++ b/src/renderer/modules/search.js
@@ -1,6 +1,7 @@
 import { state, SEARCH_PAGE_SIZE } from './state.js';
 import { saveState } from './store.js';
-import { escHtml, fmtDate, fmtSearchDate, fmtTypeLabel, fmtHHMM } from './utils.js';
+import { escHtml, fmtDate, fmtSearchDate, fmtHHMM } from './utils.js';
+import { getTypeLabel } from './ticket-types.js';
 import { getWeekStrFromDate, getDateFromWeek, buildWeekDays, updateWeekDisplay, enforceExpandedState } from './week.js';
 // Circular — resolved at call time
 import { renderAll } from './render.js';
@@ -16,7 +17,7 @@ function searchCurrentWeek(query) {
         if (!day || !day.entries) return;
         day.entries.forEach((entry, entryIdx) => {
             const matchTicket = entry.ticket && entry.ticket.toLowerCase().includes(q);
-            const matchType   = fmtTypeLabel(entry.type).toLowerCase().includes(q);
+            const matchType   = getTypeLabel(entry.type).toLowerCase().includes(q);
             const matchDesc   = entry.desc && entry.desc.toLowerCase().includes(q);
             if (matchTicket || matchType || matchDesc) {
                 results.push({ dateStr: day.date, dayIdx, entryIdx, entry });
@@ -61,7 +62,7 @@ function renderSearchDropdown(results, query, showAll) {
     const remaining = results.length - 5;
     let html = '';
     visible.forEach((r, i) => {
-        const line1 = `${escHtml(fmtSearchDate(r.dateStr))} &middot; ${escHtml(r.entry.ticket || '—')} &middot; ${escHtml(fmtTypeLabel(r.entry.type))}`;
+        const line1 = `${escHtml(fmtSearchDate(r.dateStr))} &middot; ${escHtml(r.entry.ticket || '—')} &middot; ${escHtml(getTypeLabel(r.entry.type))}`;
         const desc = r.entry.desc || '';
         html += `<div class="search-result-item" data-idx="${i}" tabindex="-1">
             <div class="search-result-line1">${line1}</div>
@@ -211,7 +212,7 @@ function runAdvancedSearch() {
         day.entries.forEach((entry, entryIdx) => {
             if (q) {
                 const mTicket = fieldTicket && entry.ticket && entry.ticket.toLowerCase().includes(q);
-                const mType   = fieldType   && fmtTypeLabel(entry.type).toLowerCase().includes(q);
+                const mType   = fieldType   && getTypeLabel(entry.type).toLowerCase().includes(q);
                 const mDesc   = fieldDesc   && entry.desc && entry.desc.toLowerCase().includes(q);
                 if (!mTicket && !mType && !mDesc) return;
             }
@@ -236,7 +237,7 @@ function renderAdvancedResults() {
 
     container.innerHTML = pageItems.map((r, i) => {
         const hhmm = fmtHHMM(r.entry.hh, r.entry.mm);
-        const line1Left = `${escHtml(fmtSearchDate(r.dateStr))} &middot; ${escHtml(r.entry.ticket || '—')} &middot; ${escHtml(fmtTypeLabel(r.entry.type))}`;
+        const line1Left = `${escHtml(fmtSearchDate(r.dateStr))} &middot; ${escHtml(r.entry.ticket || '—')} &middot; ${escHtml(getTypeLabel(r.entry.type))}`;
         const desc = r.entry.desc || '';
         return `<div class="adv-result-card" data-pidx="${i}">
             <div class="adv-result-line1">

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -9,6 +9,7 @@ import { updateSummary } from './summary.js';
 import { renderDays } from './render.js';
 import { escHtml } from './utils.js';
 import { applyTheme } from './theme.js';
+import { renderTicketTypesSection } from './ticket-types.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -303,16 +304,7 @@ function renderManagement(el) {
 }
 
 function renderTicketTypes(el) {
-    el.innerHTML = `
-        <div class="settings-section-header">
-            <button class="settings-back-btn"><i class="bi bi-arrow-left"></i> Management</button>
-            <h2 class="settings-section-title">Ticket Types</h2>
-            <p class="settings-section-desc">Configure the ticket types available when adding or editing entries.</p>
-        </div>
-        <div class="settings-section-body">
-            <p class="settings-placeholder">Ticket Types — coming soon.</p>
-        </div>`;
-    el.querySelector('.settings-back-btn').addEventListener('click', () => navigateTo('management'));
+    renderTicketTypesSection(el, navigateTo);
 }
 
 function renderLeaveTypes(el) {

--- a/src/renderer/modules/star.js
+++ b/src/renderer/modules/star.js
@@ -1,6 +1,7 @@
 import { state } from './state.js';
 import { saveState } from './store.js';
-import { escHtml, fmtSearchDate, fmtHHMM, fmtTypeLabel } from './utils.js';
+import { escHtml, fmtSearchDate, fmtHHMM } from './utils.js';
+import { getTypeLabel } from './ticket-types.js';
 import { navigateToResult } from './search.js';
 
 export function toggleEntryStarred(dayIdx, entryIdx, btnEl) {
@@ -39,7 +40,7 @@ export function renderStarredList() {
 
     container.innerHTML = results.map((r, i) => {
         const hhmm = fmtHHMM(r.entry.hh, r.entry.mm);
-        const typeLabel = fmtTypeLabel(r.entry.type);
+        const typeLabel = getTypeLabel(r.entry.type);
         return `<div class="adv-result-card" data-sidx="${i}">
             <div class="adv-result-line1">
                 <span>${escHtml(fmtSearchDate(r.dateStr))} &middot; ${escHtml(r.entry.ticket || '—')} &middot; ${escHtml(typeLabel)}</span>

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -9,6 +9,11 @@ export const RECURRING_DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 export const DAY_IDX_TO_NAME = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri' };
 export const SEARCH_PAGE_SIZE = 10;
 
+export const DEFAULT_TICKET_TYPES = [
+    { id: 'jira',        label: 'Jira',         color: '#c8c8c8', hasPrefix: false, prefixText: '' },
+    { id: 'servicedesk', label: 'Service Desk',  color: '#fbbf24', hasPrefix: true,  prefixText: '(Service desk) ' },
+];
+
 export const state = {
     reportTitle: 'Booked hours in Jira and Service Desk',
     employeeName: '',
@@ -17,5 +22,6 @@ export const state = {
     days: [],
     lastOpenedDateByWeek: {},
     recurringTasks: [],
-    dailyTargetMins: 480
+    dailyTargetMins: 480,
+    ticketTypes: [],
 };

--- a/src/renderer/modules/store.js
+++ b/src/renderer/modules/store.js
@@ -1,4 +1,4 @@
-import { state, LS_KEY } from './state.js';
+import { state, LS_KEY, DEFAULT_TICKET_TYPES } from './state.js';
 
 export async function saveState() {
     try {
@@ -13,7 +13,8 @@ export async function saveState() {
             allDaysByDate: state.allDaysByDate,
             lastOpenedDateByWeek: state.lastOpenedDateByWeek,
             recurringTasks: state.recurringTasks,
-            dailyTargetMins: state.dailyTargetMins
+            dailyTargetMins: state.dailyTargetMins,
+            ticketTypes: state.ticketTypes,
         };
         await window.electronStore.set(LS_KEY, toSave);
     } catch (e) { console.warn('Could not save state', e); }
@@ -33,7 +34,10 @@ export async function loadState() {
         }
 
         const saved = await window.electronStore.get(LS_KEY);
-        if (!saved) return false;
+        if (!saved) {
+            state.ticketTypes = [...DEFAULT_TICKET_TYPES];
+            return false;
+        }
 
         state.reportTitle = saved.reportTitle || 'Booked hours in Jira and Service Desk';
         state.employeeName = saved.employeeName || '';
@@ -42,6 +46,9 @@ export async function loadState() {
         state.lastOpenedDateByWeek = saved.lastOpenedDateByWeek || {};
         state.recurringTasks = saved.recurringTasks || [];
         state.dailyTargetMins = saved.dailyTargetMins || 480;
+        state.ticketTypes = saved.ticketTypes && saved.ticketTypes.length > 0
+            ? saved.ticketTypes
+            : [...DEFAULT_TICKET_TYPES];
 
         if (saved.days && Array.isArray(saved.days)) {
             saved.days.forEach(d => {

--- a/src/renderer/modules/ticket-types.js
+++ b/src/renderer/modules/ticket-types.js
@@ -1,0 +1,230 @@
+/* =============================================================
+   TICKET TYPES — configurable type list, CRUD, select helpers
+   ============================================================= */
+
+import { state, DEFAULT_TICKET_TYPES } from './state.js';
+import { saveState } from './store.js';
+import { showToast, showConfirm } from './toast.js';
+import { escHtml } from './utils.js';
+// Circular — resolved at call time
+import { renderAll } from './render.js';
+
+/* ── PUBLIC HELPERS ─────────────────────────────────────────── */
+
+export function getTypeLabel(typeId) {
+    const type = (state.ticketTypes || []).find(t => t.id === typeId);
+    if (type) return type.label;
+    // Fallbacks for built-in IDs (in case ticketTypes hasn't loaded yet)
+    if (typeId === 'servicedesk') return 'Service Desk';
+    if (typeId === 'jira') return 'Jira';
+    // Deleted / unrecognised type
+    return typeId ? `Unknown (${typeId})` : 'Unknown';
+}
+
+export function getTypeById(typeId) {
+    return (state.ticketTypes || []).find(t => t.id === typeId) || null;
+}
+
+export function populateTypeSelect(selectEl, selectedId) {
+    const types = state.ticketTypes && state.ticketTypes.length
+        ? state.ticketTypes
+        : DEFAULT_TICKET_TYPES;
+    selectEl.innerHTML = types
+        .map(t => `<option value="${escHtml(t.id)}"${t.id === selectedId ? ' selected' : ''}>${escHtml(t.label)}</option>`)
+        .join('');
+}
+
+/* ── SETTINGS SECTION RENDERER ──────────────────────────────── */
+
+export function renderTicketTypesSection(el, navigate) {
+    _render(el, navigate, undefined);
+}
+
+/* formTypeId:
+ *   undefined → list + "Add Type" button, no form
+ *   null      → show empty add form
+ *   'some-id' → show edit form for that type id
+ */
+function _render(el, navigate, formTypeId) {
+    const types = state.ticketTypes || [];
+    const BUILT_IN = new Set(['jira', 'servicedesk']);
+    const showForm = formTypeId !== undefined;
+    const editingType = showForm && formTypeId !== null
+        ? types.find(t => t.id === formTypeId) || null
+        : null;
+
+    const listHtml = types.length === 0
+        ? '<p class="settings-placeholder">No ticket types defined.</p>'
+        : types.map(t => `
+            <div class="tt-row" data-id="${escHtml(t.id)}">
+                <span class="tt-color-dot" style="background:${escHtml(t.color)}"></span>
+                <span class="tt-label">${escHtml(t.label)}</span>
+                <span class="tt-prefix-hint">${t.hasPrefix ? escHtml(t.prefixText) : ''}</span>
+                <div class="tt-actions">
+                    <button class="btn btn-sm btn-outline-light tt-edit-btn" data-id="${escHtml(t.id)}" title="Edit">
+                        <i class="bi bi-pencil-square"></i>
+                    </button>
+                    <button class="btn btn-sm btn-outline-danger tt-delete-btn" data-id="${escHtml(t.id)}"${BUILT_IN.has(t.id) ? ' disabled title="Built-in type cannot be deleted"' : ' title="Delete"'}>
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </div>
+            </div>`).join('');
+
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <button class="settings-back-btn"><i class="bi bi-arrow-left"></i> Management</button>
+            <h2 class="settings-section-title">Ticket Types</h2>
+            <p class="settings-section-desc">Configure the ticket types available when adding entries.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="tt-list">${listHtml}</div>
+            ${showForm
+                ? `<div class="tt-form mt-4">${_buildForm(editingType, formTypeId)}</div>`
+                : `<button class="btn btn-outline-light btn-sm mt-3 tt-add-btn">
+                       <i class="bi bi-plus-lg me-1"></i> Add Type
+                   </button>`
+            }
+        </div>`;
+
+    el.querySelector('.settings-back-btn')
+        .addEventListener('click', () => navigate('management'));
+
+    el.querySelectorAll('.tt-edit-btn').forEach(btn => {
+        btn.addEventListener('click', () => _render(el, navigate, btn.dataset.id));
+    });
+
+    el.querySelectorAll('.tt-delete-btn:not([disabled])').forEach(btn => {
+        btn.addEventListener('click', () => _deleteType(btn.dataset.id, el, navigate));
+    });
+
+    const addBtn = el.querySelector('.tt-add-btn');
+    if (addBtn) {
+        addBtn.addEventListener('click', () => _render(el, navigate, null));
+    }
+
+    if (showForm) {
+        _bindForm(el.querySelector('.tt-form'), editingType, el, navigate);
+    }
+}
+
+function _buildForm(editingType, formTypeId) {
+    const isNew = formTypeId === null || !editingType;
+    const t = editingType;
+    return `
+        <div class="settings-form">
+            <div class="tt-form-title">${isNew ? 'Add Ticket Type' : `Edit — ${escHtml(t.label)}`}</div>
+            <div class="settings-form-group">
+                <label class="label-text" for="tt-form-label">Label</label>
+                <input type="text" id="tt-form-label" class="form-control dark-input"
+                    placeholder="e.g. Service Desk" value="${escHtml(t?.label || '')}" maxlength="50" />
+            </div>
+            <div class="settings-form-group">
+                <label class="label-text">Color</label>
+                <div class="d-flex align-items-center gap-2">
+                    <input type="color" id="tt-form-color" class="tt-color-input" value="${escHtml(t?.color || '#aaaaaa')}" />
+                    <span class="label-text" id="tt-form-color-val">${escHtml(t?.color || '#aaaaaa')}</span>
+                </div>
+            </div>
+            <div class="settings-form-group">
+                <div class="d-flex align-items-center gap-2">
+                    <input type="checkbox" id="tt-form-hasprefix" class="form-check-input" ${t?.hasPrefix ? 'checked' : ''} />
+                    <label class="label-text mb-0" for="tt-form-hasprefix">Add prefix text to report entries</label>
+                </div>
+            </div>
+            <div class="settings-form-group" id="tt-form-prefix-row" style="${t?.hasPrefix ? '' : 'display:none'}">
+                <label class="label-text" for="tt-form-prefixtext">Prefix Text</label>
+                <input type="text" id="tt-form-prefixtext" class="form-control dark-input"
+                    placeholder="e.g. (Service desk) " value="${escHtml(t?.prefixText || '')}" maxlength="100" />
+            </div>
+            <div class="settings-form-actions d-flex gap-2">
+                <button class="btn btn-gradient px-4" id="tt-form-save">
+                    <i class="bi bi-check-lg me-1"></i>${isNew ? 'Add' : 'Save'}
+                </button>
+                <button class="btn btn-outline-light px-4" id="tt-form-cancel">Cancel</button>
+            </div>
+        </div>`;
+}
+
+function _bindForm(formEl, editingType, el, navigate) {
+    const colorInput  = formEl.querySelector('#tt-form-color');
+    const colorVal    = formEl.querySelector('#tt-form-color-val');
+    const hasPrefixCb = formEl.querySelector('#tt-form-hasprefix');
+    const prefixRow   = formEl.querySelector('#tt-form-prefix-row');
+
+    colorInput.addEventListener('input', () => { colorVal.textContent = colorInput.value; });
+    hasPrefixCb.addEventListener('change', () => {
+        prefixRow.style.display = hasPrefixCb.checked ? '' : 'none';
+    });
+
+    formEl.querySelector('#tt-form-save').addEventListener('click', () => {
+        const labelInput = formEl.querySelector('#tt-form-label');
+        const label = labelInput.value.trim();
+        if (!label) { labelInput.classList.add('is-invalid'); return; }
+        labelInput.classList.remove('is-invalid');
+
+        const color      = colorInput.value;
+        const hasPrefix  = hasPrefixCb.checked;
+        const prefixText = hasPrefix ? (formEl.querySelector('#tt-form-prefixtext').value) : '';
+
+        if (editingType) {
+            const type = state.ticketTypes.find(t => t.id === editingType.id);
+            if (type) { type.label = label; type.color = color; type.hasPrefix = hasPrefix; type.prefixText = prefixText; }
+        } else {
+            const id = 'type_' + Date.now();
+            state.ticketTypes.push({ id, label, color, hasPrefix, prefixText });
+        }
+
+        saveState();
+        _syncTypeSelects();
+        renderAll();
+        showToast(editingType ? 'Ticket type updated.' : 'Ticket type added.', 'success');
+        _render(el, navigate, undefined);
+    });
+
+    formEl.querySelector('#tt-form-cancel').addEventListener('click', () => {
+        _render(el, navigate, undefined);
+    });
+}
+
+function _deleteType(id, el, navigate) {
+    const type = state.ticketTypes.find(t => t.id === id);
+    if (!type) return;
+
+    const inUse = Object.values(state.allDaysByDate).some(day =>
+        day.entries && day.entries.some(e => e.type === id)
+    ) || (state.days || []).some(day =>
+        day && day.entries && day.entries.some(e => e.type === id)
+    );
+
+    const doDelete = async () => {
+        state.ticketTypes = state.ticketTypes.filter(t => t.id !== id);
+        await saveState();
+        _syncTypeSelects();
+        renderAll();
+        showToast('Ticket type deleted.', 'success');
+        _render(el, navigate, undefined);
+    };
+
+    if (inUse) {
+        let warning = `Entries using "${type.label}" will show as unknown type with grey colour.`;
+        if (type.hasPrefix && type.prefixText) {
+            warning += ` The prefix "${type.prefixText}" will no longer appear in reports.`;
+        }
+        showConfirm(warning, doDelete);
+    } else {
+        showConfirm(`Delete ticket type "${type.label}"?`, doDelete);
+    }
+}
+
+function _syncTypeSelects() {
+    ['modal-type', 'recurring-type', 'scheduled-form-type'].forEach(id => {
+        const sel = document.getElementById(id);
+        if (!sel) return;
+        const current = sel.value;
+        populateTypeSelect(sel, current);
+        // If the previously selected type was deleted, fall back to first type
+        if (!state.ticketTypes.find(t => t.id === sel.value)) {
+            sel.value = state.ticketTypes[0]?.id || 'jira';
+        }
+    });
+}

--- a/src/renderer/modules/toast.js
+++ b/src/renderer/modules/toast.js
@@ -11,6 +11,11 @@ export function showConfirm(message, onYes) {
     yesBtn.onclick = () => { confirmModal.hide(); cleanup(); onYes(); };
     noBtn.onclick = () => { confirmModal.hide(); cleanup(); };
     confirmModal.show();
+    // If another modal is already open, push the new backdrop above it
+    requestAnimationFrame(() => {
+        const backdrops = document.querySelectorAll('.modal-backdrop');
+        if (backdrops.length >= 2) backdrops[backdrops.length - 1].style.zIndex = '1059';
+    });
 }
 
 export function showToast(msg, type = 'success') {

--- a/src/renderer/modules/utils.js
+++ b/src/renderer/modules/utils.js
@@ -37,10 +37,6 @@ export function fmtSearchDate(dateStr) {
     return `${days[d.getDay()]} ${d.getDate()} ${months[d.getMonth()]}`;
 }
 
-export function fmtTypeLabel(type) {
-    return type === 'servicedesk' ? 'Service Desk' : 'Jira';
-}
-
 export function padTicket(ticket) {
     const target = 11;
     if (ticket.length < target) return ticket + ' '.repeat(target - ticket.length);

--- a/src/renderer/styles/modals.css
+++ b/src/renderer/styles/modals.css
@@ -44,3 +44,8 @@
   overflow-x: auto;
   line-height: 1.7;
 }
+
+/* Ensure confirm modal always renders above other open modals (e.g. settings) */
+#confirmModal {
+  z-index: 1060;
+}

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -345,3 +345,79 @@
   margin: 0 0 16px;
   line-height: 1.5;
 }
+
+/* ── TICKET TYPES ── */
+
+.tt-list {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.tt-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card);
+  transition: background 0.15s;
+}
+
+.tt-row:last-child {
+  border-bottom: none;
+}
+
+.tt-row:hover {
+  background: var(--bg-hover);
+}
+
+.tt-color-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid rgba(255,255,255,0.15);
+}
+
+.tt-label {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  min-width: 110px;
+}
+
+.tt-prefix-hint {
+  font-size: 0.76rem;
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tt-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.tt-form-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 16px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.tt-color-input {
+  width: 40px;
+  height: 32px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Replaces hardcoded Jira/Service Desk types with a fully user-configurable ticket type system
- New `ticket-types.js` module with CRUD UI in Settings → Management → Ticket Types
- All modules (render, report, recurring, scheduled, entry modal, search, star, context menu) now use dynamic type lookups instead of hardcoded `'servicedesk'` comparisons

## What's new
- **Ticket Types settings UI** — add, edit, delete types with label, color picker, and optional report prefix
- **Dynamic entry rendering** — ticket color and badge driven by type config; deleting a type shows entries as grey/unknown immediately
- **Backward compatible** — existing entries with `type: 'jira'` / `type: 'servicedesk'` continue to work via seeded defaults
- **Delete protection** — deleting an in-use type shows a confirmation warning instead of blocking
- **Confirm modal z-index fix** — confirm dialog now appears above the full-screen settings modal

## Test plan
- [ ] Settings → Management → Ticket Types shows Jira and Service Desk defaults
- [ ] Add a new type with custom color and prefix — appears in all type dropdowns (entry modal, recurring, scheduled)
- [ ] Edit a type — entry cards update color/badge immediately without restart
- [ ] Delete an in-use type — confirmation warns about unknown entries, main page updates immediately
- [ ] Built-in types (Jira, Service Desk) have delete button disabled
- [ ] Report output uses custom prefix text for types with hasPrefix enabled
- [ ] Confirm dialog appears above settings modal (not behind it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)