### PR TITLE
feat(tm-91): no-ticket placeholder with persistent reminder banner

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -56,6 +56,14 @@
 
   <!-- MAIN CONTENT -->
   <main class="container-fluid px-4 py-4">
+
+    <!-- NO-TICKET REMINDER BANNER -->
+    <div id="no-ticket-banner" class="no-ticket-banner" style="display:none">
+      <i class="bi bi-exclamation-triangle-fill"></i>
+      <span id="no-ticket-banner-msg"></span>
+      <button id="btn-dismiss-no-ticket" title="Dismiss"><i class="bi bi-x-lg"></i></button>
+    </div>
+
     <div class="row g-4">
 
       <!-- LEFT COLUMN: Details & Summary -->
@@ -196,7 +204,13 @@
           <input type="hidden" id="modal-group-id" />
           <input type="hidden" id="modal-group-type-ref" />
           <div class="row g-3">
-            <div class="col-12 col-lg-5">
+            <div class="col-12">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="modal-no-ticket" />
+                <label class="form-check-label" for="modal-no-ticket" style="font-size:0.82rem;color:var(--text-secondary);cursor:pointer">No ticket yet</label>
+              </div>
+            </div>
+            <div id="modal-ticket-wrap" class="col-12 col-lg-5">
               <label class="form-label label-text">Ticket / Reference ID</label>
               <input type="text" id="modal-ticket" class="form-control dark-input"
                 placeholder="e.g. JIRA-123 or #123" />

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -22,6 +22,7 @@ import { state } from './modules/state.js';
 import { getWeekStrFromDate, getDateFromWeek, buildWeekDays, enforceExpandedState, updateWeekDisplay } from './modules/week.js';
 import { updateSummary } from './modules/summary.js';
 import { initOnboarding, needsOnboarding, showOnboarding } from './modules/onboarding.js';
+import { initNoTicketBanner, updateNoTicketBanner } from './modules/no-ticket-reminder.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
@@ -29,6 +30,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initRipple();
     initSettings();
     initOnboarding();
+    initNoTicketBanner();
     initSidebar();
     initUpdater();
     initContextMenu();
@@ -72,4 +74,5 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     updateSummary();
     initKeyboard();
+    updateNoTicketBanner();
 });

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -5,12 +5,18 @@ import { updateSummary } from './summary.js';
 import { populateTypeSelect } from './ticket-types.js';
 // Circular — resolved at call time
 import { rerenderDayCard, renderAll } from './render.js';
+import { updateNoTicketBanner } from './no-ticket-reminder.js';
 
 let entryModal;
 export let lastDeleted = null;
 
 export function initEntryModal() {
     entryModal = new bootstrap.Modal(document.getElementById('entryModal'));
+
+    document.getElementById('modal-no-ticket').addEventListener('change', function () {
+        document.getElementById('modal-ticket-wrap').style.display = this.checked ? 'none' : '';
+        if (!this.checked) document.getElementById('modal-ticket').value = '';
+    });
 }
 
 export function openEntryModal(dayIdx, entryIdx) {
@@ -30,7 +36,10 @@ export function openEntryModal(dayIdx, entryIdx) {
         title.innerHTML = `<i class="bi bi-plus-circle me-2"></i>Add Entry — ${WEEK_DAYS[dayIdx]}`;
     } else {
         const e = state.days[dayIdx].entries[entryIdx];
-        document.getElementById('modal-ticket').value = e.ticket || '';
+        const noTicketToggle = document.getElementById('modal-no-ticket');
+        noTicketToggle.checked = !!e.noTicket;
+        document.getElementById('modal-ticket-wrap').style.display = e.noTicket ? 'none' : '';
+        document.getElementById('modal-ticket').value = e.noTicket ? '' : (e.ticket || '');
         document.getElementById('modal-hh').value = e.hh ?? 0;
         document.getElementById('modal-mm').value = String(e.mm ?? 0).padStart(2, '0');
         populateTypeSelect(document.getElementById('modal-type'), e.type || state.ticketTypes[0]?.id || 'jira');
@@ -115,6 +124,8 @@ export function openEntryModalPreFilled(dayIdx, fromEntryIdx, keepField) {
 }
 
 export function clearEntryModal() {
+    document.getElementById('modal-no-ticket').checked = false;
+    document.getElementById('modal-ticket-wrap').style.display = '';
     document.getElementById('modal-ticket').value = '';
     document.getElementById('modal-hh').value = '';
     document.getElementById('modal-mm').value = '00';
@@ -137,11 +148,12 @@ export function saveEntryInternal() {
     const tkt = ticketInput.value.trim();
     const desc = descInput.value.trim();
 
+    const isNoTicket = document.getElementById('modal-no-ticket').checked;
     let hasError = false;
 
     [ticketInput, descInput, hhInput, mmInput].forEach(el => el.classList.remove('is-invalid'));
 
-    if (!tkt) { ticketInput.classList.add('is-invalid'); hasError = true; }
+    if (!isNoTicket && !tkt) { ticketInput.classList.add('is-invalid'); hasError = true; }
     if (!desc) { descInput.classList.add('is-invalid'); hasError = true; }
     if (hh === 0 && mm === 0) {
         hhInput.classList.add('is-invalid');
@@ -197,13 +209,15 @@ export function saveEntryInternal() {
 export function commitEntry(dayIdx, entryIdx) {
     const groupId = document.getElementById('modal-group-id').value;
     const groupType = document.getElementById('modal-group-type-ref').value;
-    const tkt = document.getElementById('modal-ticket').value.trim();
+    const isNoTicket = document.getElementById('modal-no-ticket').checked;
+    const tkt = isNoTicket ? 'NO-TICKET' : document.getElementById('modal-ticket').value.trim();
     const hh = parseInt(document.getElementById('modal-hh').value) || 0;
     const mm = parseInt(document.getElementById('modal-mm').value) || 0;
     const type = document.getElementById('modal-type').value;
     const desc = document.getElementById('modal-desc').value.trim();
 
     const entry = { ticket: tkt, hh, mm, type, desc };
+    if (isNoTicket) entry.noTicket = true;
     if (groupId) { entry.groupId = groupId; entry.groupType = groupType; }
 
     if (entryIdx === -1) {
@@ -218,6 +232,7 @@ export function commitEntry(dayIdx, entryIdx) {
     rerenderDayCard(dayIdx);
     updateSummary();
     saveState();
+    updateNoTicketBanner();
     entryModal.hide();
 }
 
@@ -256,6 +271,7 @@ export function finishDeleteEntry(dayIdx, entryIdx, deletedEntry) {
     state.days[dayIdx].entries.splice(entryIdx, 1);
     rerenderDayCard(dayIdx);
     updateSummary();
+    updateNoTicketBanner();
 
     const timerId = setTimeout(() => {
         lastDeleted = null;

--- a/src/renderer/modules/no-ticket-reminder.js
+++ b/src/renderer/modules/no-ticket-reminder.js
@@ -1,0 +1,47 @@
+/* =============================================================
+   NO-TICKET REMINDER — persistent banner for unresolved entries
+   ============================================================= */
+
+import { state } from './state.js';
+
+let _dismissed = false;
+
+export function initNoTicketBanner() {
+    document.getElementById('btn-dismiss-no-ticket')
+        .addEventListener('click', () => {
+            document.getElementById('no-ticket-banner').style.display = 'none';
+            _dismissed = true;
+        });
+}
+
+export function updateNoTicketBanner() {
+    if (_dismissed) return;
+
+    const banner = document.getElementById('no-ticket-banner');
+    if (!banner) return;
+
+    const today = new Date().toISOString().slice(0, 10);
+
+    const flaggedDays = Object.values(state.allDaysByDate)
+        .filter(d => d.date < today && (d.entries || []).some(e => e.noTicket))
+        .sort((a, b) => a.date.localeCompare(b.date));
+
+    if (flaggedDays.length === 0) {
+        banner.style.display = 'none';
+        return;
+    }
+
+    const totalCount = flaggedDays.reduce(
+        (sum, d) => sum + (d.entries || []).filter(e => e.noTicket).length, 0
+    );
+
+    const dayLabels = flaggedDays.map(d => {
+        const date = new Date(d.date + 'T12:00:00');
+        return date.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' });
+    }).join(', ');
+
+    document.getElementById('no-ticket-banner-msg').textContent =
+        `${totalCount} entr${totalCount > 1 ? 'ies' : 'y'} without a ticket number — ${dayLabels}. Open those entries to assign a ticket.`;
+
+    banner.style.display = 'flex';
+}

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -148,9 +148,14 @@ export function buildEntriesHTML(entries, dayIdx) {
             let tktStr = (e.ticket || '');
             const typeObj = getTypeById(e.type);
             const ticketColor = typeObj ? typeObj.color : '#c8c8c8';
-            let ticketHtml = `<span class="entry-ticket" style="color:${ticketColor}">${escHtml(tktStr || '—')}</span>`;
-            if (group.type === 'ticket_group' && !isFirst) {
-                ticketHtml = `<span class="entry-ticket text-muted entry-grouped-hint">${escHtml(tktStr || '—')}</span>`;
+            let ticketHtml;
+            if (e.noTicket) {
+                ticketHtml = `<span class="entry-ticket entry-no-ticket-label">NO TICKET</span>`;
+            } else {
+                ticketHtml = `<span class="entry-ticket" style="color:${ticketColor}">${escHtml(tktStr || '—')}</span>`;
+                if (group.type === 'ticket_group' && !isFirst) {
+                    ticketHtml = `<span class="entry-ticket text-muted entry-grouped-hint">${escHtml(tktStr || '—')}</span>`;
+                }
             }
 
             const hhmm = `${String(e.hh || 0).padStart(2, '0')}:${String(e.mm || 0).padStart(2, '0')}`;
@@ -172,7 +177,7 @@ export function buildEntriesHTML(entries, dayIdx) {
 
             const rowI = rowIndex++;
             return `
-    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
+    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}${e.noTicket ? ' entry-no-ticket' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
       <span class="drag-handle" title="Drag to reorder"><i class="bi bi-grip-vertical"></i></span>
       <span class="entry-num entry-num-roman">${rStr}</span>
       ${ticketHtml}

--- a/src/renderer/styles/entries.css
+++ b/src/renderer/styles/entries.css
@@ -284,6 +284,63 @@
   100% { transform: scale(1); }
 }
 
+/* ── NO-TICKET REMINDER BANNER ── */
+
+.no-ticket-banner {
+  align-items: center;
+  gap: 12px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-left: 4px solid var(--danger);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  color: #fca5a5;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.no-ticket-banner .bi-exclamation-triangle-fill {
+  color: var(--danger);
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.no-ticket-banner #btn-dismiss-no-ticket {
+  background: none;
+  border: none;
+  color: #fca5a5;
+  margin-left: auto;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  opacity: 0.7;
+  flex-shrink: 0;
+  line-height: 1;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.no-ticket-banner #btn-dismiss-no-ticket:hover {
+  opacity: 1;
+  background: rgba(239, 68, 68, 0.15);
+}
+
+/* ── NO-TICKET ENTRIES ── */
+
+.entry-row.entry-no-ticket {
+  border-left-color: var(--danger) !important;
+}
+
+.entry-no-ticket-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--danger) !important;
+  min-width: 120px;
+  flex-shrink: 0;
+  letter-spacing: 0.02em;
+}
+
 /* ── SCHEDULED ENTRIES ── */
 
 .entry-row.entry-scheduled {


### PR DESCRIPTION
## Summary

- Adds a **No ticket yet** toggle to the add/edit entry modal — hides the ticket field when checked
- Entry saved with `ticket: 'NO-TICKET'` and `noTicket: true` flag
- Entry row displays **NO TICKET** in red with a red left border
- A persistent dismissible banner appears above the day cards when any past-day entries still have no ticket assigned
- Banner auto-clears when all flagged entries are resolved; re-evaluates on every save/delete

## Changes

- `src/renderer/index.html` — no-ticket toggle in entry modal, reminder banner above day cards
- `src/renderer/modules/no-ticket-reminder.js` — new module (`initNoTicketBanner`, `updateNoTicketBanner`)
- `src/renderer/modules/entry-modal.js` — toggle logic, skip ticket validation when checked, save `noTicket` flag, call banner update
- `src/renderer/modules/render.js` — NO TICKET label + `entry-no-ticket` class on row
- `src/renderer/styles/entries.css` — banner styles, red border and label styles
- `src/renderer/main.js` — init and trigger banner on app open

## Test plan

- [ ] Add entry with "No ticket yet" checked — ticket field hides, entry saves with red label and red left border
- [ ] Edit that entry — toggle is pre-checked, uncheck → ticket field reappears → save with real ticket → red styling clears
- [ ] Add no-ticket entry on a past date, reopen app — banner appears with the day name
- [ ] Resolve the entry → banner disappears automatically
- [ ] Dismiss banner with ✕ — hidden for the session

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)