### PR TITLE
feat(tm-97): G key shortcut to jump to current week and expand today

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -564,6 +564,7 @@
             <div class="cheatsheet-group-label">Navigation</div>
             <div class="cheatsheet-row"><kbd>↑</kbd><kbd>↓</kbd> <span>Switch expanded day up / down</span></div>
             <div class="cheatsheet-row"><kbd>←</kbd><kbd>→</kbd> <span>Switch to previous / next week</span></div>
+            <div class="cheatsheet-row"><kbd>G</kbd> <span>Jump to current week and expand today</span></div>
           </div>
           <div class="cheatsheet-group">
             <div class="cheatsheet-group-label">Entries</div>

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -4,7 +4,8 @@ import { escHtml } from './utils.js';
 import { renderStarredList } from './star.js';
 import { saveEntry, openEntryModal } from './entry-modal.js';
 import { toggleDay, renderAll } from './render.js';
-import { changeWeekBy } from './week.js';
+import { changeWeekBy, setCurrentWeek } from './week.js';
+import { updateSummary } from './summary.js';
 import { openPreview, openDayQuickView, doPrint } from './report.js';
 import { openSettings, addChangelogEntry } from './settings.js';
 import { logError } from './error-log.js';
@@ -200,6 +201,13 @@ export function initKeyboard() {
         }
 
         switch (e.key) {
+            case 'g':
+            case 'G':
+                setCurrentWeek();
+                renderAll();
+                updateSummary();
+                break;
+
             case 'n':
             case 'N':
                 if (!e.altKey && expandedIdx !== -1) openEntryModal(expandedIdx, -1);


### PR DESCRIPTION
## Summary
- `G` key jumps to the current week and expands today's card from anywhere in the app
- Added `G` to the keyboard shortcuts cheatsheet under Navigation

Closes #97

## Test plan
- [ ] Navigate to a past week with `←`, press `G` — jumps back to current week with today expanded
- [ ] Press `G` when already on current week — no-op / stays on today
- [ ] Check cheatsheet (`?`) — `G` listed under Navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)