### PR TITLE
feat(tm-80): show group total time with right-side bracket indicator

### DIFF
--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -133,9 +133,13 @@ export function buildEntriesHTML(entries, dayIdx) {
 
     groups.forEach((group, gi) => {
         const roman = ROMAN[gi] + '.';
+        const isMulti = group.items.length > 1;
 
-        group.items.forEach((e, itemIdx) => {
-            let actualOriginalIndex = group.indices[itemIdx];
+        const groupTotalMins = group.items.reduce((sum, e) => sum + (e.hh || 0) * 60 + (e.mm || 0), 0);
+        const groupTotalStr = minsToHHMM(groupTotalMins);
+
+        const rowsHtml = group.items.map((e, itemIdx) => {
+            const actualOriginalIndex = group.indices[itemIdx];
             const isFirst = itemIdx === 0;
             const isLast = itemIdx === group.items.length - 1;
 
@@ -167,7 +171,7 @@ export function buildEntriesHTML(entries, dayIdx) {
             const starIcon  = e.starred ? 'bi-star-fill' : 'bi-star';
 
             const rowI = rowIndex++;
-            htmlFragments.push(`
+            return `
     <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
       <span class="drag-handle" title="Drag to reorder"><i class="bi bi-grip-vertical"></i></span>
       <span class="entry-num entry-num-roman">${rStr}</span>
@@ -180,8 +184,13 @@ export function buildEntriesHTML(entries, dayIdx) {
       <div class="ms-auto d-flex align-items-center gap-1">
         <button class="entry-btn-star ${starClass}" title="${e.starred ? 'Unstar' : 'Star'}"><i class="bi ${starIcon}"></i></button>
       </div>
-    </div>`);
-        });
+    </div>`;
+        }).join('');
+
+        htmlFragments.push(`<div class="entry-group${isMulti ? ' entry-group-multi' : ''}" data-group-idx="${gi}">
+  ${rowsHtml}
+  <div class="entry-group-total" title="${isMulti ? 'Group total' : 'Time'}">${groupTotalStr}</div>
+</div>`);
     });
 
     return htmlFragments.join('');
@@ -233,12 +242,12 @@ export function buildDayCard(day, dayIdx) {
           style="max-width:200px;display:${day.isHoliday ? 'block' : 'none'}">
         </select>
       </div>
-      <div class="entries-list" id="entries-${dayIdx}" ${day.isHoliday ? 'style="opacity:0.4;pointer-events:none"' : ''}>
+      <div class="entries-list${day.entries && day.entries.length > 0 ? ' has-entries' : ''}" id="entries-${dayIdx}" ${day.isHoliday ? 'style="opacity:0.4;pointer-events:none"' : ''}>
+        ${day.isHoliday ? '' : `<button class="add-entry-btn" data-day="${dayIdx}">
+          <i class="bi bi-plus-circle"></i> Add Entry
+        </button>`}
         ${buildEntriesHTML(day.entries, dayIdx)}
       </div>
-      ${day.isHoliday ? '' : `<button class="add-entry-btn" data-day="${dayIdx}">
-        <i class="bi bi-plus-circle"></i> Add Entry
-      </button>`}
     </div>
   `;
 

--- a/src/renderer/styles/entries.css
+++ b/src/renderer/styles/entries.css
@@ -6,17 +6,74 @@
   gap: 8px;
 }
 
+.entries-list.has-entries {
+  padding-right: 52px;
+}
+
+/* ── GROUP WRAPPER ── */
+
+.entry-group {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.entry-group-total {
+  position: absolute;
+  top: 0;
+  right: -52px;
+  bottom: 0;
+  width: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 4px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--accent-light);
+}
+
+.entry-group-total::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 25%;
+  bottom: 25%;
+  width: 2px;
+  background: var(--accent-light);
+  border-radius: 1px;
+  opacity: 0.25;
+}
+
+.entry-group-multi .entry-group-total::before {
+  top: 8px;
+  bottom: 8px;
+  opacity: 0.4;
+  background: linear-gradient(to bottom, transparent, var(--accent-light) 20%, var(--accent-light) 80%, transparent);
+}
+
 .entry-row {
   display: flex;
   align-items: center;
   gap: 10px;
   background: var(--bg-input);
   border: 1px solid var(--border);
+  border-left-width: 3px;
   border-radius: var(--radius-sm);
   padding: 10px 14px;
   transition: all 0.18s;
   cursor: pointer;
   position: relative;
+}
+
+.entry-row[data-group-type="ticket_group"] {
+  border-left-color: rgba(99, 102, 241, 0.55);
+}
+
+.entry-row[data-group-type="desc_group"] {
+  border-left-color: rgba(251, 146, 60, 0.65);
 }
 
 /* ── DRAG HANDLE ── */
@@ -170,7 +227,7 @@
   gap: 8px;
   width: 100%;
   padding: 10px 14px;
-  margin-top: 8px;
+  margin-bottom: 8px;
   background: none;
   border: 1px dashed rgba(160, 160, 160, 0.2);
   border-radius: var(--radius-sm);


### PR DESCRIPTION
Closes #87

## Summary
- Each entry group is wrapped in a container with a right-side time indicator
- Single rows show their own time; multi-entry groups show the combined total
- A vertical bracket line spans grouped rows; a short tick appears for single rows
- Ticket groups have an indigo left border; description groups have an amber left border
- Add Entry button moved to the top of the entries list
- Right gutter (52px) only applied when entries exist — empty days show full-width Add Entry button

## Test plan
- [ ] Single rows show own time on the right with a short tick
- [ ] Ticket groups show indigo left border + group total on the right with bracket line
- [ ] Description groups show amber left border + group total on the right with bracket line
- [ ] Empty days show full-width Add Entry button with no gap
- [ ] Add Entry button sits at the top on days with entries
- [ ] Drag-and-drop still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)