### PR TITLE
feat(tm-99): logged-to-timesheet indicator per entry

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -211,10 +211,14 @@
           <input type="hidden" id="modal-group-id" />
           <input type="hidden" id="modal-group-type-ref" />
           <div class="row g-3">
-            <div class="col-12">
+            <div class="col-12 d-flex align-items-center gap-4">
               <div class="form-check">
                 <input class="form-check-input" type="checkbox" id="modal-no-ticket" />
                 <label class="form-check-label" for="modal-no-ticket" style="font-size:0.82rem;color:var(--text-secondary);cursor:pointer">No ticket yet</label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="modal-logged" />
+                <label class="form-check-label" for="modal-logged" style="font-size:0.82rem;color:var(--text-secondary);cursor:pointer"><i class="bi bi-journal-check me-1"></i>Already logged to timesheet</label>
               </div>
             </div>
             <div id="modal-ticket-wrap" class="col-12 col-lg-5">
@@ -469,6 +473,7 @@
     <div class="ctx-item ctx-make-regular" id="ctx-make-regular" style="display:none"><i class="bi bi-calendar-check"></i> Make Regular</div>
     <div class="ctx-divider"></div>
     <div class="ctx-item" id="ctx-star"><i class="bi bi-star"></i> <span id="ctx-star-label">Star</span></div>
+    <div class="ctx-item" id="ctx-logged"><i class="bi bi-journal"></i> <span id="ctx-logged-label">Mark as logged</span></div>
     <div class="ctx-divider"></div>
     <div class="ctx-item ctx-danger" id="ctx-delete"><i class="bi bi-trash"></i> Delete</div>
   </div>

--- a/src/renderer/modules/context-menu.js
+++ b/src/renderer/modules/context-menu.js
@@ -5,7 +5,7 @@ import { getTypeLabel } from './ticket-types.js';
 // Circular — resolved at call time
 import { rerenderDayCard } from './render.js';
 import { openEntryModal, openEntryModalPreFilled, makeRegularEntry, deleteEntry } from './entry-modal.js';
-import { toggleEntryStarred } from './star.js';
+import { toggleEntryStarred, toggleEntryLogged } from './star.js';
 
 let ctxTarget = null;
 
@@ -29,6 +29,8 @@ export function showEntryContextMenu(row, x, y) {
 
     document.getElementById('ctx-star-label').textContent = entry.starred ? 'Unstar' : 'Star';
     document.getElementById('ctx-star').querySelector('i').className = entry.starred ? 'bi bi-star-fill' : 'bi bi-star';
+    document.getElementById('ctx-logged-label').textContent = entry.logged ? 'Unmark as logged' : 'Mark as logged';
+    document.getElementById('ctx-logged').querySelector('i').className = entry.logged ? 'bi bi-journal-check' : 'bi bi-journal';
 
     menu.classList.remove('ctx-open');
     menu.style.display = 'block';
@@ -101,6 +103,13 @@ export function initContextMenu() {
         const { dayIdx, entryIdx, row } = ctxTarget;
         hideContextMenu();
         toggleEntryStarred(dayIdx, entryIdx, row.querySelector('.entry-btn-star'));
+    });
+
+    document.getElementById('ctx-logged').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx, row } = ctxTarget;
+        hideContextMenu();
+        toggleEntryLogged(dayIdx, entryIdx, row.querySelector('.entry-btn-logged'));
     });
 
     document.getElementById('ctx-delete').addEventListener('click', () => {

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -47,6 +47,8 @@ export function openEntryModal(dayIdx, entryIdx) {
         document.getElementById('modal-desc').value = e.desc || '';
         document.getElementById('modal-group-id').value = e.groupId || '';
         document.getElementById('modal-group-type-ref').value = e.groupType || '';
+        // Auto-unmark logged when editing — entry may change and need re-logging
+        document.getElementById('modal-logged').checked = false;
         deleteBtn.style.display = 'inline-flex';
         if (e.isScheduled) {
             makeRegularBtn.style.display = 'inline-flex';
@@ -126,6 +128,7 @@ export function openEntryModalPreFilled(dayIdx, fromEntryIdx, keepField) {
 
 export function clearEntryModal() {
     document.getElementById('modal-no-ticket').checked = false;
+    document.getElementById('modal-logged').checked = false;
     document.getElementById('modal-ticket-wrap').style.display = '';
     document.getElementById('modal-ticket').value = '';
     document.getElementById('modal-hh').value = '';
@@ -217,8 +220,10 @@ export function commitEntry(dayIdx, entryIdx) {
     const type = document.getElementById('modal-type').value;
     const desc = document.getElementById('modal-desc').value.trim();
 
+    const isLogged = document.getElementById('modal-logged').checked;
     const entry = { ticket: tkt, hh, mm, type, desc };
     if (isNoTicket) entry.noTicket = true;
+    if (isLogged) entry.logged = true;
     if (groupId) { entry.groupId = groupId; entry.groupType = groupType; }
 
     if (entryIdx === -1) {
@@ -227,6 +232,7 @@ export function commitEntry(dayIdx, entryIdx) {
         const existing = state.days[dayIdx].entries[entryIdx];
         if (existing && existing.recurringId) entry.recurringId = existing.recurringId;
         if (existing && existing.isScheduled) entry.isScheduled = existing.isScheduled;
+        // logged is NOT carried over from existing — modal already pre-unchecked it (auto-unmark on edit)
         state.days[dayIdx].entries[entryIdx] = entry;
     }
 

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -5,7 +5,7 @@ import { calcDayTotalMins, updateSummary } from './summary.js';
 // Circular imports — resolved at call time (runtime only, not load time)
 import { openEntryModal } from './entry-modal.js';
 import { showEntryContextMenu } from './context-menu.js';
-import { toggleEntryStarred } from './star.js';
+import { toggleEntryStarred, toggleEntryLogged } from './star.js';
 import { openDayQuickView } from './report.js';
 import { showEntryQuickView } from './context-menu.js';
 import { getTypeById } from './ticket-types.js';
@@ -174,10 +174,13 @@ export function buildEntriesHTML(entries, dayIdx) {
 
             const starClass = e.starred ? 'starred' : '';
             const starIcon  = e.starred ? 'bi-star-fill' : 'bi-star';
+            const loggedClass = e.logged ? 'logged' : '';
+            const loggedIcon  = e.logged ? 'bi-journal-check' : 'bi-journal';
+            const loggedTitle = e.logged ? 'Logged to timesheet — click to unmark' : 'Mark as logged to timesheet';
 
             const rowI = rowIndex++;
             return `
-    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}${e.noTicket ? ' entry-no-ticket' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
+    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}${e.noTicket ? ' entry-no-ticket' : ''}${e.logged ? ' entry-logged' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
       <span class="drag-handle" title="Drag to reorder"><i class="bi bi-grip-vertical"></i></span>
       <span class="entry-num entry-num-roman">${rStr}</span>
       ${ticketHtml}
@@ -187,6 +190,7 @@ export function buildEntriesHTML(entries, dayIdx) {
       ${e.isScheduled ? '<span class="entry-scheduled-badge" title="Scheduled task"><i class="bi bi-clock"></i></span>' : ''}
       ${descHtml}
       <div class="ms-auto d-flex align-items-center gap-1">
+        <button class="entry-btn-logged ${loggedClass}" title="${loggedTitle}"><i class="bi ${loggedIcon}"></i></button>
         <button class="entry-btn-star ${starClass}" title="${e.starred ? 'Unstar' : 'Star'}"><i class="bi ${starIcon}"></i></button>
       </div>
     </div>`;
@@ -298,7 +302,7 @@ export function buildDayCard(day, dayIdx) {
 
     wrap.querySelectorAll('.entry-row').forEach(row => {
         row.addEventListener('dblclick', e => {
-            if (e.target.closest('.drag-handle') || e.target.closest('.entry-btn-eye') || e.target.closest('.entry-btn-star')) return;
+            if (e.target.closest('.drag-handle') || e.target.closest('.entry-btn-eye') || e.target.closest('.entry-btn-star') || e.target.closest('.entry-btn-logged')) return;
             openEntryModal(parseInt(row.dataset.day), parseInt(row.dataset.entry));
         });
 
@@ -310,6 +314,11 @@ export function buildDayCard(day, dayIdx) {
         row.querySelector('.entry-btn-star').addEventListener('click', e => {
             e.stopPropagation();
             toggleEntryStarred(parseInt(row.dataset.day), parseInt(row.dataset.entry), e.currentTarget);
+        });
+
+        row.querySelector('.entry-btn-logged').addEventListener('click', e => {
+            e.stopPropagation();
+            toggleEntryLogged(parseInt(row.dataset.day), parseInt(row.dataset.entry), e.currentTarget);
         });
     });
 

--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -77,15 +77,16 @@ export function generateDayTxt(day) {
                     }
 
                     const showDesc = !(group.type === 'desc_group' && !isLast);
+                    const loggedMark = e.logged ? '  (✓ logged)' : '';
 
                     if (!showDesc) {
-                        lines.push(`${indent}${rStr}${ticket} ${timeStr}`);
+                        lines.push(`${indent}${rStr}${ticket} ${timeStr}${loggedMark}`);
                     } else {
                         const descLines = desc ? desc.split(/\r?\n/) : [];
                         if (descLines.length === 0) {
-                            lines.push(`${indent}${rStr}${ticket} ${timeStr}`);
+                            lines.push(`${indent}${rStr}${ticket} ${timeStr}${loggedMark}`);
                         } else {
-                            lines.push(`${indent}${rStr}${ticket} ${timeStr}- ${sdTag}${descLines[0]}`);
+                            lines.push(`${indent}${rStr}${ticket} ${timeStr}- ${sdTag}${descLines[0]}${loggedMark}`);
                             if (descLines.length > 1) {
                                 const indentStr = indent + romanBlank + ' '.repeat(`${ticket} ${timeStr}- ${sdTag}`.length);
                                 for (let j = 1; j < descLines.length; j++) {

--- a/src/renderer/modules/star.js
+++ b/src/renderer/modules/star.js
@@ -22,6 +22,22 @@ export function toggleEntryStarred(dayIdx, entryIdx, btnEl) {
     saveState();
 }
 
+export function toggleEntryLogged(dayIdx, entryIdx, btnEl) {
+    const entry = state.days[dayIdx]?.entries[entryIdx];
+    if (!entry) return;
+    entry.logged = !entry.logged;
+    btnEl.classList.toggle('logged', entry.logged);
+    btnEl.querySelector('i').className = entry.logged ? 'bi bi-journal-check' : 'bi bi-journal';
+    btnEl.title = entry.logged ? 'Logged to timesheet — click to unmark' : 'Mark as logged to timesheet';
+    const row = btnEl.closest('.entry-row');
+    if (row) row.classList.toggle('entry-logged', entry.logged);
+    const dateStr = state.days[dayIdx].date;
+    if (state.allDaysByDate[dateStr]) {
+        state.allDaysByDate[dateStr].entries[entryIdx] = entry;
+    }
+    saveState();
+}
+
 export function renderStarredList() {
     const container = document.getElementById('starred-list');
     const results = [];

--- a/src/renderer/styles/entries.css
+++ b/src/renderer/styles/entries.css
@@ -247,7 +247,8 @@
 /* ── ENTRY ROW BUTTONS ── */
 
 .entry-btn-eye,
-.entry-btn-star {
+.entry-btn-star,
+.entry-btn-logged {
   background: none;
   border: none;
   padding: 3px 5px;
@@ -272,6 +273,19 @@
 
 .entry-btn-star.starred {
   color: var(--warning);
+}
+
+.entry-btn-logged:hover {
+  color: var(--success);
+  background: rgba(34, 197, 94, 0.08);
+}
+
+.entry-btn-logged.logged {
+  color: var(--success);
+}
+
+.entry-row.entry-logged {
+  opacity: 0.65;
 }
 
 .entry-btn-star.star-pulse {


### PR DESCRIPTION
## Summary
- `bi-journal` (muted) / `bi-journal-check` (green) button on each entry row to toggle logged state
- Clicking the icon or using right-click → "Mark as logged" / "Unmark as logged" toggles the state
- Logged entries are visually dimmed (opacity 0.65) for at-a-glance scanning
- Entry modal includes "Already logged to timesheet" checkbox for new entries; auto-unchecked when editing (entry may need re-logging after changes)
- Context menu shows dynamic icon and label based on current logged state
- Day quick view (Q) appends `(✓ logged)` to logged entry lines

Closes #103

## Test plan
- [ ] Journal icon appears on every entry row beside the star
- [ ] Clicking toggles logged state — icon changes, row dims, persists after reload
- [ ] Right-click → Mark/Unmark as logged works
- [ ] Add entry with "Already logged" checked → saved as logged
- [ ] Edit a logged entry → checkbox is unchecked (auto-unmark); saving unmarks it
- [ ] Day preview (Q) shows `(✓ logged)` for logged entries only

🤖 Generated with [Claude Code](https://claude.com/claude-code)