### PR TITLE
feat(tm-90): first-run onboarding popup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,47 @@ All data stored via **electron-store** (not localStorage). The central `state` o
 ## Git Workflow
 
 Follows Gitflow. Feature branches use the pattern `feature/tm-<ticket-number>-<description>`. PRs merge into `develop`; releases merge into `main` and are tagged (e.g., `v1.4.0`).
+
+### Branch Lifecycle Rules
+
+Follow these steps **in order** when working on any issue:
+
+1. **Sync develop first** — always pull the latest `develop` before creating a branch:
+   ```bash
+   git checkout develop && git pull origin develop
+   ```
+
+2. **Move issue to In Progress** — before creating the branch, move the GitHub issue to "In Progress" status:
+   ```bash
+   gh issue edit <number> --add-label "in progress"
+   # or use project board field if applicable
+   ```
+
+3. **Create the feature branch** from the updated `develop`:
+   ```bash
+   git checkout -b feature/tm-<issue-number>-<short-description>
+   ```
+
+4. **Do NOT commit after finishing the code** — wait for the developer to test the changes. Only proceed to step 5 after the developer explicitly confirms the changes work.
+
+5. **After developer confirms** — commit the changes and open a PR targeting `develop`:
+   ```bash
+   gh pr create --base develop --title "feat(tm-<number>): ..." --body "..."
+   ```
+   Then move the GitHub issue to "In Review" status.
+
+6. **PR review & merge** — after the PR is created, ask the developer: *"Ready to review and merge?"*. Only if they confirm:
+   - Review the code changes in the PR
+   - Merge the PR into `develop`
+   - Close the GitHub issue
+   ```bash
+   gh pr merge <pr-number> --squash
+   gh issue close <number>
+   ```
+
+### Rules Summary
+
+- Never create a branch without pulling `develop` first.
+- Never commit without developer confirmation that the feature works.
+- Never merge a PR without explicitly asking the developer for approval.
+- Always close the GitHub issue after a successful merge.

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -622,6 +622,52 @@
     </div>
   </div>
 
+  <!-- ONBOARDING MODAL -->
+  <div class="modal fade" id="onboardingModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" style="max-width: 480px;">
+      <div class="modal-content modal-dark">
+        <div class="modal-body p-4 p-md-5">
+
+          <!-- Logo + heading -->
+          <div class="text-center mb-4">
+            <img src="favicon.png" alt="App Icon" style="width:56px;height:56px;border-radius:14px;" class="mb-3" />
+            <h4 class="fw-semibold mb-1">Welcome to Timesheet Manager</h4>
+            <p class="text-muted" style="font-size:0.9rem;">Let's set up your profile before you start.</p>
+          </div>
+
+          <!-- Name -->
+          <div class="mb-3">
+            <label class="form-label label-text" for="onb-name">Your Name <span class="text-danger">*</span></label>
+            <input type="text" id="onb-name" class="form-control dark-input" placeholder="e.g. John Smith" autocomplete="off" />
+            <div class="form-text text-muted">Used in the timesheet report header.</div>
+          </div>
+
+          <!-- Report Title -->
+          <div class="mb-3">
+            <label class="form-label label-text" for="onb-report-title">Report Title</label>
+            <input type="text" id="onb-report-title" class="form-control dark-input" placeholder="Booked hours in Jira and Service Desk" />
+          </div>
+
+          <!-- Daily Target -->
+          <div class="mb-4">
+            <label class="form-label label-text">Daily Target</label>
+            <div class="d-flex align-items-center gap-2">
+              <input type="number" id="onb-target-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="08" style="max-width:64px" />
+              <span class="label-text">hrs</span>
+              <input type="number" id="onb-target-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" style="max-width:64px" />
+              <span class="label-text">min</span>
+            </div>
+          </div>
+
+          <button class="btn btn-gradient w-100 btn-ripple" id="btn-onb-submit" disabled>
+            <i class="bi bi-check-circle me-2"></i>Get Started
+          </button>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- SETTINGS MODAL -->
   <div class="modal fade" id="settingsModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-fullscreen">

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -21,12 +21,14 @@ import { renderAll } from './modules/render.js';
 import { state } from './modules/state.js';
 import { getWeekStrFromDate, getDateFromWeek, buildWeekDays, enforceExpandedState, updateWeekDisplay } from './modules/week.js';
 import { updateSummary } from './modules/summary.js';
+import { initOnboarding, needsOnboarding, showOnboarding } from './modules/onboarding.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
     initTheme();
     initRipple();
     initSettings();
+    initOnboarding();
     initSidebar();
     initUpdater();
     initContextMenu();
@@ -41,6 +43,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const restored = await loadState();
     await loadErrorLog();
     await loadChangelog();
+
+    if (needsOnboarding()) await showOnboarding();
 
     updateSheetDetailsDisplay();
 

--- a/src/renderer/modules/onboarding.js
+++ b/src/renderer/modules/onboarding.js
@@ -1,0 +1,67 @@
+/* =============================================================
+   ONBOARDING — first-run setup modal
+   ============================================================= */
+
+import { state } from './state.js';
+import { saveState } from './store.js';
+import { updateSheetDetailsDisplay } from './settings.js';
+
+let _modalInst = null;
+
+export function needsOnboarding() {
+    return !state.employeeName || state.employeeName.trim() === '';
+}
+
+export function initOnboarding() {
+    const nameInput  = document.getElementById('onb-name');
+    const submitBtn  = document.getElementById('btn-onb-submit');
+    const hhInput    = document.getElementById('onb-target-hh');
+    const mmInput    = document.getElementById('onb-target-mm');
+
+    nameInput.addEventListener('input', () => {
+        submitBtn.disabled = nameInput.value.trim() === '';
+    });
+
+    hhInput.addEventListener('input', function () {
+        if (this.value.length >= 2) mmInput.focus();
+    });
+
+    submitBtn.addEventListener('click', async () => {
+        const name = nameInput.value.trim();
+        if (!name) return;
+
+        const title = document.getElementById('onb-report-title').value.trim();
+        const hh    = parseInt(hhInput.value) || 8;
+        const mm    = parseInt(mmInput.value) || 0;
+        const mins  = hh * 60 + mm;
+
+        state.employeeName    = name;
+        state.reportTitle     = title || 'Booked hours in Jira and Service Desk';
+        state.dailyTargetMins = mins > 0 ? mins : 480;
+
+        await saveState();
+        updateSheetDetailsDisplay();
+
+        _modalInst.hide();
+    });
+}
+
+export function showOnboarding() {
+    return new Promise(resolve => {
+        const modalEl = document.getElementById('onboardingModal');
+
+        // Pre-fill defaults
+        document.getElementById('onb-report-title').value = state.reportTitle || 'Booked hours in Jira and Service Desk';
+        const tgt = state.dailyTargetMins || 480;
+        document.getElementById('onb-target-hh').value = Math.floor(tgt / 60);
+        document.getElementById('onb-target-mm').value = tgt % 60;
+        document.getElementById('onb-name').value = '';
+        document.getElementById('btn-onb-submit').disabled = true;
+
+        _modalInst = new bootstrap.Modal(modalEl, { backdrop: 'static', keyboard: false });
+
+        modalEl.addEventListener('hidden.bs.modal', () => resolve(), { once: true });
+
+        _modalInst.show();
+    });
+}


### PR DESCRIPTION
## Summary

- Adds a non-dismissible modal on first launch when no employee name is saved
- User sets **Name** (required), **Report Title**, and **Daily Target** before the app loads
- "Get Started" button is disabled until a name is entered
- Saves directly to state via `saveState()` and never shown again once completed
- Existing users (name already saved) are unaffected

## Changes

- `src/renderer/modules/onboarding.js` — new module (`needsOnboarding`, `initOnboarding`, `showOnboarding`)
- `src/renderer/index.html` — added `#onboardingModal`
- `src/renderer/main.js` — wired up onboarding after `loadState()`
- `CLAUDE.md` — added Git workflow branch lifecycle rules

## Test plan

- [ ] Clear store (rename `LS_KEY` temporarily) and launch — onboarding modal appears
- [ ] "Get Started" button disabled until name is typed
- [ ] Submitting saves name, report title and daily target to Sheet Details panel
- [ ] Relaunch — modal does not appear again
- [ ] Existing users (data already saved) — modal never shown

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)