### PR TITLE
fix(tm-111): prevent deleted recurring entry from re-appearing on reload

### DIFF
--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -276,6 +276,14 @@ export function deleteEntry() {
 }
 
 export function finishDeleteEntry(dayIdx, entryIdx, deletedEntry) {
+    if (deletedEntry.recurringId) {
+        const dateStr = state.days[dayIdx].date;
+        const rule = state.recurringTasks?.find(r => r.id === deletedEntry.recurringId);
+        if (rule) {
+            if (!rule.skippedDates) rule.skippedDates = [];
+            if (!rule.skippedDates.includes(dateStr)) rule.skippedDates.push(dateStr);
+        }
+    }
     state.days[dayIdx].entries.splice(entryIdx, 1);
     rerenderDayCard(dayIdx);
     updateSummary();
@@ -309,6 +317,13 @@ export function undoDelete() {
     clearTimeout(lastDeleted.timerId);
     const { dayIdx, entryIdx, entry } = lastDeleted;
     lastDeleted = null;
+    if (entry.recurringId) {
+        const dateStr = state.days[dayIdx].date;
+        const rule = state.recurringTasks?.find(r => r.id === entry.recurringId);
+        if (rule && rule.skippedDates) {
+            rule.skippedDates = rule.skippedDates.filter(d => d !== dateStr);
+        }
+    }
     state.days[dayIdx].entries.splice(entryIdx, 0, entry);
     rerenderDayCard(dayIdx);
     updateSummary();

--- a/src/renderer/modules/recurring.js
+++ b/src/renderer/modules/recurring.js
@@ -23,7 +23,8 @@ export function populateRecurringForWeek(monDt) {
         state.recurringTasks.forEach(rule => {
             if (!rule.days.includes(dayName)) return;
             const exists = day.entries.some(e => e.recurringId === rule.id);
-            if (!exists) {
+            const skipped = rule.skippedDates?.includes(dateStr);
+            if (!exists && !skipped) {
                 day.entries.push({ ticket: rule.ticket, hh: rule.hh, mm: rule.mm, type: rule.type, desc: rule.desc, recurringId: rule.id });
             }
         });


### PR DESCRIPTION
## Summary
- Added `skippedDates[]` to recurring rules to track intentionally deleted instances
- `finishDeleteEntry` — records the date when a recurring entry is manually deleted
- `populateRecurringForWeek` — skips dates present in `rule.skippedDates`
- `undoDelete` — removes the date from `skippedDates` so the entry is correctly restored

Closes #111

## Test plan
- [ ] Delete a recurring entry → navigate away and back → entry stays deleted
- [ ] Delete a recurring entry → close and reopen app → entry stays deleted
- [ ] Undo delete → navigate away and back → entry is still present
- [ ] Other days with the same recurring rule are unaffected
- [ ] Deleting the entire rule from Recurring Tasks modal still works as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)