### PR TITLE
feat(tm-77): settings Management — configurable leave types

### DIFF
--- a/src/renderer/modules/copy-to.js
+++ b/src/renderer/modules/copy-to.js
@@ -96,7 +96,7 @@ function executeCopyTo() {
         if (!state.allDaysByDate[dateStr]) {
             state.allDaysByDate[dateStr] = {
                 date: dateStr, isHoliday: false,
-                holidayLabel: 'Offshore Holiday', expanded: false, entries: []
+                leaveTypeId: '', holidayLabel: 'Offshore Holiday', expanded: false, entries: []
             };
         }
         state.allDaysByDate[dateStr].entries.push({ ...entryCopy });

--- a/src/renderer/modules/leave-types.js
+++ b/src/renderer/modules/leave-types.js
@@ -1,0 +1,207 @@
+/* =============================================================
+   LEAVE TYPES — configurable leave/holiday list, CRUD, helpers
+   ============================================================= */
+
+import { state, DEFAULT_LEAVE_TYPES } from './state.js';
+import { saveState } from './store.js';
+import { showToast, showConfirm } from './toast.js';
+import { escHtml } from './utils.js';
+// Circular — resolved at call time
+import { renderAll } from './render.js';
+
+/* ── PUBLIC HELPERS ─────────────────────────────────────────── */
+
+/** Resolve the display label for a day that may use old or new data model. */
+export function getLeaveLabel(day) {
+    if (day.leaveTypeId) {
+        const type = getLeaveTypeById(day.leaveTypeId);
+        if (type) return type.label;
+    }
+    // Fallback for old data (holidayLabel string) or deleted types
+    return day.holidayLabel || 'Offshore Holiday';
+}
+
+export function getLeaveTypeById(id) {
+    return (state.leaveTypes || []).find(t => t.id === id) || null;
+}
+
+/**
+ * Resolve the effective leave type ID for a day.
+ * Handles backward compat with days that only have holidayLabel.
+ */
+export function resolveLeaveTypeId(day) {
+    if (day.leaveTypeId && getLeaveTypeById(day.leaveTypeId)) return day.leaveTypeId;
+    // Try to match existing label to a type (old data migration)
+    if (day.holidayLabel) {
+        const byLabel = (state.leaveTypes || []).find(t => t.label === day.holidayLabel);
+        if (byLabel) return byLabel.id;
+    }
+    return (state.leaveTypes || DEFAULT_LEAVE_TYPES)[0]?.id || 'offshore-holiday';
+}
+
+export function populateLeaveSelect(selectEl, selectedId) {
+    const types = state.leaveTypes && state.leaveTypes.length
+        ? state.leaveTypes
+        : DEFAULT_LEAVE_TYPES;
+    selectEl.innerHTML = types
+        .map(t => `<option value="${escHtml(t.id)}"${t.id === selectedId ? ' selected' : ''}>${escHtml(t.label)}</option>`)
+        .join('');
+}
+
+/* ── SETTINGS SECTION RENDERER ──────────────────────────────── */
+
+export function renderLeaveTypesSection(el, navigate) {
+    _render(el, navigate, undefined);
+}
+
+/* formTypeId:
+ *   undefined → list + "Add Type" button, no form
+ *   null      → show empty add form
+ *   'some-id' → show edit form for that type id
+ */
+function _render(el, navigate, formTypeId) {
+    const types = state.leaveTypes || [];
+    const BUILT_IN = new Set(['offshore-holiday', 'sick-leave', 'planned-leave']);
+    const showForm = formTypeId !== undefined;
+    const editingType = showForm && formTypeId !== null
+        ? types.find(t => t.id === formTypeId) || null
+        : null;
+
+    const listHtml = types.length === 0
+        ? '<p class="settings-placeholder">No leave types defined.</p>'
+        : types.map(t => `
+            <div class="tt-row" data-id="${escHtml(t.id)}">
+                <span class="tt-label">${escHtml(t.label)}</span>
+                <span class="tt-prefix-hint">${t.paid ? 'Paid' : 'Unpaid'}</span>
+                <div class="tt-actions">
+                    <button class="btn btn-sm btn-outline-light tt-edit-btn" data-id="${escHtml(t.id)}" title="Edit">
+                        <i class="bi bi-pencil-square"></i>
+                    </button>
+                    <button class="btn btn-sm btn-outline-danger tt-delete-btn" data-id="${escHtml(t.id)}"${BUILT_IN.has(t.id) ? ' disabled title="Built-in type cannot be deleted"' : ' title="Delete"'}>
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </div>
+            </div>`).join('');
+
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <button class="settings-back-btn"><i class="bi bi-arrow-left"></i> Management</button>
+            <h2 class="settings-section-title">Leave Types</h2>
+            <p class="settings-section-desc">Configure the leave types available when marking a day as holiday or leave.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="tt-list">${listHtml}</div>
+            ${showForm
+                ? `<div class="tt-form mt-4">${_buildForm(editingType, formTypeId)}</div>`
+                : `<button class="btn btn-outline-light btn-sm mt-3 tt-add-btn">
+                       <i class="bi bi-plus-lg me-1"></i> Add Type
+                   </button>`
+            }
+        </div>`;
+
+    el.querySelector('.settings-back-btn')
+        .addEventListener('click', () => navigate('management'));
+
+    el.querySelectorAll('.tt-edit-btn').forEach(btn => {
+        btn.addEventListener('click', () => _render(el, navigate, btn.dataset.id));
+    });
+
+    el.querySelectorAll('.tt-delete-btn:not([disabled])').forEach(btn => {
+        btn.addEventListener('click', () => _deleteType(btn.dataset.id, el, navigate));
+    });
+
+    const addBtn = el.querySelector('.tt-add-btn');
+    if (addBtn) addBtn.addEventListener('click', () => _render(el, navigate, null));
+
+    if (showForm) _bindForm(el.querySelector('.tt-form'), editingType, el, navigate);
+}
+
+function _buildForm(editingType, formTypeId) {
+    const isNew = formTypeId === null || !editingType;
+    const t = editingType;
+    return `
+        <div class="settings-form">
+            <div class="tt-form-title">${isNew ? 'Add Leave Type' : `Edit — ${escHtml(t.label)}`}</div>
+            <div class="settings-form-group">
+                <label class="label-text" for="lt-form-label">Label</label>
+                <input type="text" id="lt-form-label" class="form-control dark-input"
+                    placeholder="e.g. Bank Holiday" value="${escHtml(t?.label || '')}" maxlength="60" />
+            </div>
+            <div class="settings-form-group">
+                <div class="d-flex align-items-center gap-2">
+                    <input type="checkbox" id="lt-form-paid" class="form-check-input" ${t?.paid ? 'checked' : ''} />
+                    <label class="label-text mb-0" for="lt-form-paid">Paid leave</label>
+                </div>
+            </div>
+            <div class="settings-form-actions d-flex gap-2">
+                <button class="btn btn-gradient px-4" id="lt-form-save">
+                    <i class="bi bi-check-lg me-1"></i>${isNew ? 'Add' : 'Save'}
+                </button>
+                <button class="btn btn-outline-light px-4" id="lt-form-cancel">Cancel</button>
+            </div>
+        </div>`;
+}
+
+function _bindForm(formEl, editingType, el, navigate) {
+    formEl.querySelector('#lt-form-save').addEventListener('click', () => {
+        const labelInput = formEl.querySelector('#lt-form-label');
+        const label = labelInput.value.trim();
+        if (!label) { labelInput.classList.add('is-invalid'); return; }
+        labelInput.classList.remove('is-invalid');
+
+        const paid = formEl.querySelector('#lt-form-paid').checked;
+
+        if (editingType) {
+            const type = state.leaveTypes.find(t => t.id === editingType.id);
+            if (type) { type.label = label; type.paid = paid; }
+        } else {
+            state.leaveTypes.push({ id: 'lt_' + Date.now(), label, paid });
+        }
+
+        saveState();
+        _syncLeaveSelects();
+        renderAll();
+        showToast(editingType ? 'Leave type updated.' : 'Leave type added.', 'success');
+        _render(el, navigate, undefined);
+    });
+
+    formEl.querySelector('#lt-form-cancel').addEventListener('click', () => {
+        _render(el, navigate, undefined);
+    });
+}
+
+function _deleteType(id, el, navigate) {
+    const type = state.leaveTypes.find(t => t.id === id);
+    if (!type) return;
+
+    const inUse = Object.values(state.allDaysByDate).some(day => day.leaveTypeId === id)
+        || (state.days || []).some(day => day && day.leaveTypeId === id);
+
+    const doDelete = async () => {
+        state.leaveTypes = state.leaveTypes.filter(t => t.id !== id);
+        await saveState();
+        _syncLeaveSelects();
+        renderAll();
+        showToast('Leave type deleted.', 'success');
+        _render(el, navigate, undefined);
+    };
+
+    if (inUse) {
+        showConfirm(
+            `Days using "${type.label}" will fall back to their saved label or "Offshore Holiday".`,
+            doDelete
+        );
+    } else {
+        showConfirm(`Delete leave type "${type.label}"?`, doDelete);
+    }
+}
+
+function _syncLeaveSelects() {
+    document.querySelectorAll('[id^="holiday-label-"]').forEach(sel => {
+        const current = sel.value;
+        populateLeaveSelect(sel, current);
+        if (!state.leaveTypes.find(t => t.id === sel.value)) {
+            sel.value = state.leaveTypes[0]?.id || 'offshore-holiday';
+        }
+    });
+}

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -9,6 +9,7 @@ import { toggleEntryStarred } from './star.js';
 import { openDayQuickView } from './report.js';
 import { showEntryQuickView } from './context-menu.js';
 import { getTypeById } from './ticket-types.js';
+import { getLeaveLabel, resolveLeaveTypeId, populateLeaveSelect } from './leave-types.js';
 
 let weekTransitionDir = null;
 
@@ -198,7 +199,7 @@ export function buildDayCard(day, dayIdx) {
 
     let topRightBadge = '';
     if (day.isHoliday) {
-        topRightBadge = `<span class="day-holiday-badge"><i class="bi bi-umbrella me-1"></i>${escHtml(day.holidayLabel || 'Offshore Holiday')}</span>`;
+        topRightBadge = `<span class="day-holiday-badge"><i class="bi bi-umbrella me-1"></i>${escHtml(getLeaveLabel(day))}</span>`;
     } else if (totalMins > 0) {
         topRightBadge = `<span class="day-hours-total">${totalHrsStr} hrs</span>`;
     } else {
@@ -230,9 +231,6 @@ export function buildDayCard(day, dayIdx) {
         <label for="holiday-${dayIdx}">Mark as Holiday / Leave</label>
         <select id="holiday-label-${dayIdx}" class="form-select dark-input ms-2"
           style="max-width:200px;display:${day.isHoliday ? 'block' : 'none'}">
-          <option value="Offshore Holiday" ${(day.holidayLabel || 'Offshore Holiday') === 'Offshore Holiday' ? 'selected' : ''}>Offshore Holiday</option>
-          <option value="Sick Leave"       ${day.holidayLabel === 'Sick Leave' ? 'selected' : ''}>Sick Leave</option>
-          <option value="Planned Leave"    ${day.holidayLabel === 'Planned Leave' ? 'selected' : ''}>Planned Leave</option>
         </select>
       </div>
       <div class="entries-list" id="entries-${dayIdx}" ${day.isHoliday ? 'style="opacity:0.4;pointer-events:none"' : ''}>
@@ -255,16 +253,28 @@ export function buildDayCard(day, dayIdx) {
 
     const cb = wrap.querySelector(`#holiday-${dayIdx}`);
     const lbl = wrap.querySelector(`#holiday-label-${dayIdx}`);
+
+    // Populate leave type select dynamically
+    populateLeaveSelect(lbl, resolveLeaveTypeId(day));
+
     cb.addEventListener('change', () => {
         state.days[dayIdx].isHoliday = cb.checked;
         lbl.style.display = cb.checked ? 'block' : 'none';
-        if (!cb.checked) state.days[dayIdx].holidayLabel = 'Offshore Holiday';
+        if (!cb.checked) {
+            state.days[dayIdx].leaveTypeId = '';
+        } else {
+            state.days[dayIdx].leaveTypeId = resolveLeaveTypeId(state.days[dayIdx]);
+        }
         rerenderDayCard(dayIdx);
         updateSummary();
         saveState();
     });
     lbl.addEventListener('change', () => {
-        state.days[dayIdx].holidayLabel = lbl.value;
+        state.days[dayIdx].leaveTypeId = lbl.value;
+        // Keep holidayLabel in sync for backward compat fallback
+        const leaveType = state.leaveTypes?.find(t => t.id === lbl.value);
+        if (leaveType) state.days[dayIdx].holidayLabel = leaveType.label;
+        rerenderDayCard(dayIdx);
         updateSummary();
         saveState();
     });

--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -5,6 +5,7 @@ import { getDateFromWeek } from './week.js';
 import { calcDayTotalMins } from './summary.js';
 import { minsToHHMM } from './utils.js';
 import { getTypeById } from './ticket-types.js';
+import { getLeaveLabel } from './leave-types.js';
 // Circular — resolved at call time
 import { buildGroups } from './render.js';
 
@@ -29,7 +30,7 @@ export function generateTxt() {
 
         if (day.isHoliday) {
             lines.push(`${displayDate} :   `);
-            lines.push(`\ti)\t${day.holidayLabel || 'Offshore Holiday'}`);
+            lines.push(`\ti)\t${getLeaveLabel(day)}`);
             lines.push('');
         } else {
             const totalMins = calcDayTotalMins(day);

--- a/src/renderer/modules/scheduled.js
+++ b/src/renderer/modules/scheduled.js
@@ -186,7 +186,7 @@ function saveScheduledTask() {
     if (!state.allDaysByDate[scheduledDate]) {
         state.allDaysByDate[scheduledDate] = {
             date: scheduledDate, isHoliday: false,
-            holidayLabel: 'Offshore Holiday', expanded: false, entries: []
+            leaveTypeId: '', holidayLabel: 'Offshore Holiday', expanded: false, entries: []
         };
     }
     state.allDaysByDate[scheduledDate].entries.push({ ticket: tkt, hh, mm, type, desc, isScheduled: true });

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -10,6 +10,7 @@ import { renderDays } from './render.js';
 import { escHtml } from './utils.js';
 import { applyTheme } from './theme.js';
 import { renderTicketTypesSection } from './ticket-types.js';
+import { renderLeaveTypesSection } from './leave-types.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -308,16 +309,7 @@ function renderTicketTypes(el) {
 }
 
 function renderLeaveTypes(el) {
-    el.innerHTML = `
-        <div class="settings-section-header">
-            <button class="settings-back-btn"><i class="bi bi-arrow-left"></i> Management</button>
-            <h2 class="settings-section-title">Leave Types</h2>
-            <p class="settings-section-desc">Configure leave and holiday categories for marking days.</p>
-        </div>
-        <div class="settings-section-body">
-            <p class="settings-placeholder">Leave Types — coming soon.</p>
-        </div>`;
-    el.querySelector('.settings-back-btn').addEventListener('click', () => navigateTo('management'));
+    renderLeaveTypesSection(el, navigateTo);
 }
 
 function renderDeveloper(el) {

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -9,6 +9,12 @@ export const RECURRING_DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 export const DAY_IDX_TO_NAME = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri' };
 export const SEARCH_PAGE_SIZE = 10;
 
+export const DEFAULT_LEAVE_TYPES = [
+    { id: 'offshore-holiday', label: 'Offshore Holiday', paid: false },
+    { id: 'sick-leave',       label: 'Sick Leave',       paid: false },
+    { id: 'planned-leave',    label: 'Planned Leave',    paid: true  },
+];
+
 export const DEFAULT_TICKET_TYPES = [
     { id: 'jira',        label: 'Jira',         color: '#c8c8c8', hasPrefix: false, prefixText: '' },
     { id: 'servicedesk', label: 'Service Desk',  color: '#fbbf24', hasPrefix: true,  prefixText: '(Service desk) ' },
@@ -24,4 +30,5 @@ export const state = {
     recurringTasks: [],
     dailyTargetMins: 480,
     ticketTypes: [],
+    leaveTypes: [],
 };

--- a/src/renderer/modules/store.js
+++ b/src/renderer/modules/store.js
@@ -1,4 +1,4 @@
-import { state, LS_KEY, DEFAULT_TICKET_TYPES } from './state.js';
+import { state, LS_KEY, DEFAULT_TICKET_TYPES, DEFAULT_LEAVE_TYPES } from './state.js';
 
 export async function saveState() {
     try {
@@ -15,6 +15,7 @@ export async function saveState() {
             recurringTasks: state.recurringTasks,
             dailyTargetMins: state.dailyTargetMins,
             ticketTypes: state.ticketTypes,
+            leaveTypes: state.leaveTypes,
         };
         await window.electronStore.set(LS_KEY, toSave);
     } catch (e) { console.warn('Could not save state', e); }
@@ -36,6 +37,7 @@ export async function loadState() {
         const saved = await window.electronStore.get(LS_KEY);
         if (!saved) {
             state.ticketTypes = [...DEFAULT_TICKET_TYPES];
+            state.leaveTypes  = [...DEFAULT_LEAVE_TYPES];
             return false;
         }
 
@@ -49,6 +51,9 @@ export async function loadState() {
         state.ticketTypes = saved.ticketTypes && saved.ticketTypes.length > 0
             ? saved.ticketTypes
             : [...DEFAULT_TICKET_TYPES];
+        state.leaveTypes = saved.leaveTypes && saved.leaveTypes.length > 0
+            ? saved.leaveTypes
+            : [...DEFAULT_LEAVE_TYPES];
 
         if (saved.days && Array.isArray(saved.days)) {
             saved.days.forEach(d => {

--- a/src/renderer/modules/week.js
+++ b/src/renderer/modules/week.js
@@ -48,6 +48,7 @@ export function buildWeekDays(monDt) {
             const newDay = {
                 date: dStr,
                 isHoliday: false,
+                leaveTypeId: '',
                 holidayLabel: 'Offshore Holiday',
                 expanded: false,
                 entries: []


### PR DESCRIPTION
## Summary
- Replaces hardcoded Offshore Holiday / Sick Leave / Planned Leave select with a user-configurable leave type system
- New `leave-types.js` module with CRUD UI in Settings → Management → Leave Types
- Backward compatible: days with only `holidayLabel` fall back gracefully via `getLeaveLabel(day)`

## What's new
- **Leave Types settings UI** — add, edit, delete types with label and paid/unpaid indicator
- **Dynamic day card select** — holiday/leave dropdown populated from configured types
- **Report output** — uses resolved label from `leaveTypeId → leaveTypes[]` with fallback to `holidayLabel`
- **Delete protection** — confirms when type is in use, warns entries will fall back to saved label

## Test plan
- [ ] Settings → Management → Leave Types shows 3 defaults: Offshore Holiday, Sick Leave, Planned Leave
- [ ] Mark a day as Holiday/Leave — dropdown shows configured types
- [ ] Add a custom leave type — appears in the day card dropdown immediately
- [ ] Edit a leave type — badge on day card updates immediately
- [ ] Delete an in-use type — confirmation warning shown; day falls back to holidayLabel
- [ ] Built-in types have delete button disabled
- [ ] Report TXT output shows correct leave label

🤖 Generated with [Claude Code](https://claude.com/claude-code)