### PR TITLE
feat(tm-125): add exit button in sidebar to fully quit the app

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -178,6 +178,9 @@ ipcMain.handle('check-for-updates', () => autoUpdater.checkForUpdates());
 ipcMain.handle('download-update', () => autoUpdater.downloadUpdate());
 ipcMain.handle('install-update', () => autoUpdater.quitAndInstall());
 
+// ── IPC: app control ─────────────────────────────────────
+ipcMain.handle('app-quit', () => { isQuitting = true; app.quit(); });
+
 // Forward updater events to renderer
 autoUpdater.on('update-available', (info) => {
   mainWindow.webContents.send('update-available', info);

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -11,6 +11,10 @@ contextBridge.exposeInMainWorld('tray', {
     onNavigateToToday: (cb) => ipcRenderer.on('navigate-to-today', () => cb()),
 });
 
+contextBridge.exposeInMainWorld('app', {
+    quit: () => ipcRenderer.invoke('app-quit'),
+});
+
 contextBridge.exposeInMainWorld('updater', {
     checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
     downloadUpdate: () => ipcRenderer.invoke('download-update'),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -668,6 +668,11 @@
           <i class="bi bi-clock me-3"></i>
           <span>Scheduled Tasks</span>
         </a>
+        <div class="sidebar-menu-divider"></div>
+        <a href="#" class="sidebar-menu-item sidebar-menu-item--danger" id="menu-exit">
+          <i class="bi bi-box-arrow-right me-3"></i>
+          <span>Exit</span>
+        </a>
       </div>
       
       <div class="sidebar-footer p-3 border-top border-secondary border-opacity-25 mt-auto">

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -48,6 +48,14 @@ export function initSidebar() {
         });
     }
 
+    const exitBtn = document.getElementById('menu-exit');
+    if (exitBtn) {
+        exitBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            window.app.quit();
+        });
+    }
+
     const updateBtn = document.getElementById('menu-check-updates');
     if (updateBtn) {
         updateBtn.addEventListener('click', (e) => {

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -44,6 +44,11 @@
   pointer-events: none;
 }
 
+.sidebar-menu-item--danger:hover {
+  border-left-color: var(--danger);
+  color: var(--danger);
+}
+
 .sidebar-menu-divider {
   height: 1px;
   background: var(--border);


### PR DESCRIPTION
## Summary
- Adds an **Exit** button at the bottom of the sidebar offcanvas menu
- Clicking it calls `app.quit()` via IPC, fully terminating the Electron process including the tray icon
- Button is visually distinct with a red hover accent (`.sidebar-menu-item--danger`)
- Complements the existing tray "Quit" option with an in-app equivalent

## Changes
| File | Change |
|------|--------|
| `src/main/index.js` | Added `ipcMain.handle('app-quit', ...)` — sets `isQuitting = true` then calls `app.quit()` |
| `src/preload/index.js` | Exposed `window.app.quit()` via new `contextBridge` namespace |
| `src/renderer/index.html` | Added `#menu-exit` item with divider at bottom of sidebar list |
| `src/renderer/modules/sidebar.js` | Wired click handler for `#menu-exit` in `initSidebar()` |
| `src/renderer/styles/sidebar.css` | Added `.sidebar-menu-item--danger:hover` with `var(--danger)` accent |

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Exit button appears at bottom of sidebar with a divider above it
- [ ] Clicking Exit fully terminates the process (tray icon disappears)
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #125

🤖 Generated with [Claude Code](https://claude.ai/claude-code)