### PR TITLE
fix(tm-107): preview TXT per-entry time format corrected to HH:MM

### DIFF
--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -32,7 +32,7 @@ export function initReport() {
 
 const DAY_ROMAN_WIDTH = 6; // wide enough for 'viii)' + 1 space
 
-export function generateDayTxt(day) {
+export function generateDayTxt(day, useHHMM = false) {
     const displayDate = fmtDisplayDate(day.date);
     const lines = [];
     const indent = '  '; // 2-space initial indent, no tabs
@@ -63,7 +63,9 @@ export function generateDayTxt(day) {
 
                     const h = parseInt(e.hh) || 0;
                     const m = parseInt(e.mm) || 0;
-                    const timeFmt = h === 0 ? `(${m}m)` : m === 0 ? `(${h}h)` : `(${h}h ${m}m)`;
+                    const timeFmt = useHHMM
+                        ? `(${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')})`
+                        : h === 0 ? `(${m}m)` : m === 0 ? `(${h}h)` : `(${h}h ${m}m)`;
                     const timeStr = timeFmt.padEnd(10);
 
                     const eTypeObj = getTypeById(e.type);
@@ -109,7 +111,7 @@ export function generateTxt() {
     lines.push(SEPARATOR);
 
     state.days.forEach((day) => {
-        lines.push(generateDayTxt(day));
+        lines.push(generateDayTxt(day, true));
         lines.push('');
     });
 


### PR DESCRIPTION
## Summary
- `generateDayTxt` now accepts a `useHHMM` flag
- `generateTxt` (preview, copy, download, print) passes `true` → `(02:30)` format
- `openDayQuickView` omits the flag → keeps `(2h 30m)` format

Closes #107

## Test plan
- [ ] P key: per-entry times show `(02:30)` in preview TXT
- [ ] Copy / download / print: same `(02:30)` format
- [ ] Q key: quick-view still shows `(2h 30m)`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)