### PR TITLE
fix(tm-117): prevent second app instance with single instance lock

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -199,6 +199,14 @@ autoUpdater.on('error', (err) => {
   mainWindow.webContents.send('update-error', err.message);
 });
 
+// ── Single instance lock ─────────────────────────────────
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', () => showMainWindow());
+}
+
 // ── App lifecycle ────────────────────────────────────────
 app.on('before-quit', () => { isQuitting = true; });
 


### PR DESCRIPTION
## Summary
- Added `app.requestSingleInstanceLock()` — second launch attempt quits immediately
- First instance listens for `second-instance` event and calls `showMainWindow()` to focus/restore the window

Closes #117

## Test plan
- [ ] App open → launch again → existing window is focused
- [ ] App hidden in tray → launch again → window is restored and focused
- [ ] Only one instance runs at a time

🤖 Generated with [Claude Code](https://claude.ai/claude-code)