### PR TITLE
feat(tm-114): scheduled tasks modal with Active/Completed/Cancelled tabs

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -404,7 +404,34 @@
           <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
         </div>
         <div class="modal-body">
-          <div id="scheduled-list"></div>
+          <ul class="nav nav-tabs scheduled-tabs mb-3" id="scheduledTabs">
+            <li class="nav-item">
+              <button class="nav-link active" id="tab-btn-active" data-bs-toggle="tab" data-bs-target="#tab-scheduled-active" type="button">
+                Active <span class="badge scheduled-tab-badge ms-1" id="badge-scheduled-active"></span>
+              </button>
+            </li>
+            <li class="nav-item">
+              <button class="nav-link" id="tab-btn-completed" data-bs-toggle="tab" data-bs-target="#tab-scheduled-completed" type="button">
+                Completed <span class="badge scheduled-tab-badge ms-1" id="badge-scheduled-completed"></span>
+              </button>
+            </li>
+            <li class="nav-item">
+              <button class="nav-link" id="tab-btn-cancelled" data-bs-toggle="tab" data-bs-target="#tab-scheduled-cancelled" type="button">
+                Cancelled <span class="badge scheduled-tab-badge ms-1" id="badge-scheduled-cancelled"></span>
+              </button>
+            </li>
+          </ul>
+          <div class="tab-content">
+            <div class="tab-pane fade show active" id="tab-scheduled-active">
+              <div id="scheduled-list-active"></div>
+            </div>
+            <div class="tab-pane fade" id="tab-scheduled-completed">
+              <div id="scheduled-list-completed"></div>
+            </div>
+            <div class="tab-pane fade" id="tab-scheduled-cancelled">
+              <div id="scheduled-list-cancelled"></div>
+            </div>
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Close</button>
@@ -472,6 +499,7 @@
     <div class="ctx-item ctx-sub-desc" id="ctx-sub-desc" style="display:none"><i class="bi bi-card-text"></i> Add Sub-entry (same desc)</div>
     <div class="ctx-item ctx-make-regular" id="ctx-make-regular" style="display:none"><i class="bi bi-calendar-check"></i> Make Regular</div>
     <div class="ctx-item ctx-warning" id="ctx-skip-recurring" style="display:none"><i class="bi bi-skip-forward"></i> Skip this occurrence</div>
+    <div class="ctx-item ctx-danger" id="ctx-cancel-scheduled" style="display:none"><i class="bi bi-calendar-x"></i> Cancel scheduled task</div>
     <div class="ctx-divider"></div>
     <div class="ctx-item" id="ctx-star"><i class="bi bi-star"></i> <span id="ctx-star-label">Star</span></div>
     <div class="ctx-item" id="ctx-logged"><i class="bi bi-journal"></i> <span id="ctx-logged-label">Mark as logged</span></div>

--- a/src/renderer/modules/context-menu.js
+++ b/src/renderer/modules/context-menu.js
@@ -9,6 +9,7 @@ import { updateSummary } from './summary.js';
 import { openEntryModal, openEntryModalPreFilled, makeRegularEntry, deleteEntry } from './entry-modal.js';
 import { toggleEntryStarred, toggleEntryLogged } from './star.js';
 import { skipRecurringOccurrence } from './recurring.js';
+import { cancelScheduledEntry } from './scheduled.js';
 
 let ctxTarget = null;
 
@@ -29,6 +30,7 @@ export function showEntryContextMenu(row, x, y) {
     document.getElementById('ctx-sub-desc').style.display =
         (ctxTarget.groupType === 'normal' || ctxTarget.groupType === 'desc_group') ? 'flex' : 'none';
     document.getElementById('ctx-make-regular').style.display = entry.isScheduled ? 'flex' : 'none';
+    document.getElementById('ctx-cancel-scheduled').style.display = entry.isScheduled ? 'flex' : 'none';
     document.getElementById('ctx-skip-recurring').style.display = entry.recurringId ? 'flex' : 'none';
 
     document.getElementById('ctx-star-label').textContent = entry.starred ? 'Unstar' : 'Star';
@@ -101,6 +103,14 @@ export function initContextMenu() {
         rerenderDayCard(dayIdx);
         updateSummary();
         showToast('Occurrence skipped.', 'success');
+    });
+
+    document.getElementById('ctx-cancel-scheduled').addEventListener('click', () => {
+        if (!ctxTarget) return;
+        const { dayIdx, entryIdx } = ctxTarget;
+        hideContextMenu();
+        const dateStr = state.days[dayIdx].date;
+        cancelScheduledEntry(dateStr, entryIdx);
     });
 
     document.getElementById('ctx-make-regular').addEventListener('click', () => {

--- a/src/renderer/modules/scheduled.js
+++ b/src/renderer/modules/scheduled.js
@@ -16,6 +16,13 @@ export function promoteExpiredScheduled() {
         if (dateStr >= todayStr) return;
         state.allDaysByDate[dateStr].entries.forEach(entry => {
             if (entry.isScheduled) {
+                if (!state.scheduledHistory) state.scheduledHistory = [];
+                state.scheduledHistory.push({
+                    ticket: entry.ticket, hh: entry.hh, mm: entry.mm,
+                    type: entry.type, desc: entry.desc,
+                    date: dateStr, status: 'completed',
+                    actionAt: todayStr
+                });
                 delete entry.isScheduled;
                 changed = true;
             }
@@ -55,73 +62,105 @@ export function initScheduledTasks() {
     document.getElementById('btn-scheduled-form-cancel').addEventListener('click', closeForm);
 }
 
-function renderScheduledList() {
-    const container = document.getElementById('scheduled-list');
+function formatDateLabel(dateStr) {
+    const dt = new Date(dateStr + 'T00:00:00');
+    return dt.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' });
+}
 
-    const scheduled = [];
+function buildEntryCard({ dateStr, entry, isPast = false, buttons = '' }) {
+    const hhmm = `${String(entry.hh || 0).padStart(2, '0')}:${String(entry.mm || 0).padStart(2, '0')}`;
+    const entryTypeObj = getTypeById(entry.type);
+    const isSd = entryTypeObj?.hasPrefix === true;
+    const sdLabel = isSd ? entryTypeObj.label : '';
+    const dateLabel = formatDateLabel(dateStr);
+    return `
+    <div class="recurring-rule-card mb-2${isPast ? ' opacity-50' : ''}">
+      <div class="d-flex align-items-start justify-content-between gap-2">
+        <div class="flex-grow-1">
+          <div class="d-flex align-items-center gap-2 mb-1 flex-wrap">
+            <i class="bi bi-clock" style="color:var(--warning);font-size:0.8rem"></i>
+            <span style="font-size:0.75rem;color:var(--text-secondary)">${escHtml(dateLabel)}${isPast ? ' <span class="text-danger">(past)</span>' : ''}</span>
+          </div>
+          <div class="d-flex align-items-center gap-2 flex-wrap">
+            <span class="fw-semibold" style="font-size:0.9rem">${escHtml(entry.ticket || '—')}</span>
+            <span class="text-muted" style="font-size:0.8rem">${hhmm}</span>
+            ${isSd ? `<span class="entry-type-badge">${escHtml(sdLabel)}</span>` : ''}
+          </div>
+          <div class="text-muted mt-1" style="font-size:0.8rem">${escHtml(entry.desc || '')}</div>
+        </div>
+        <div class="d-flex gap-1 flex-shrink-0">${buttons}</div>
+      </div>
+    </div>`;
+}
+
+function renderScheduledList() {
+    const todayStr = fmtDate(new Date());
+    if (!state.scheduledHistory) state.scheduledHistory = [];
+
+    // ── Active ───────────────────────────────────────────
+    const active = [];
     Object.keys(state.allDaysByDate).sort().forEach(dateStr => {
-        const day = state.allDaysByDate[dateStr];
-        day.entries.forEach((entry, entryIdx) => {
-            if (entry.isScheduled) {
-                scheduled.push({ dateStr, entry, entryIdx });
-            }
+        state.allDaysByDate[dateStr].entries.forEach((entry, entryIdx) => {
+            if (entry.isScheduled) active.push({ dateStr, entry, entryIdx });
         });
     });
 
-    if (scheduled.length === 0) {
-        container.innerHTML = `<p class="text-muted text-center py-3" style="font-size:0.9rem;">No scheduled tasks. Click "Add Scheduled Task" to pre-schedule an entry for a future date.</p>`;
-        return;
+    const activeContainer = document.getElementById('scheduled-list-active');
+    document.getElementById('badge-scheduled-active').textContent = active.length || '';
+    if (active.length === 0) {
+        activeContainer.innerHTML = `<p class="text-center py-3" style="font-size:0.9rem;color:var(--text-secondary);">No active scheduled tasks. Click "Add Scheduled Task" to pre-schedule an entry.</p>`;
+    } else {
+        activeContainer.innerHTML = active.map(({ dateStr, entry, entryIdx }) => {
+            const isPast = dateStr <= todayStr;
+            const buttons = `
+              <button class="btn btn-sm btn-outline-warning py-0 px-2" title="Make Regular" data-make-date="${dateStr}" data-make-idx="${entryIdx}"><i class="bi bi-calendar-check"></i></button>
+              <button class="btn btn-sm btn-outline-danger py-0 px-2" title="Cancel" data-cancel-date="${dateStr}" data-cancel-idx="${entryIdx}"><i class="bi bi-x-circle"></i></button>`;
+            return buildEntryCard({ dateStr, entry, isPast, buttons });
+        }).join('');
+
+        activeContainer.querySelectorAll('[data-make-date]').forEach(btn => {
+            btn.addEventListener('click', () => makeScheduledRegular(btn.dataset.makeDate, parseInt(btn.dataset.makeIdx)));
+        });
+        activeContainer.querySelectorAll('[data-cancel-date]').forEach(btn => {
+            btn.addEventListener('click', () => cancelScheduledEntry(btn.dataset.cancelDate, parseInt(btn.dataset.cancelIdx)));
+        });
     }
 
-    let html = '';
-    scheduled.forEach(({ dateStr, entry, entryIdx }) => {
-        const dt = new Date(dateStr + 'T00:00:00');
-        const dateLabel = dt.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' });
-        const hhmm = `${String(entry.hh || 0).padStart(2, '0')}:${String(entry.mm || 0).padStart(2, '0')}`;
-        const entryTypeObj = getTypeById(entry.type);
-        const isSd = entryTypeObj?.hasPrefix === true;
-        const sdLabel = isSd ? entryTypeObj.label : '';
-        const isPast = dateStr <= fmtDate(new Date());
-        html += `
-        <div class="recurring-rule-card mb-2${isPast ? ' opacity-50' : ''}">
-          <div class="d-flex align-items-start justify-content-between gap-2">
-            <div class="flex-grow-1">
-              <div class="d-flex align-items-center gap-2 mb-1 flex-wrap">
-                <i class="bi bi-clock" style="color:var(--warning);font-size:0.8rem"></i>
-                <span style="font-size:0.75rem;color:var(--text-secondary)">${escHtml(dateLabel)}${isPast ? ' <span class="text-danger">(past)</span>' : ''}</span>
-              </div>
-              <div class="d-flex align-items-center gap-2 flex-wrap">
-                <span class="fw-semibold" style="font-size:0.9rem">${escHtml(entry.ticket || '—')}</span>
-                <span class="text-muted" style="font-size:0.8rem">${hhmm}</span>
-                ${isSd ? `<span class="entry-type-badge">${escHtml(sdLabel)}</span>` : ''}
-              </div>
-              <div class="text-muted mt-1" style="font-size:0.8rem">${escHtml(entry.desc || '')}</div>
-            </div>
-            <div class="d-flex gap-1 flex-shrink-0">
-              <button class="btn btn-sm btn-outline-warning py-0 px-2" title="Make Regular" data-scheduled-date="${dateStr}" data-scheduled-idx="${entryIdx}">
-                <i class="bi bi-calendar-check"></i>
-              </button>
-              <button class="btn btn-sm btn-outline-danger py-0 px-2" title="Delete" data-delete-scheduled-date="${dateStr}" data-delete-scheduled-idx="${entryIdx}">
-                <i class="bi bi-trash"></i>
-              </button>
-            </div>
-          </div>
-        </div>`;
-    });
+    // ── Completed ────────────────────────────────────────
+    const completed = state.scheduledHistory.filter(h => h.status === 'completed')
+        .sort((a, b) => b.date.localeCompare(a.date));
 
-    container.innerHTML = html;
+    const completedContainer = document.getElementById('scheduled-list-completed');
+    document.getElementById('badge-scheduled-completed').textContent = completed.length || '';
+    if (completed.length === 0) {
+        completedContainer.innerHTML = `<p class="text-center py-3" style="font-size:0.9rem;color:var(--text-secondary);">No completed scheduled tasks yet.</p>`;
+    } else {
+        completedContainer.innerHTML = completed.map(h =>
+            buildEntryCard({ dateStr: h.date, entry: h, isPast: true, buttons: '' })
+        ).join('');
+    }
 
-    container.querySelectorAll('[data-scheduled-date]').forEach(btn => {
-        btn.addEventListener('click', () => {
-            makeScheduledRegular(btn.dataset.scheduledDate, parseInt(btn.dataset.scheduledIdx));
+    // ── Cancelled ────────────────────────────────────────
+    const cancelled = state.scheduledHistory.filter(h => h.status === 'cancelled')
+        .sort((a, b) => b.actionAt.localeCompare(a.actionAt));
+
+    const cancelledContainer = document.getElementById('scheduled-list-cancelled');
+    document.getElementById('badge-scheduled-cancelled').textContent = cancelled.length || '';
+    if (cancelled.length === 0) {
+        cancelledContainer.innerHTML = `<p class="text-center py-3" style="font-size:0.9rem;color:var(--text-secondary);">No cancelled scheduled tasks.</p>`;
+    } else {
+        cancelledContainer.innerHTML = cancelled.map((h, histIdx) => {
+            const canReactivate = h.date > todayStr;
+            const buttons = canReactivate
+                ? `<button class="btn btn-sm btn-outline-success py-0 px-2" title="Reactivate" data-reactivate-idx="${histIdx}"><i class="bi bi-arrow-counterclockwise"></i></button>`
+                : '';
+            return buildEntryCard({ dateStr: h.date, entry: h, isPast: !canReactivate, buttons });
+        }).join('');
+
+        cancelledContainer.querySelectorAll('[data-reactivate-idx]').forEach(btn => {
+            btn.addEventListener('click', () => reactivateScheduledEntry(parseInt(btn.dataset.reactivateIdx)));
         });
-    });
-
-    container.querySelectorAll('[data-delete-scheduled-date]').forEach(btn => {
-        btn.addEventListener('click', () => {
-            deleteScheduledEntry(btn.dataset.deleteScheduledDate, parseInt(btn.dataset.deleteScheduledIdx));
-        });
-    });
+    }
 }
 
 function openScheduledForm() {
@@ -221,9 +260,19 @@ function makeScheduledRegular(dateStr, entryIdx) {
     showToast('Entry converted to a regular entry.', 'success');
 }
 
-function deleteScheduledEntry(dateStr, entryIdx) {
+export function cancelScheduledEntry(dateStr, entryIdx) {
     const day = state.allDaysByDate[dateStr];
-    if (!day) return;
+    if (!day || !day.entries[entryIdx]) return;
+
+    const entry = day.entries[entryIdx];
+    if (!state.scheduledHistory) state.scheduledHistory = [];
+    state.scheduledHistory.push({
+        ticket: entry.ticket, hh: entry.hh, mm: entry.mm,
+        type: entry.type, desc: entry.desc,
+        date: dateStr, status: 'cancelled',
+        actionAt: fmtDate(new Date())
+    });
+
     day.entries.splice(entryIdx, 1);
 
     const dayInWeek = state.days.findIndex(d => d.date === dateStr);
@@ -235,4 +284,42 @@ function deleteScheduledEntry(dateStr, entryIdx) {
     saveState();
     updateSummary();
     renderScheduledList();
+    showToast('Scheduled task cancelled.', 'success');
+}
+
+function reactivateScheduledEntry(historyIdx) {
+    if (!state.scheduledHistory) return;
+    const cancelled = state.scheduledHistory.filter(h => h.status === 'cancelled');
+    const record = cancelled[historyIdx];
+    if (!record) return;
+
+    // Remove from history
+    const globalIdx = state.scheduledHistory.indexOf(record);
+    state.scheduledHistory.splice(globalIdx, 1);
+
+    // Restore as scheduled entry
+    if (!state.allDaysByDate[record.date]) {
+        state.allDaysByDate[record.date] = {
+            date: record.date, isHoliday: false,
+            leaveTypeId: '', holidayLabel: 'Offshore Holiday', expanded: false, entries: []
+        };
+    }
+    state.allDaysByDate[record.date].entries.push({
+        ticket: record.ticket, hh: record.hh, mm: record.mm,
+        type: record.type, desc: record.desc, isScheduled: true
+    });
+
+    const dayInWeek = state.days.findIndex(d => d.date === record.date);
+    if (dayInWeek !== -1) {
+        state.days[dayInWeek] = state.allDaysByDate[record.date];
+        rerenderDayCard(dayInWeek);
+    }
+
+    saveState();
+    updateSummary();
+
+    // Switch to Active tab
+    document.getElementById('tab-btn-active')?.click();
+    renderScheduledList();
+    showToast('Scheduled task reactivated.', 'success');
 }

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -292,11 +292,11 @@ function renderAppearance(el) {
             <div class="settings-form-group">
                 <label class="label-text">Theme</label>
                 <div class="settings-theme-options">
-                    <button class="settings-theme-btn ${currentTheme === 'dark' ? 'active' : ''}" data-theme="dark">
+                    <button class="settings-theme-btn ${currentTheme === 'dark' ? 'active' : ''}" data-select-theme="dark">
                         <i class="bi bi-moon-fill"></i>
                         <span>Dark</span>
                     </button>
-                    <button class="settings-theme-btn ${currentTheme === 'light' ? 'active' : ''}" data-theme="light">
+                    <button class="settings-theme-btn ${currentTheme === 'light' ? 'active' : ''}" data-select-theme="light">
                         <i class="bi bi-sun-fill"></i>
                         <span>Light</span>
                     </button>
@@ -307,8 +307,8 @@ function renderAppearance(el) {
 
     el.querySelectorAll('.settings-theme-btn').forEach(btn => {
         btn.addEventListener('click', () => {
-            applyTheme(btn.dataset.theme);
-            localStorage.setItem('theme', btn.dataset.theme);
+            applyTheme(btn.dataset.selectTheme);
+            localStorage.setItem('theme', btn.dataset.selectTheme);
         });
     });
 }

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -28,6 +28,7 @@ export const state = {
     days: [],
     lastOpenedDateByWeek: {},
     recurringTasks: [],
+    scheduledHistory: [],
     dailyTargetMins: 480,
     ticketTypes: [],
     leaveTypes: [],

--- a/src/renderer/modules/theme.js
+++ b/src/renderer/modules/theme.js
@@ -25,6 +25,6 @@ export function applyTheme(theme) {
 
     // Update theme buttons in Settings → Appearance if visible
     document.querySelectorAll('.settings-theme-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.theme === theme);
+        btn.classList.toggle('active', btn.dataset.selectTheme === theme);
     });
 }

--- a/src/renderer/styles/modals.css
+++ b/src/renderer/styles/modals.css
@@ -49,3 +49,41 @@
 #confirmModal {
   z-index: 1060;
 }
+
+/* ── SCHEDULED TASKS TABS ── */
+.scheduled-tabs {
+  border-bottom: 1px solid var(--border);
+  gap: 4px;
+}
+
+.scheduled-tabs .nav-link,
+.scheduled-tabs .nav-link:not(.active) {
+  color: var(--text-primary) !important;
+  opacity: 0.55;
+  background: transparent !important;
+  border: none !important;
+  border-bottom: 2px solid transparent !important;
+  border-radius: 0;
+  padding: 6px 14px;
+  font-size: 0.85rem;
+}
+
+.scheduled-tabs .nav-link:hover {
+  opacity: 0.85;
+}
+
+.scheduled-tabs .nav-link.active {
+  color: var(--text-primary) !important;
+  opacity: 1;
+  border-bottom: 2px solid var(--warning) !important;
+  background: transparent !important;
+}
+
+.scheduled-tab-badge {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  border: 1px solid var(--border-accent);
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 1px 6px;
+}


### PR DESCRIPTION
## Summary
- Added `scheduledHistory[]` to state for tracking the full lifecycle of scheduled tasks
- **Active tab**: existing behaviour — Make Regular + Cancel (×) buttons
- **Completed tab**: tasks auto-promoted by `promoteExpiredScheduled` (read-only)
- **Cancelled tab**: manually cancelled tasks; Reactivate button shown if date is still in future
- `ctx-cancel-scheduled` context menu item for scheduled entries on day cards
- Cancel logs to `scheduledHistory` with `status: 'cancelled'` instead of plain delete

### Bug fixes included
- Light theme button in Settings → Appearance showed white bg in dark mode — fixed by renaming `data-theme` to `data-select-theme` on buttons to avoid CSS variable scope conflict
- Tab labels and empty state text now visible in dark mode

Closes #114

## Test plan
- [ ] Active tab shows upcoming scheduled tasks with Make Regular + Cancel buttons
- [ ] Cancelling a task moves it to Cancelled tab
- [ ] Cancelled task with future date shows Reactivate button → clicking moves it back to Active
- [ ] Cancelled task with past date shows no Reactivate button
- [ ] Date passing promotes task → appears in Completed tab
- [ ] Right-click scheduled entry → "Cancel scheduled task" → moves to Cancelled tab
- [ ] Settings → Appearance → Light button has correct dark bg in dark mode

🤖 Generated with [Claude Code](https://claude.ai/claude-code)