### PR TITLE
fix(tm-109): hide logged marker from preview TXT, keep in quick-view

### DIFF
--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -79,7 +79,7 @@ export function generateDayTxt(day, useHHMM = false) {
                     }
 
                     const showDesc = !(group.type === 'desc_group' && !isLast);
-                    const loggedMark = e.logged ? '  (✓ logged)' : '';
+                    const loggedMark = (!useHHMM && e.logged) ? '  (✓ logged)' : '';
 
                     if (!showDesc) {
                         lines.push(`${indent}${rStr}${ticket} ${timeStr}${loggedMark}`);


### PR DESCRIPTION
## Summary
- `loggedMark` is now suppressed when `useHHMM` is `true` (preview / copy / download / print)
- Quick-view (`useHHMM` false) continues to show `(✓ logged)`

Closes #109

## Test plan
- [ ] P key: no `(✓ logged)` markers in preview TXT
- [ ] Copy / download / print: same — no logged markers
- [ ] Q key: logged entries still show `(✓ logged)`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)