### PR TITLE
feat(tm-92): amber banner reminder for under-logged days in current week

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -64,6 +64,13 @@
       <button id="btn-dismiss-no-ticket" title="Dismiss"><i class="bi bi-x-lg"></i></button>
     </div>
 
+    <!-- UNDERLOGGED REMINDER BANNER -->
+    <div id="underlogged-banner" class="underlogged-banner" style="display:none">
+      <i class="bi bi-clock-history"></i>
+      <span id="underlogged-banner-msg"></span>
+      <button id="btn-dismiss-underlogged" title="Dismiss"><i class="bi bi-x-lg"></i></button>
+    </div>
+
     <div class="row g-4">
 
       <!-- LEFT COLUMN: Details & Summary -->

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -23,6 +23,7 @@ import { getWeekStrFromDate, getDateFromWeek, buildWeekDays, enforceExpandedStat
 import { updateSummary } from './modules/summary.js';
 import { initOnboarding, needsOnboarding, showOnboarding } from './modules/onboarding.js';
 import { initNoTicketBanner, updateNoTicketBanner } from './modules/no-ticket-reminder.js';
+import { initUnderloggedBanner, updateUnderloggedBanner } from './modules/underlogged-reminder.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
@@ -31,6 +32,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initSettings();
     initOnboarding();
     initNoTicketBanner();
+    initUnderloggedBanner();
     initSidebar();
     initUpdater();
     initContextMenu();
@@ -75,4 +77,5 @@ document.addEventListener('DOMContentLoaded', async () => {
     updateSummary();
     initKeyboard();
     updateNoTicketBanner();
+    updateUnderloggedBanner();
 });

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -6,6 +6,7 @@ import { populateTypeSelect } from './ticket-types.js';
 // Circular — resolved at call time
 import { rerenderDayCard, renderAll } from './render.js';
 import { updateNoTicketBanner } from './no-ticket-reminder.js';
+import { updateUnderloggedBanner } from './underlogged-reminder.js';
 
 let entryModal;
 export let lastDeleted = null;
@@ -233,6 +234,7 @@ export function commitEntry(dayIdx, entryIdx) {
     updateSummary();
     saveState();
     updateNoTicketBanner();
+    updateUnderloggedBanner();
     entryModal.hide();
 }
 
@@ -272,6 +274,7 @@ export function finishDeleteEntry(dayIdx, entryIdx, deletedEntry) {
     rerenderDayCard(dayIdx);
     updateSummary();
     updateNoTicketBanner();
+    updateUnderloggedBanner();
 
     const timerId = setTimeout(() => {
         lastDeleted = null;

--- a/src/renderer/modules/underlogged-reminder.js
+++ b/src/renderer/modules/underlogged-reminder.js
@@ -1,0 +1,62 @@
+/* =============================================================
+   UNDERLOGGED REMINDER — banner for past days below daily target
+   ============================================================= */
+
+import { state, WEEK_DAYS } from './state.js';
+import { fmtDate } from './utils.js';
+
+let _dismissed = false;
+
+export function initUnderloggedBanner() {
+    document.getElementById('btn-dismiss-underlogged')
+        .addEventListener('click', () => {
+            document.getElementById('underlogged-banner').style.display = 'none';
+            _dismissed = true;
+        });
+}
+
+export function updateUnderloggedBanner() {
+    if (_dismissed) return;
+
+    const banner = document.getElementById('underlogged-banner');
+    if (!banner) return;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const todayStr = fmtDate(today);
+
+    // Monday of the current real week
+    const dow = today.getDay();
+    const monday = new Date(today);
+    monday.setDate(today.getDate() - (dow === 0 ? 6 : dow - 1));
+
+    const flagged = [];
+
+    for (let i = 0; i < 5; i++) {
+        const d = new Date(monday);
+        d.setDate(monday.getDate() + i);
+        const dateStr = fmtDate(d);
+
+        if (dateStr >= todayStr) break; // only past days
+
+        const dayData = state.days.find(day => day.date === dateStr) || state.allDaysByDate[dateStr];
+        if (dayData?.isHoliday || dayData?.leaveTypeId) continue; // skip holidays and leave days
+
+        const totalMins = (dayData?.entries || [])
+            .reduce((sum, e) => sum + (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0), 0);
+
+        if (totalMins < (state.dailyTargetMins || 480)) {
+            flagged.push(WEEK_DAYS[i]);
+        }
+    }
+
+    if (flagged.length === 0) {
+        banner.style.display = 'none';
+        return;
+    }
+
+    document.getElementById('underlogged-banner-msg').textContent =
+        `Incomplete time logs this week: ${flagged.join(', ')}. Hours logged are below your daily target.`;
+
+    banner.style.display = 'flex';
+}

--- a/src/renderer/styles/entries.css
+++ b/src/renderer/styles/entries.css
@@ -325,6 +325,47 @@
   background: rgba(239, 68, 68, 0.15);
 }
 
+/* ── UNDERLOGGED REMINDER BANNER ── */
+
+.underlogged-banner {
+  align-items: center;
+  gap: 12px;
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  border-left: 4px solid var(--warning);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  color: #fde68a;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.underlogged-banner .bi-clock-history {
+  color: var(--warning);
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.underlogged-banner #btn-dismiss-underlogged {
+  background: none;
+  border: none;
+  color: #fde68a;
+  margin-left: auto;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  opacity: 0.7;
+  flex-shrink: 0;
+  line-height: 1;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.underlogged-banner #btn-dismiss-underlogged:hover {
+  opacity: 1;
+  background: rgba(251, 191, 36, 0.12);
+}
+
 /* ── NO-TICKET ENTRIES ── */
 
 .entry-row.entry-no-ticket {


### PR DESCRIPTION
## Summary

- On app open, checks all weekdays **before today** in the current real week
- Flags days where total logged time < daily target, skipping holidays and leave days
- Shows a persistent amber dismissible banner listing the specific day names (e.g. "Monday, Tuesday")
- Banner auto-clears when all flagged days meet the target; re-evaluates on every entry save/delete
- Uses `fmtDate` (local timezone) for date key consistency with `allDaysByDate`

## Changes

- `src/renderer/modules/underlogged-reminder.js` — new module (`initUnderloggedBanner`, `updateUnderloggedBanner`)
- `src/renderer/index.html` — amber banner added above day cards
- `src/renderer/styles/entries.css` — amber banner styles
- `src/renderer/main.js` — init and trigger banner on app open
- `src/renderer/modules/entry-modal.js` — re-evaluate banner after save/delete

## Test plan

- [ ] Open app on Wednesday or later with Monday/Tuesday under target — banner shows those day names
- [ ] Log enough hours to meet target on a flagged day — banner updates and removes that day
- [ ] All flagged days resolved — banner disappears automatically
- [ ] Holiday/leave days not listed in the banner
- [ ] Dismiss with ✕ — hidden for the session

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)