### PR TITLE
feat(tm-113): skip this occurrence for recurring entries via context menu

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -471,6 +471,7 @@
     <div class="ctx-item ctx-sub-ticket" id="ctx-sub-ticket" style="display:none"><i class="bi bi-ticket-detailed"></i> Add Sub-entry (same ticket)</div>
     <div class="ctx-item ctx-sub-desc" id="ctx-sub-desc" style="display:none"><i class="bi bi-card-text"></i> Add Sub-entry (same desc)</div>
     <div class="ctx-item ctx-make-regular" id="ctx-make-regular" style="display:none"><i class="bi bi-calendar-check"></i> Make Regular</div>
+    <div class="ctx-item ctx-warning" id="ctx-skip-recurring" style="display:none"><i class="bi bi-skip-forward"></i> Skip this occurrence</div>
     <div class="ctx-divider"></div>
     <div class="ctx-item" id="ctx-star"><i class="bi bi-star"></i> <span id="ctx-star-label">Star</span></div>
     <div class="ctx-item" id="ctx-logged"><i class="bi bi-journal"></i> <span id="ctx-logged-label">Mark as logged</span></div>

--- a/src/renderer/modules/context-menu.js
+++ b/src/renderer/modules/context-menu.js
@@ -2,10 +2,13 @@ import { state } from './state.js';
 import { saveState } from './store.js';
 import { escHtml } from './utils.js';
 import { getTypeLabel } from './ticket-types.js';
+import { showToast } from './toast.js';
 // Circular — resolved at call time
 import { rerenderDayCard } from './render.js';
+import { updateSummary } from './summary.js';
 import { openEntryModal, openEntryModalPreFilled, makeRegularEntry, deleteEntry } from './entry-modal.js';
 import { toggleEntryStarred, toggleEntryLogged } from './star.js';
+import { skipRecurringOccurrence } from './recurring.js';
 
 let ctxTarget = null;
 
@@ -26,6 +29,7 @@ export function showEntryContextMenu(row, x, y) {
     document.getElementById('ctx-sub-desc').style.display =
         (ctxTarget.groupType === 'normal' || ctxTarget.groupType === 'desc_group') ? 'flex' : 'none';
     document.getElementById('ctx-make-regular').style.display = entry.isScheduled ? 'flex' : 'none';
+    document.getElementById('ctx-skip-recurring').style.display = entry.recurringId ? 'flex' : 'none';
 
     document.getElementById('ctx-star-label').textContent = entry.starred ? 'Unstar' : 'Star';
     document.getElementById('ctx-star').querySelector('i').className = entry.starred ? 'bi bi-star-fill' : 'bi bi-star';
@@ -87,6 +91,16 @@ export function initContextMenu() {
         const { dayIdx, entryIdx } = ctxTarget;
         hideContextMenu();
         openEntryModalPreFilled(dayIdx, entryIdx, 'desc');
+    });
+
+    document.getElementById('ctx-skip-recurring').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx } = ctxTarget;
+        hideContextMenu();
+        skipRecurringOccurrence(dayIdx, entryIdx);
+        rerenderDayCard(dayIdx);
+        updateSummary();
+        showToast('Occurrence skipped.', 'success');
     });
 
     document.getElementById('ctx-make-regular').addEventListener('click', () => {

--- a/src/renderer/modules/recurring.js
+++ b/src/renderer/modules/recurring.js
@@ -11,6 +11,21 @@ import { updateSummary } from './summary.js';
 let recurringModal;
 let recurringFormModal;
 
+export function skipRecurringOccurrence(dayIdx, entryIdx) {
+    const day = state.days[dayIdx];
+    const entry = day?.entries[entryIdx];
+    if (!entry?.recurringId) return;
+
+    const rule = state.recurringTasks?.find(r => r.id === entry.recurringId);
+    if (rule) {
+        if (!rule.skippedDates) rule.skippedDates = [];
+        if (!rule.skippedDates.includes(day.date)) rule.skippedDates.push(day.date);
+    }
+
+    day.entries.splice(entryIdx, 1);
+    saveState();
+}
+
 export function populateRecurringForWeek(monDt) {
     if (!state.recurringTasks || state.recurringTasks.length === 0) return;
     for (let i = 0; i < 5; i++) {

--- a/src/renderer/styles/context-menu.css
+++ b/src/renderer/styles/context-menu.css
@@ -53,6 +53,15 @@
   color: var(--danger);
 }
 
+.ctx-item.ctx-warning {
+  color: var(--warning);
+}
+
+.ctx-item.ctx-warning:hover {
+  background: rgba(251,191,36,0.08);
+  color: var(--warning);
+}
+
 .ctx-divider {
   height: 1px;
   background: var(--border);


### PR DESCRIPTION
## Summary
- New "Skip this occurrence" context menu item (warning/amber style) for recurring entries only
- Adds the day's date to `rule.skippedDates[]`, removes the entry, saves state
- No undo toast — intentional skip action
- Added `ctx-warning` CSS class for the amber styling
- Uses the `skippedDates` mechanism already in place from tm-111

Closes #113

## Test plan
- [ ] Right-click recurring entry → "Skip this occurrence" appears in amber
- [ ] Clicking it removes the entry and shows "Occurrence skipped." toast
- [ ] No undo toast shown
- [ ] Navigate away and back / restart → entry stays gone for that day only
- [ ] Other days with same recurring rule unaffected
- [ ] Right-click non-recurring entry → item not visible

🤖 Generated with [Claude Code](https://claude.ai/claude-code)