### PR TITLE
feat(tm-95): system tray icon + daily notification + light mode fixes

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,10 +1,12 @@
-const { app, BrowserWindow, Menu, shell, ipcMain, screen } = require('electron');
+const { app, BrowserWindow, Menu, shell, ipcMain, screen, Tray, nativeImage, Notification } = require('electron');
 const path = require('path');
 const Store = require('electron-store');
 const { autoUpdater } = require('electron-updater');
 
 const store = new Store();
 const WINDOW_BOUNDS_KEY = 'windowBounds';
+const LS_KEY = 'timesheetState_v1';
+const NOTIFICATION_KEY = 'notificationSettings';
 
 // Disable auto-download — we control when to download
 autoUpdater.autoDownload = false;
@@ -26,7 +28,102 @@ function getValidBounds() {
   return onScreen ? saved : null;
 }
 
+function minsToHHMM(mins) {
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function getTodayStats() {
+  const saved = store.get(LS_KEY);
+  const targetMins = saved?.dailyTargetMins || 480;
+  if (!saved) return { totalMins: 0, targetMins, isHoliday: false };
+
+  const now = new Date();
+  const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const dayData = saved.allDaysByDate?.[dateStr];
+
+  if (!dayData) return { totalMins: 0, targetMins, isHoliday: false };
+  if (dayData.isHoliday || dayData.leaveTypeId) return { totalMins: 0, targetMins, isHoliday: true };
+
+  const totalMins = (dayData.entries || []).reduce((sum, e) =>
+    sum + (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0), 0);
+
+  return { totalMins, targetMins, isHoliday: false };
+}
+
 let mainWindow;
+let tray = null;
+let isQuitting = false;
+
+function showMainWindow() {
+  if (!mainWindow) return;
+  mainWindow.show();
+  mainWindow.focus();
+  mainWindow.webContents.send('navigate-to-today');
+}
+
+function buildTrayMenu() {
+  const { totalMins, targetMins, isHoliday } = getTodayStats();
+  const statusLabel = isHoliday
+    ? 'Today: Holiday / Leave'
+    : `Today: ${minsToHHMM(totalMins)} / ${minsToHHMM(targetMins)}`;
+
+  return Menu.buildFromTemplate([
+    { label: statusLabel, enabled: false },
+    { type: 'separator' },
+    { label: 'Open Timesheet Manager', click: () => showMainWindow() },
+    { type: 'separator' },
+    { label: 'Quit', click: () => { isQuitting = true; app.quit(); } }
+  ]);
+}
+
+function createTray() {
+  const iconPath = path.join(__dirname, '../../favicon.png');
+  const icon = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 });
+  tray = new Tray(icon);
+  tray.setToolTip('Timesheet Manager');
+  tray.setContextMenu(buildTrayMenu());
+
+  tray.on('click', () => showMainWindow());
+  tray.on('right-click', () => {
+    tray.setContextMenu(buildTrayMenu());
+    tray.popUpContextMenu();
+  });
+}
+
+function scheduleNotifications() {
+  setInterval(() => {
+    const settings = store.get(NOTIFICATION_KEY, { enabled: true, time: '17:30', lastFiredDate: '' });
+    if (!settings.enabled) return;
+
+    const now = new Date();
+    const currentTime = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+    const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+
+    if (currentTime !== settings.time) return;
+    if (settings.lastFiredDate === todayStr) return;
+
+    const { totalMins, targetMins, isHoliday } = getTodayStats();
+    if (isHoliday || totalMins >= targetMins) return;
+
+    const remaining = targetMins - totalMins;
+    const notification = new Notification({
+      title: 'Timesheet Manager',
+      body: `Don't forget to log your time!\nToday: ${minsToHHMM(totalMins)} logged — ${minsToHHMM(remaining)} remaining`,
+      icon: iconPath(),
+    });
+
+    notification.on('click', () => showMainWindow());
+    notification.show();
+
+    store.set(NOTIFICATION_KEY, { ...settings, lastFiredDate: todayStr });
+  }, 30000); // check every 30 seconds
+}
+
+function iconPath() {
+  return path.join(__dirname, '../../favicon.png');
+}
 
 function createWindow() {
   const savedBounds = getValidBounds();
@@ -46,8 +143,12 @@ function createWindow() {
     }
   });
 
-  mainWindow.on('close', () => {
+  mainWindow.on('close', (e) => {
     store.set(WINDOW_BOUNDS_KEY, mainWindow.getBounds());
+    if (!isQuitting) {
+      e.preventDefault();
+      mainWindow.hide();
+    }
   });
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
@@ -99,8 +200,12 @@ autoUpdater.on('error', (err) => {
 });
 
 // ── App lifecycle ────────────────────────────────────────
+app.on('before-quit', () => { isQuitting = true; });
+
 app.whenReady().then(() => {
   createWindow();
+  createTray();
+  scheduleNotifications();
 
   // Check for updates silently after window is ready
   mainWindow.webContents.once('did-finish-load', () => {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -7,6 +7,10 @@ contextBridge.exposeInMainWorld('electronStore', {
     has: (key) => ipcRenderer.invoke('store-has', key),
 });
 
+contextBridge.exposeInMainWorld('tray', {
+    onNavigateToToday: (cb) => ipcRenderer.on('navigate-to-today', () => cb()),
+});
+
 contextBridge.exposeInMainWorld('updater', {
     checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
     downloadUpdate: () => ipcRenderer.invoke('download-update'),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -716,6 +716,10 @@
               <i class="bi bi-palette"></i>
               <span>Appearance</span>
             </div>
+            <div class="settings-nav-item" data-section="notifications">
+              <i class="bi bi-bell"></i>
+              <span>Notifications</span>
+            </div>
             <div class="settings-nav-item settings-nav-parent" data-section="management">
               <i class="bi bi-grid"></i>
               <span>Management</span>

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -24,6 +24,7 @@ import { updateSummary } from './modules/summary.js';
 import { initOnboarding, needsOnboarding, showOnboarding } from './modules/onboarding.js';
 import { initNoTicketBanner, updateNoTicketBanner } from './modules/no-ticket-reminder.js';
 import { initUnderloggedBanner, updateUnderloggedBanner } from './modules/underlogged-reminder.js';
+import { setCurrentWeek } from './modules/week.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
@@ -78,4 +79,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     initKeyboard();
     updateNoTicketBanner();
     updateUnderloggedBanner();
+
+    // Navigate to today when triggered from tray or notification click
+    if (window.tray) {
+        window.tray.onNavigateToToday(() => {
+            setCurrentWeek();
+            renderAll();
+            updateSummary();
+        });
+    }
 });

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -147,7 +147,7 @@ export function buildEntriesHTML(entries, dayIdx) {
 
             let tktStr = (e.ticket || '');
             const typeObj = getTypeById(e.type);
-            const ticketColor = typeObj ? typeObj.color : '#c8c8c8';
+            const ticketColor = typeObj ? typeObj.color : 'var(--entry-ticket-color)';
             let ticketHtml;
             if (e.noTicket) {
                 ticketHtml = `<span class="entry-ticket entry-no-ticket-label">NO TICKET</span>`;

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -15,15 +15,18 @@ import { renderErrorLogSection } from './error-log.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
-    'general':      { parent: null,         label: 'General',      isParent: false },
-    'appearance':   { parent: null,         label: 'Appearance',   isParent: false },
-    'management':   { parent: null,         label: 'Management',   isParent: true  },
-    'ticket-types': { parent: 'management', label: 'Ticket Types', isParent: false },
-    'leave-types':  { parent: 'management', label: 'Leave Types',  isParent: false },
-    'developer':    { parent: null,         label: 'Developer',    isParent: true  },
-    'error-logs':   { parent: 'developer',  label: 'Error Logs',   isParent: false },
-    'about':        { parent: null,         label: 'About',        isParent: false },
+    'general':       { parent: null,         label: 'General',       isParent: false },
+    'appearance':    { parent: null,         label: 'Appearance',    isParent: false },
+    'notifications': { parent: null,         label: 'Notifications', isParent: false },
+    'management':    { parent: null,         label: 'Management',    isParent: true  },
+    'ticket-types':  { parent: 'management', label: 'Ticket Types',  isParent: false },
+    'leave-types':   { parent: 'management', label: 'Leave Types',   isParent: false },
+    'developer':     { parent: null,         label: 'Developer',     isParent: true  },
+    'error-logs':    { parent: 'developer',  label: 'Error Logs',    isParent: false },
+    'about':         { parent: null,         label: 'About',         isParent: false },
 };
+
+const NOTIFICATION_KEY = 'notificationSettings';
 
 /* ── STATE ──────────────────────────────────────────────── */
 let currentSection = 'general';
@@ -174,9 +177,10 @@ function updateNav(section) {
 function renderSection(section) {
     const el = document.getElementById('settings-content');
     switch (section) {
-        case 'general':      return renderGeneral(el);
-        case 'appearance':   return renderAppearance(el);
-        case 'management':   return renderManagement(el);
+        case 'general':        return renderGeneral(el);
+        case 'appearance':     return renderAppearance(el);
+        case 'notifications':  return renderNotifications(el);
+        case 'management':     return renderManagement(el);
         case 'ticket-types': return renderTicketTypes(el);
         case 'leave-types':  return renderLeaveTypes(el);
         case 'developer':    return renderDeveloper(el);
@@ -306,6 +310,61 @@ function renderAppearance(el) {
             applyTheme(btn.dataset.theme);
             localStorage.setItem('theme', btn.dataset.theme);
         });
+    });
+}
+
+async function renderNotifications(el) {
+    const saved = await window.electronStore.get(NOTIFICATION_KEY) || { enabled: true, time: '17:30' };
+    const enabled = saved.enabled !== false;
+    const time = saved.time || '17:30';
+
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Notifications</h2>
+            <p class="settings-section-desc">Daily reminder to log your time before end of day.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="settings-form">
+                <div class="settings-form-group">
+                    <label class="label-text">Daily Reminder</label>
+                    <div class="form-check form-switch mt-1">
+                        <input class="form-check-input" type="checkbox" id="notif-enabled" ${enabled ? 'checked' : ''} />
+                        <label class="form-check-label label-text" for="notif-enabled">
+                            Enable daily reminder notification
+                        </label>
+                    </div>
+                    <p class="form-text text-muted mt-1">Shows a system notification if your daily target isn't met yet.</p>
+                </div>
+                <div class="settings-form-group" id="notif-time-group" style="${enabled ? '' : 'opacity:0.4;pointer-events:none'}">
+                    <label class="label-text" for="notif-time">Reminder Time</label>
+                    <input type="time" id="notif-time" class="form-control dark-input" value="${time}" style="max-width:140px" />
+                </div>
+                <div class="settings-form-actions">
+                    <button class="btn btn-gradient px-4" id="btn-save-notifications">
+                        <i class="bi bi-check-lg me-1"></i> Save
+                    </button>
+                </div>
+            </div>
+        </div>`;
+
+    const enabledToggle = el.querySelector('#notif-enabled');
+    const timeGroup = el.querySelector('#notif-time-group');
+
+    enabledToggle.addEventListener('change', () => {
+        timeGroup.style.opacity = enabledToggle.checked ? '1' : '0.4';
+        timeGroup.style.pointerEvents = enabledToggle.checked ? '' : 'none';
+        markDirty('notifications');
+    });
+
+    el.querySelector('#notif-time').addEventListener('change', () => markDirty('notifications'));
+
+    el.querySelector('#btn-save-notifications').addEventListener('click', async () => {
+        const newEnabled = el.querySelector('#notif-enabled').checked;
+        const newTime = el.querySelector('#notif-time').value || '17:30';
+        const current = await window.electronStore.get(NOTIFICATION_KEY) || {};
+        await window.electronStore.set(NOTIFICATION_KEY, { ...current, enabled: newEnabled, time: newTime });
+        clearDirty();
+        showToast('Notification settings saved.', 'success');
     });
 }
 

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -22,6 +22,7 @@
   --radius: 14px;
   --radius-sm: 8px;
   --header-h: 68px;
+  --entry-ticket-color: #c8c8c8;
 }
 
 [data-theme="light"] {
@@ -43,6 +44,7 @@
   --glass: rgba(255, 255, 255, 0.8);
   --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.05);
   --shadow-glow: 0 0 20px rgba(0, 0, 0, 0.05);
+  --entry-ticket-color: var(--text-primary);
 }
 
 [data-theme="light"] .app-header {
@@ -104,9 +106,14 @@
   background: rgba(0, 0, 0, 0.04);
 }
 [data-theme="light"] .total-chip-value,
-[data-theme="light"] .entry-ticket,
 [data-theme="light"] .modal-title {
   color: var(--text-primary);
+}
+[data-theme="light"] .entry-ticket {
+  color: var(--text-primary) !important;
+}
+[data-theme="light"] .entry-ticket.text-muted {
+  color: var(--text-secondary) !important;
 }
 [data-theme="light"] .day-hours-total {
     background: rgba(5, 150, 105, 0.1);
@@ -132,4 +139,30 @@
     background:
         radial-gradient(ellipse 80% 50% at 20% -10%, rgba(0, 0, 0, 0.03) 0%, transparent 60%),
         radial-gradient(ellipse 60% 40% at 80% 110%, rgba(5, 150, 105, 0.04) 0%, transparent 60%);
+}
+
+[data-theme="light"] .no-ticket-banner {
+    background: rgba(220, 38, 38, 0.07);
+    border-color: rgba(220, 38, 38, 0.3);
+    border-left-color: #dc2626;
+    color: #991b1b;
+}
+[data-theme="light"] .no-ticket-banner .bi-exclamation-triangle-fill {
+    color: #dc2626;
+}
+[data-theme="light"] .no-ticket-banner #btn-dismiss-no-ticket {
+    color: #991b1b;
+}
+
+[data-theme="light"] .underlogged-banner {
+    background: rgba(180, 83, 9, 0.07);
+    border-color: rgba(180, 83, 9, 0.3);
+    border-left-color: #b45309;
+    color: #78350f;
+}
+[data-theme="light"] .underlogged-banner .bi-clock-history {
+    color: #b45309;
+}
+[data-theme="light"] .underlogged-banner #btn-dismiss-underlogged {
+    color: #78350f;
 }


### PR DESCRIPTION
## Summary
- System tray icon with today's logged hours, Open and Quit actions; window close hides to tray
- Daily notification scheduling via setInterval — fires once per day at a user-configured time
- Settings → Notifications panel (enable toggle + time picker) persisted in electron-store
- Navigate-to-today IPC sent when tray icon is left-clicked
- Fix light mode entry ticket colors: `!important` overrides inline styles so all tickets use `--text-primary`; ticket_group 2nd+ rows use `--text-secondary` (dimmed but readable)
- Fix light mode no-ticket and underlogged banner text with darker theme-aware colors

Closes #98

## Test plan
- [ ] Tray icon appears after launch; right-click shows today's hours, Open, Quit
- [ ] Closing window hides to tray; Quit actually exits
- [ ] Left-clicking tray icon shows window and navigates to today
- [ ] Settings → Notifications: toggle enables/disables, time picker saves correctly
- [ ] Light mode: all ticket names are dark; only ticket_group 2nd+ rows are dimmed slate
- [ ] Light mode: no-ticket and underlogged banners have readable dark text

🤖 Generated with [Claude Code](https://claude.com/claude-code)