### PR TITLE
feat(tm-79): settings About — app info, changelog from GitHub Releases

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -603,10 +603,6 @@
           <i class="bi bi-cloud-arrow-down me-3"></i>
           <span>Check for Updates</span>
         </a>
-        <a href="#" class="sidebar-menu-item" id="menu-about">
-          <i class="bi bi-info-circle me-3"></i>
-          <span>About Timesheet Manager</span>
-        </a>
         <a href="#" class="sidebar-menu-item" id="menu-recurring">
           <i class="bi bi-arrow-repeat me-3"></i>
           <span>Recurring Tasks</span>
@@ -621,36 +617,6 @@
         <div class="d-flex align-items-center gap-2 text-muted-v" style="font-size: 0.8rem;">
           <i class="bi bi-cpu"></i>
           <span>v<span class="app-version"></span> — Desktop App</span>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- ABOUT MODAL -->
-  <div class="modal fade" id="aboutModal" tabindex="-1" aria-labelledby="aboutModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content modal-dark text-center">
-        <div class="modal-body p-5">
-          <div class="mb-4">
-            <img src="favicon.png" alt="App Logo" style="width: 80px; height: 80px; border-radius: 20px; box-shadow: 0 10px 30px rgba(0,0,0,0.5);">
-          </div>
-          <h3 class="mb-1">Timesheet Manager</h3>
-          <p class="text-accent mb-2">v<span class="app-version"></span></p>
-          <p class="text-muted-v mb-4" style="font-size: 0.9rem;">Developed by <span class="text-white fw-bold">Veera Bharath</span></p>
-          <div class="text-start mb-4">
-            <p class="text-muted mb-2">Developed for seamless Jira & Service Desk time tracking.</p>
-            <ul class="list-unstyled text-muted" style="font-size: 0.9rem;">
-              <li><i class="bi bi-check2-circle text-success me-2"></i> Weekly group-based reordering</li>
-              <li><i class="bi bi-check2-circle text-success me-2"></i> Instant TXT export / Print</li>
-              <li><i class="bi bi-check2-circle text-success me-2"></i> Dark Mode / Light Mode support</li>
-            </ul>
-          </div>
-          <div class="d-flex flex-column gap-2 align-items-center">
-            <a href="https://github.com/veera-bharath/Timesheet-Manager" target="_blank" class="btn btn-outline-light px-4 w-100 mb-2">
-              <i class="bi bi-github me-2"></i> View on GitHub
-            </a>
-            <button type="button" class="btn btn-gradient px-5" data-bs-dismiss="modal">Close</button>
-          </div>
         </div>
       </div>
     </div>

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -15,7 +15,7 @@ import { initEntryModal } from './modules/entry-modal.js';
 import { initCopyTo } from './modules/copy-to.js';
 import { initReport } from './modules/report.js';
 import { bindHeaderEvents } from './modules/header.js';
-import { initSettings, updateSheetDetailsDisplay } from './modules/settings.js';
+import { initSettings, updateSheetDetailsDisplay, loadChangelog } from './modules/settings.js';
 import { loadErrorLog } from './modules/error-log.js';
 import { renderAll } from './modules/render.js';
 import { state } from './modules/state.js';
@@ -40,6 +40,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const restored = await loadState();
     await loadErrorLog();
+    await loadChangelog();
 
     updateSheetDetailsDisplay();
 

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -2,7 +2,7 @@
    SETTINGS — full-screen modal shell, nav routing, dirty state
    ============================================================= */
 
-import { state } from './state.js';
+import { state, APP_VERSION } from './state.js';
 import { saveState } from './store.js';
 import { showToast } from './toast.js';
 import { updateSummary } from './summary.js';
@@ -30,6 +30,45 @@ let currentSection = 'general';
 let dirtySection   = null;
 let _pendingTarget = null;   // section key or '__close__'
 let settingsModalInst = null;
+
+/* ── CHANGELOG ──────────────────────────────────────────── */
+const CHANGELOG_KEY = 'changelog_v1';
+
+export async function loadChangelog() {
+    try {
+        const saved = await window.electronStore.get(CHANGELOG_KEY);
+        // Discard the old bogus seed (single "Initial release." entry)
+        const isBogus = Array.isArray(saved) && saved.length === 1 && saved[0]?.notes === 'Initial release.';
+        if (saved && Array.isArray(saved) && saved.length > 0 && !isBogus) {
+            state.changelog = saved;
+        }
+    } catch (e) { /* silent */ }
+    // Refresh from GitHub in background (non-blocking)
+    _refreshChangelogFromGitHub().catch(() => {});
+}
+
+async function _refreshChangelogFromGitHub() {
+    try {
+        const res = await fetch('https://api.github.com/repos/veera-bharath/Timesheet-Manager/releases');
+        if (!res.ok) return;
+        const releases = await res.json();
+        if (!Array.isArray(releases) || releases.length === 0) return;
+        state.changelog = releases.map(r => ({
+            version: r.tag_name.replace(/^v/, ''),
+            date: r.published_at ? r.published_at.slice(0, 10) : '',
+            notes: r.body || '',
+        }));
+        await window.electronStore.set(CHANGELOG_KEY, state.changelog);
+    } catch (e) { /* offline or API error — silently keep existing data */ }
+}
+
+export async function addChangelogEntry(version, notes, date) {
+    if (!Array.isArray(state.changelog)) state.changelog = [];
+    // Avoid duplicate versions
+    if (state.changelog.some(e => e.version === version)) return;
+    state.changelog.unshift({ version, date: date || new Date().toISOString().slice(0, 10), notes: notes || '' });
+    try { await window.electronStore.set(CHANGELOG_KEY, state.changelog); } catch (e) { /* silent */ }
+}
 
 /* ── INIT ───────────────────────────────────────────────── */
 export function initSettings() {
@@ -340,15 +379,99 @@ function renderErrorLogs(el) {
     renderErrorLogSection(el, navigateTo);
 }
 
+function _renderMarkdown(md) {
+    if (!md) return '';
+    let h = escHtml(md);
+    // Headings
+    h = h.replace(/^### (.+)$/gm, '<p class="cl-md-h3">$1</p>');
+    h = h.replace(/^## (.+)$/gm,  '<p class="cl-md-h2">$1</p>');
+    h = h.replace(/^# (.+)$/gm,   '<p class="cl-md-h1">$1</p>');
+    // Bold + italic
+    h = h.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
+    h = h.replace(/\*\*(.+?)\*\*/g,     '<strong>$1</strong>');
+    h = h.replace(/\*(.+?)\*/g,         '<em>$1</em>');
+    // Inline code
+    h = h.replace(/`([^`]+)`/g, '<code class="cl-md-code">$1</code>');
+    // List items
+    h = h.replace(/^[-*+] (.+)$/gm, '<div class="cl-md-li">$1</div>');
+    // Links (escHtml turns & → &amp; in URLs, which is valid in href)
+    h = h.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    // Strip newlines immediately adjacent to block elements (headings, list items)
+    h = h.replace(/\n*(<(?:p class="cl-md-h\d"|div class="cl-md-li")[^>]*>)/g, '$1');
+    h = h.replace(/(<\/(?:p|div)>)\n*/g, '$1');
+    // Remaining blank lines → single line break, single newlines → <br>
+    h = h.replace(/\n{2,}/g, '<br>').replace(/\n/g, '<br>');
+    // Collapse consecutive <br> tags
+    h = h.replace(/(<br>\s*){2,}/g, '<br>');
+    return h;
+}
+
 function renderAbout(el) {
+    const allChangelog = state.changelog || [];
+    const changelog = allChangelog.slice(0, 10);
+
+    const changelogHtml = changelog.length === 0
+        ? '<p class="settings-placeholder">No changelog entries yet.</p>'
+        : changelog.map((entry, i) => `
+            <div class="cl-entry ${i === 0 ? 'open' : ''}">
+                <button class="cl-header">
+                    <span class="cl-version">v${escHtml(entry.version)}</span>
+                    ${entry.date ? `<span class="cl-date">${escHtml(entry.date)}</span>` : ''}
+                    <i class="bi bi-chevron-down cl-chevron ms-auto"></i>
+                </button>
+                <div class="cl-body">
+                    <div class="cl-notes">${_renderMarkdown(entry.notes || '')}</div>
+                </div>
+            </div>`).join('');
+
     el.innerHTML = `
         <div class="settings-section-header">
             <h2 class="settings-section-title">About</h2>
             <p class="settings-section-desc">App information and release history.</p>
         </div>
         <div class="settings-section-body">
-            <p class="settings-placeholder">About & Changelog — coming soon.</p>
+            <div class="about-app-card">
+                <img src="${document.querySelector('link[rel=\'icon\']')?.href || 'favicon.png'}" alt="App Logo" class="about-logo">
+                <div>
+                    <div class="about-app-name">Timesheet Manager</div>
+                    <div class="about-version">v${escHtml(APP_VERSION)}</div>
+                    <div class="about-built-with">Developed by <strong>Veera Bharath</strong></div>
+                    <div class="about-built-with">Built with Electron + Vite</div>
+                </div>
+            </div>
+            <div class="d-flex gap-2 mt-3 mb-4">
+                <a href="https://github.com/veera-bharath/Timesheet-Manager" target="_blank"
+                   class="btn btn-outline-light btn-sm">
+                    <i class="bi bi-github me-1"></i> GitHub
+                </a>
+                <a href="https://github.com/veera-bharath/Timesheet-Manager/issues/new" target="_blank"
+                   class="btn btn-outline-light btn-sm">
+                    <i class="bi bi-bug me-1"></i> Report a Bug
+                </a>
+            </div>
+            <h3 class="settings-subsection-title">Changelog</h3>
+            <div class="cl-list">${changelogHtml}</div>
+            ${allChangelog.length > 10 ? `
+            <div class="mt-3">
+                <a href="https://github.com/veera-bharath/Timesheet-Manager/releases" target="_blank"
+                   class="btn btn-outline-light btn-sm">
+                    <i class="bi bi-box-arrow-up-right me-1"></i> View all ${allChangelog.length} releases on GitHub
+                </a>
+            </div>` : ''}
         </div>`;
+
+    el.querySelectorAll('.cl-header').forEach(btn => {
+        btn.addEventListener('click', () => {
+            btn.closest('.cl-entry').classList.toggle('open');
+        });
+    });
+
+    // If we have no changelog yet, fetch now and re-render when done
+    if (changelog.length === 0) {
+        _refreshChangelogFromGitHub().then(() => {
+            if (state.changelog.length > 0) renderAbout(el);
+        }).catch(() => {});
+    }
 }
 
 /* ── CLOSE / UNSAVED OVERLAY ────────────────────────────── */

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -6,14 +6,12 @@ import { saveEntry, openEntryModal } from './entry-modal.js';
 import { toggleDay, renderAll } from './render.js';
 import { changeWeekBy } from './week.js';
 import { openPreview, openDayQuickView, doPrint } from './report.js';
-import { openSettings } from './settings.js';
+import { openSettings, addChangelogEntry } from './settings.js';
 import { logError } from './error-log.js';
 
 /* ── SIDEBAR & ABOUT ────────────────────────────────────── */
 export function initSidebar() {
     const sidebarEl = document.getElementById('appSidebar');
-    const aboutBtn = document.getElementById('menu-about');
-    const aboutModalEl = document.getElementById('aboutModal');
 
     const closeSidebar = () => {
         const oc = bootstrap.Offcanvas.getInstance(sidebarEl);
@@ -29,14 +27,6 @@ export function initSidebar() {
         });
     }
 
-    if (aboutBtn && sidebarEl && aboutModalEl) {
-        const aboutModal = new bootstrap.Modal(aboutModalEl);
-        aboutBtn.addEventListener('click', (e) => {
-            e.preventDefault();
-            closeSidebar();
-            aboutModal.show();
-        });
-    }
 
     const starredBtn = document.getElementById('menu-starred');
     if (starredBtn) {
@@ -109,6 +99,7 @@ export function initUpdater() {
             document.getElementById(downloadToastId)?.remove();
             downloadToastId = null;
         }
+        addChangelogEntry(info.version, info.releaseNotes || '');
         showUpdateToast(
             `v${info.version} ready to install.`,
             'Restart & Install',

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -33,4 +33,5 @@ export const state = {
     leaveTypes: [],
     errorLog: [],
     errorLogRetentionDays: 30,
+    changelog: [],
 };

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -492,3 +492,165 @@
   border-radius: var(--radius-sm);
   padding: 6px 8px;
 }
+
+/* ── ABOUT ── */
+
+.about-app-card {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 20px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.about-logo {
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.4);
+  flex-shrink: 0;
+}
+
+.about-app-name {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.about-version {
+  font-size: 0.85rem;
+  color: var(--accent);
+  font-family: 'JetBrains Mono', monospace;
+  margin: 2px 0;
+}
+
+.about-built-with {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.settings-subsection-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 12px;
+}
+
+/* ── CHANGELOG ── */
+
+.cl-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cl-entry {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-card);
+}
+
+.cl-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.cl-header:hover {
+  background: var(--bg-hover);
+}
+
+.cl-version {
+  font-size: 0.9rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--accent);
+}
+
+.cl-date {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.cl-chevron {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  transition: transform 0.2s;
+}
+
+.cl-entry.open .cl-chevron {
+  transform: rotate(180deg);
+}
+
+.cl-body {
+  display: none;
+  padding: 0 14px 12px;
+  border-top: 1px solid var(--border);
+}
+
+.cl-entry.open .cl-body {
+  display: block;
+}
+
+.cl-notes {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 10px 0 0;
+  word-break: break-word;
+}
+
+.cl-notes .cl-md-h1,
+.cl-notes .cl-md-h2,
+.cl-notes .cl-md-h3 {
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 10px 0 4px;
+}
+
+.cl-notes .cl-md-h1 { font-size: 0.95rem; }
+.cl-notes .cl-md-h2 { font-size: 0.88rem; }
+.cl-notes .cl-md-h3 { font-size: 0.83rem; }
+
+.cl-notes .cl-md-li {
+  padding-left: 14px;
+  position: relative;
+  margin: 2px 0;
+}
+
+.cl-notes .cl-md-li::before {
+  content: '•';
+  position: absolute;
+  left: 2px;
+  color: var(--accent);
+}
+
+.cl-notes .cl-md-code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8em;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+
+.cl-notes a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.cl-notes a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Adds **About** section under Settings with app card (icon, version, developer credit, tech stack)
- Fetches changelog from GitHub Releases API on load and caches in electron-store; refreshes automatically on each launch
- Renders up to 10 most recent releases as collapsible accordion entries with minimal Markdown support (headings, bold, italic, code, lists, links)
- Removes the old standalone About modal; changelog entry injection wired into the auto-updater `onUpdateDownloaded` handler
- Fixes excessive vertical gaps in changelog by stripping newlines around block-level elements before `<br>` conversion

## Test plan
- [ ] Open Settings → About — verify app icon, version, "Developed by Veera Bharath", and tech stack line appear
- [ ] Changelog entries load and collapse/expand correctly
- [ ] Markdown formatting (headings, lists, code, links) renders in changelog body
- [ ] "View all N releases on GitHub ↗" link appears when there are more than 10 releases
- [ ] No old About modal or sidebar "About" menu item remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)