### PR TITLE
feat(tm-78): settings Developer — error logging

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -16,6 +16,7 @@ import { initCopyTo } from './modules/copy-to.js';
 import { initReport } from './modules/report.js';
 import { bindHeaderEvents } from './modules/header.js';
 import { initSettings, updateSheetDetailsDisplay } from './modules/settings.js';
+import { loadErrorLog } from './modules/error-log.js';
 import { renderAll } from './modules/render.js';
 import { state } from './modules/state.js';
 import { getWeekStrFromDate, getDateFromWeek, buildWeekDays, enforceExpandedState, updateWeekDisplay } from './modules/week.js';
@@ -38,6 +39,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     bindHeaderEvents();
 
     const restored = await loadState();
+    await loadErrorLog();
 
     updateSheetDetailsDisplay();
 

--- a/src/renderer/modules/error-log.js
+++ b/src/renderer/modules/error-log.js
@@ -1,0 +1,143 @@
+/* =============================================================
+   ERROR LOG — persistent error capture, pruning, settings UI
+   ============================================================= */
+
+import { state } from './state.js';
+import { escHtml } from './utils.js';
+import { showToast } from './toast.js';
+
+const ERRORLOG_KEY = 'errorLog_v1';
+const MAX_ENTRIES  = 500;
+
+/* ── PERSISTENCE ────────────────────────────────────────────── */
+
+export async function loadErrorLog() {
+    try {
+        const saved = await window.electronStore.get(ERRORLOG_KEY);
+        if (saved) {
+            state.errorLog             = saved.logs || [];
+            state.errorLogRetentionDays = saved.retentionDays || 30;
+        }
+        _prune();
+    } catch (e) { /* silent — don't log errors about the error log */ }
+}
+
+async function _saveErrorLog() {
+    try {
+        await window.electronStore.set(ERRORLOG_KEY, {
+            logs: state.errorLog,
+            retentionDays: state.errorLogRetentionDays,
+        });
+    } catch (e) { /* silent */ }
+}
+
+function _prune() {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - (state.errorLogRetentionDays || 30));
+    state.errorLog = (state.errorLog || []).filter(e => new Date(e.timestamp) >= cutoff);
+    if (state.errorLog.length > MAX_ENTRIES) state.errorLog = state.errorLog.slice(-MAX_ENTRIES);
+}
+
+/* ── PUBLIC HELPER ──────────────────────────────────────────── */
+
+export function logError(context, error) {
+    const entry = {
+        timestamp: new Date().toISOString(),
+        context:   context || 'unknown',
+        message:   error?.message || String(error),
+        stack:     error?.stack   || '',
+    };
+    if (!Array.isArray(state.errorLog)) state.errorLog = [];
+    state.errorLog.push(entry);
+    if (state.errorLog.length > MAX_ENTRIES) state.errorLog = state.errorLog.slice(-MAX_ENTRIES);
+    _saveErrorLog();
+}
+
+/* ── SETTINGS SECTION RENDERER ──────────────────────────────── */
+
+export function renderErrorLogSection(el, navigate) {
+    _render(el, navigate);
+}
+
+function _render(el, navigate) {
+    const logs = state.errorLog || [];
+    const retention = state.errorLogRetentionDays || 30;
+    const retentionOptions = [7, 14, 30, 60, 90]
+        .map(d => `<option value="${d}"${d === retention ? ' selected' : ''}>${d} days</option>`)
+        .join('');
+
+    const logsHtml = logs.length === 0
+        ? '<p class="settings-placeholder">No errors logged.</p>'
+        : [...logs].reverse().map(e => `
+            <div class="el-row">
+                <div class="el-meta">
+                    <span class="el-timestamp">${escHtml(_fmtTs(e.timestamp))}</span>
+                    <span class="el-context-badge">${escHtml(e.context)}</span>
+                </div>
+                <div class="el-message">${escHtml(e.message)}</div>
+                ${e.stack ? `<div class="el-stack">${escHtml(e.stack)}</div>` : ''}
+            </div>`).join('');
+
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <button class="settings-back-btn"><i class="bi bi-arrow-left"></i> Developer</button>
+            <h2 class="settings-section-title">Error Logs</h2>
+            <p class="settings-section-desc">Application errors captured at runtime. Logs are pruned automatically.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="el-toolbar">
+                <div class="d-flex align-items-center gap-2">
+                    <label class="label-text mb-0">Retention</label>
+                    <select id="el-retention" class="form-select dark-input" style="width:auto">${retentionOptions}</select>
+                </div>
+                <div class="d-flex gap-2">
+                    <button class="btn btn-sm btn-outline-light" id="el-copy-btn" ${logs.length === 0 ? 'disabled' : ''}>
+                        <i class="bi bi-clipboard me-1"></i>Copy All
+                    </button>
+                    <button class="btn btn-sm btn-outline-danger" id="el-clear-btn" ${logs.length === 0 ? 'disabled' : ''}>
+                        <i class="bi bi-trash me-1"></i>Clear All
+                    </button>
+                </div>
+            </div>
+            <div class="el-list">${logsHtml}</div>
+        </div>`;
+
+    el.querySelector('.settings-back-btn')
+        .addEventListener('click', () => navigate('developer'));
+
+    el.querySelector('#el-retention').addEventListener('change', e => {
+        state.errorLogRetentionDays = parseInt(e.target.value);
+        _prune();
+        _saveErrorLog();
+        _render(el, navigate);
+    });
+
+    const clearBtn = el.querySelector('#el-clear-btn');
+    if (clearBtn && !clearBtn.disabled) {
+        clearBtn.addEventListener('click', () => {
+            state.errorLog = [];
+            _saveErrorLog();
+            showToast('Error log cleared.', 'success');
+            _render(el, navigate);
+        });
+    }
+
+    const copyBtn = el.querySelector('#el-copy-btn');
+    if (copyBtn && !copyBtn.disabled) {
+        copyBtn.addEventListener('click', () => {
+            const text = (state.errorLog || []).map(e =>
+                `[${e.timestamp}] [${e.context}] ${e.message}${e.stack ? '\n' + e.stack : ''}`
+            ).join('\n\n');
+            navigator.clipboard.writeText(text)
+                .then(() => showToast('Copied to clipboard.', 'success'))
+                .catch(() => showToast('Copy failed.', 'danger'));
+        });
+    }
+}
+
+function _fmtTs(iso) {
+    try {
+        const d = new Date(iso);
+        return d.toLocaleString('en-GB', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    } catch { return iso; }
+}

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -11,6 +11,7 @@ import { escHtml } from './utils.js';
 import { applyTheme } from './theme.js';
 import { renderTicketTypesSection } from './ticket-types.js';
 import { renderLeaveTypesSection } from './leave-types.js';
+import { renderErrorLogSection } from './error-log.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -336,16 +337,7 @@ function renderDeveloper(el) {
 }
 
 function renderErrorLogs(el) {
-    el.innerHTML = `
-        <div class="settings-section-header">
-            <button class="settings-back-btn"><i class="bi bi-arrow-left"></i> Developer</button>
-            <h2 class="settings-section-title">Error Logs</h2>
-            <p class="settings-section-desc">Application error log for troubleshooting.</p>
-        </div>
-        <div class="settings-section-body">
-            <p class="settings-placeholder">Error Logs — coming soon.</p>
-        </div>`;
-    el.querySelector('.settings-back-btn').addEventListener('click', () => navigateTo('developer'));
+    renderErrorLogSection(el, navigateTo);
 }
 
 function renderAbout(el) {

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -7,6 +7,7 @@ import { toggleDay, renderAll } from './render.js';
 import { changeWeekBy } from './week.js';
 import { openPreview, openDayQuickView, doPrint } from './report.js';
 import { openSettings } from './settings.js';
+import { logError } from './error-log.js';
 
 /* ── SIDEBAR & ABOUT ────────────────────────────────────── */
 export function initSidebar() {
@@ -115,7 +116,8 @@ export function initUpdater() {
         );
     });
 
-    window.updater.onError(() => {
+    window.updater.onError((err) => {
+        logError('update', err || new Error('Updater error'));
         if (manualUpdateCheck) {
             showToast('Update check failed.', 'danger');
             manualUpdateCheck = false;

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -31,4 +31,6 @@ export const state = {
     dailyTargetMins: 480,
     ticketTypes: [],
     leaveTypes: [],
+    errorLog: [],
+    errorLogRetentionDays: 30,
 };

--- a/src/renderer/modules/store.js
+++ b/src/renderer/modules/store.js
@@ -1,4 +1,5 @@
 import { state, LS_KEY, DEFAULT_TICKET_TYPES, DEFAULT_LEAVE_TYPES } from './state.js';
+import { logError } from './error-log.js';
 
 export async function saveState() {
     try {
@@ -18,7 +19,7 @@ export async function saveState() {
             leaveTypes: state.leaveTypes,
         };
         await window.electronStore.set(LS_KEY, toSave);
-    } catch (e) { console.warn('Could not save state', e); }
+    } catch (e) { console.warn('Could not save state', e); logError('store/save', e); }
 }
 
 export async function loadState() {
@@ -61,5 +62,5 @@ export async function loadState() {
             });
         }
         return true;
-    } catch (e) { return false; }
+    } catch (e) { logError('store/load', e); return false; }
 }

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -421,3 +421,74 @@
   background: var(--bg-input);
   cursor: pointer;
 }
+
+/* ── ERROR LOGS ── */
+
+.el-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.el-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.el-row {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+}
+
+.el-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.el-timestamp {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.el-context-badge {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--info, #818cf8);
+  background: rgba(129, 140, 248, 0.1);
+  border: 1px solid rgba(129, 140, 248, 0.2);
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.el-message {
+  font-size: 0.83rem;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.el-stack {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  margin-top: 6px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 120px;
+  overflow-y: auto;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+}


### PR DESCRIPTION
## Summary
- Adds persistent error logging accessible via Settings → Developer → Error Logs
- New `error-log.js` module with `logError(context, error)` helper, pruning, and settings UI
- Errors stored in a separate electron-store key (`errorLog_v1`) independent of main state

## What's new
- **Error Logs UI** — scrollable list showing timestamp, context badge, and message per entry
- **Retention control** — configurable 7/14/30/60/90 days (default 30), hard cap at 500 entries
- **Copy All** — copies full log as plain text to clipboard
- **Clear All** — wipes the log immediately
- **logError() integrated** in `store.js` save/load catch blocks and updater error handler

## Test plan
- [ ] Settings → Developer → Error Logs shows "No errors logged." on clean install
- [ ] Changing retention dropdown prunes old entries and saves
- [ ] Clear All empties the list and disables buttons
- [ ] Copy All copies log text to clipboard
- [ ] Errors from store/save or store/load appear in the log after a fault

🤖 Generated with [Claude Code](https://claude.com/claude-code)