### PR TITLE
fix(tm-115): use tab character for entry indent in TXT output

### DIFF
--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -35,7 +35,7 @@ const DAY_ROMAN_WIDTH = 6; // wide enough for 'viii)' + 1 space
 export function generateDayTxt(day, useHHMM = false) {
     const displayDate = fmtDisplayDate(day.date);
     const lines = [];
-    const indent = '  '; // 2-space initial indent, no tabs
+    const indent = '\t';
 
     if (day.isHoliday) {
         lines.push(`${displayDate} :   `);


### PR DESCRIPTION
## Summary
- Replaces `'  '` (2 spaces) with `'\t'` as the entry indent in `generateDayTxt()`
- Entry lines now align to a proper tab stop in Notepad and other text editors

Closes #115

## Test plan
- [ ] Preview TXT (P key): entries indented with tab
- [ ] Downloaded TXT: entries indented with tab in Notepad
- [ ] Multi-line descriptions: continuation lines still aligned correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)