### PR TITLE
feat(tm-96): Alt+N shortcut to open entry modal with no-ticket toggled on

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -569,6 +569,7 @@
             <div class="cheatsheet-group-label">Entries</div>
             <div class="cheatsheet-row"><kbd>N</kbd> <span>Add new entry to expanded day</span></div>
             <div class="cheatsheet-row"><kbd>Enter</kbd> <span>Save entry (inside entry modal)</span></div>
+            <div class="cheatsheet-row"><kbd>Alt</kbd><kbd>N</kbd> <span>Open entry modal with no-ticket toggled on</span></div>
           </div>
           <div class="cheatsheet-group">
             <div class="cheatsheet-group-label">Views</div>

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -177,15 +177,32 @@ export function initKeyboard() {
                 e.preventDefault();
                 saveEntry();
             }
+            if (e.altKey && (e.key === 'n' || e.key === 'N') && modalOpen.id === 'entryModal') {
+                e.preventDefault();
+                const toggle = document.getElementById('modal-no-ticket');
+                toggle.checked = !toggle.checked;
+                toggle.dispatchEvent(new Event('change'));
+            }
             return;
         }
 
         const expandedIdx = state.days.findIndex(d => d.expanded);
 
+        if (e.altKey && (e.key === 'n' || e.key === 'N') && expandedIdx !== -1) {
+            e.preventDefault();
+            openEntryModal(expandedIdx, -1);
+            document.getElementById('entryModal').addEventListener('shown.bs.modal', () => {
+                const toggle = document.getElementById('modal-no-ticket');
+                toggle.checked = true;
+                toggle.dispatchEvent(new Event('change'));
+            }, { once: true });
+            return;
+        }
+
         switch (e.key) {
             case 'n':
             case 'N':
-                if (expandedIdx !== -1) openEntryModal(expandedIdx, -1);
+                if (!e.altKey && expandedIdx !== -1) openEntryModal(expandedIdx, -1);
                 break;
 
             case 'ArrowUp':


### PR DESCRIPTION
## Summary
- `Alt+N` on an expanded day opens the entry modal with no-ticket checkbox auto-checked
- `Alt+N` inside the entry modal toggles the no-ticket checkbox on/off
- Plain `N` shortcut is unchanged
- Added `Alt+N` to the keyboard shortcuts cheatsheet

Closes #96

## Test plan
- [ ] Press `Alt+N` on an expanded day — entry modal opens with no-ticket already checked
- [ ] Press `Alt+N` inside the modal — toggles no-ticket off/on
- [ ] Press `N` normally — opens entry modal without no-ticket checked
- [ ] Check cheatsheet (`?`) — `Alt+N` listed under Entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)