### PR TITLE
feat(tm-123): add stats/insights modal with weekly, ticket, type and holiday breakdowns

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -655,6 +655,66 @@
     </div>
   </div>
 
+  <!-- STATS MODAL -->
+  <div class="modal fade" id="statsModal" tabindex="-1" aria-labelledby="statsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content modal-dark">
+        <div class="modal-header">
+          <h5 class="modal-title" id="statsModalLabel"><i class="bi bi-bar-chart-line me-2"></i>Stats &amp; Insights</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="stats-toolbar">
+            <ul class="stats-tabs" id="stats-tab-list">
+              <li><button class="stats-tab active" data-tab="weekly">Weekly</button></li>
+              <li><button class="stats-tab" data-tab="tickets">Tickets</button></li>
+              <li><button class="stats-tab" data-tab="types">By Type</button></li>
+              <li><button class="stats-tab" data-tab="holidays">Holidays</button></li>
+            </ul>
+            <div class="stats-filter-tabs">
+              <button class="stats-filter-btn active" data-range="4">4W</button>
+              <button class="stats-filter-btn" data-range="8">8W</button>
+              <button class="stats-filter-btn" data-range="0">All</button>
+            </div>
+          </div>
+
+          <div class="stats-tab-panel active" id="stats-panel-weekly">
+            <table class="stats-table">
+              <thead><tr><th>Week</th><th>Days Worked</th><th>Total Hours</th></tr></thead>
+              <tbody id="stats-weekly-tbody"></tbody>
+            </table>
+          </div>
+
+          <div class="stats-tab-panel" id="stats-panel-tickets">
+            <table class="stats-table">
+              <thead><tr><th>#</th><th>Ticket</th><th>Entries</th><th>Total Hours</th></tr></thead>
+              <tbody id="stats-tickets-tbody"></tbody>
+            </table>
+          </div>
+
+          <div class="stats-tab-panel" id="stats-panel-types">
+            <div id="stats-types-list"></div>
+          </div>
+
+          <div class="stats-tab-panel" id="stats-panel-holidays">
+            <table class="stats-table">
+              <thead><tr><th>Leave Type</th><th>Days</th></tr></thead>
+              <tbody id="stats-holidays-tbody"></tbody>
+            </table>
+            <div class="stats-section-title" style="margin-top:20px">Leave History</div>
+            <table class="stats-table">
+              <thead><tr><th>Date</th><th>Leave Type</th></tr></thead>
+              <tbody id="stats-holidays-history-tbody"></tbody>
+            </table>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-gradient px-4" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- PRINT AREA (hidden, used for window.print) -->
   <div id="print-area" style="display:none"></div>
   
@@ -669,6 +729,10 @@
         <a href="#" class="sidebar-menu-item" id="menu-settings">
           <i class="bi bi-gear me-3"></i>
           <span>Settings</span>
+        </a>
+        <a href="#" class="sidebar-menu-item" id="menu-stats">
+          <i class="bi bi-bar-chart-line me-3"></i>
+          <span>Stats &amp; Insights</span>
         </a>
         <div class="sidebar-menu-divider"></div>
         <a href="#" class="sidebar-menu-item" id="menu-starred">

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -24,6 +24,7 @@ import { updateSummary } from './modules/summary.js';
 import { initOnboarding, needsOnboarding, showOnboarding } from './modules/onboarding.js';
 import { initNoTicketBanner, updateNoTicketBanner } from './modules/no-ticket-reminder.js';
 import { initUnderloggedBanner, updateUnderloggedBanner } from './modules/underlogged-reminder.js';
+import { initStats } from './modules/stats.js';
 import { setCurrentWeek } from './modules/week.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -35,6 +36,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initNoTicketBanner();
     initUnderloggedBanner();
     initSidebar();
+    initStats();
     initUpdater();
     initContextMenu();
     initSearch();

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -272,7 +272,7 @@ export function buildDayCard(day, dayIdx) {
         }
     });
 
-    wrap.querySelector('.day-notes-open-btn').addEventListener('click', () => openDayNotesModal(dayIdx));
+    wrap.querySelector('.day-notes-open-btn')?.addEventListener('click', () => openDayNotesModal(dayIdx));
 
     const cb = wrap.querySelector(`#holiday-${dayIdx}`);
     const lbl = wrap.querySelector(`#holiday-label-${dayIdx}`);

--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -102,15 +102,7 @@ export function generateDayTxt(day, useHHMM = false) {
         }
     }
 
-    if (!day.isHoliday && day.notes) {
-        const noteLines = day.notes.split(/\r?\n/);
-        const labelStr = 'Notes: ';
-        const contIndent = indent + ' '.repeat(labelStr.length);
-        lines.push(`${indent}${labelStr}${noteLines[0]}`);
-        for (let i = 1; i < noteLines.length; i++) {
-            lines.push(`${contIndent}${noteLines[i]}`);
-        }
-    }
+
 
     return lines.join('\r\n');
 }

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -4,6 +4,7 @@ import { escHtml } from './utils.js';
 import { renderStarredList } from './star.js';
 import { saveEntry, openEntryModal } from './entry-modal.js';
 import { toggleDay, renderAll, openDayNotesModal } from './render.js';
+import { openStatsModal } from './stats.js';
 import { changeWeekBy, setCurrentWeek } from './week.js';
 import { updateSummary } from './summary.js';
 import { openPreview, openDayQuickView, doPrint } from './report.js';
@@ -25,6 +26,15 @@ export function initSidebar() {
             e.preventDefault();
             closeSidebar();
             openSettings();
+        });
+    }
+
+    const statsBtn = document.getElementById('menu-stats');
+    if (statsBtn) {
+        statsBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            closeSidebar();
+            openStatsModal();
         });
     }
 

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -1,0 +1,207 @@
+import { state } from './state.js';
+import { escHtml, minsToHHMM } from './utils.js';
+import { getWeekStrFromDate, getDateFromWeek } from './week.js';
+
+let _statsModal = null;
+let _currentRange = 4;
+let _currentTab = 'weekly';
+
+export function initStats() {
+    _statsModal = new bootstrap.Modal(document.getElementById('statsModal'));
+
+    document.querySelectorAll('.stats-filter-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.stats-filter-btn').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            _currentRange = parseInt(btn.dataset.range);
+            renderCurrentTab();
+        });
+    });
+
+    document.querySelectorAll('.stats-tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+            document.querySelectorAll('.stats-tab').forEach(t => t.classList.remove('active'));
+            document.querySelectorAll('.stats-tab-panel').forEach(p => p.classList.remove('active'));
+            tab.classList.add('active');
+            _currentTab = tab.dataset.tab;
+            document.getElementById(`stats-panel-${_currentTab}`)?.classList.add('active');
+            renderCurrentTab();
+        });
+    });
+}
+
+export function openStatsModal() {
+    _currentRange = 4;
+    _currentTab = 'weekly';
+    document.querySelectorAll('.stats-filter-btn').forEach(b => b.classList.remove('active'));
+    document.querySelector('.stats-filter-btn[data-range="4"]')?.classList.add('active');
+    document.querySelectorAll('.stats-tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.stats-tab-panel').forEach(p => p.classList.remove('active'));
+    document.querySelector('.stats-tab[data-tab="weekly"]')?.classList.add('active');
+    document.getElementById('stats-panel-weekly')?.classList.add('active');
+    renderCurrentTab();
+    _statsModal.show();
+}
+
+function getFilteredDays(rangeWeeks) {
+    const allDays = Object.values(state.allDaysByDate).filter(d => d && d.date);
+    if (rangeWeeks === 0) return allDays;
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - rangeWeeks * 7);
+    const cutoffStr = cutoff.toISOString().slice(0, 10);
+    return allDays.filter(d => d.date >= cutoffStr);
+}
+
+function fmtWeekLabel(weekStr) {
+    try {
+        const mon = getDateFromWeek(weekStr);
+        const fri = new Date(mon);
+        fri.setDate(mon.getDate() + 4);
+        const fmt = d => d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+        return `${fmt(mon)} – ${fmt(fri)}`;
+    } catch {
+        return weekStr;
+    }
+}
+
+function renderCurrentTab() {
+    const days = getFilteredDays(_currentRange);
+    switch (_currentTab) {
+        case 'weekly':   renderWeeklyTable(days); break;
+        case 'tickets':  renderTicketsTable(days); break;
+        case 'types':    renderTypesBreakdown(days); break;
+        case 'holidays': renderHolidays(days); break;
+    }
+}
+
+function renderWeeklyTable(days) {
+    const weekMap = {};
+    days.forEach(day => {
+        const weekStr = getWeekStrFromDate(new Date(day.date + 'T00:00:00'));
+        if (!weekMap[weekStr]) weekMap[weekStr] = { totalMins: 0, daysWorked: 0 };
+        const dayMins = (day.entries || []).reduce((s, e) => s + (e.hh || 0) * 60 + (e.mm || 0), 0);
+        if (dayMins > 0) weekMap[weekStr].daysWorked++;
+        weekMap[weekStr].totalMins += dayMins;
+    });
+
+    const weeks = Object.keys(weekMap).sort().reverse();
+    const tbody = document.getElementById('stats-weekly-tbody');
+    if (!weeks.length) {
+        tbody.innerHTML = '<tr><td colspan="3" class="stats-empty">No data for this range</td></tr>';
+        return;
+    }
+    tbody.innerHTML = weeks.map(w => {
+        const { totalMins, daysWorked } = weekMap[w];
+        return `<tr>
+            <td>${escHtml(fmtWeekLabel(w))}</td>
+            <td>${daysWorked}</td>
+            <td class="stats-mono">${minsToHHMM(totalMins)}</td>
+        </tr>`;
+    }).join('');
+}
+
+function renderTicketsTable(days) {
+    const ticketMap = {};
+    days.forEach(day => {
+        (day.entries || []).forEach(e => {
+            const key = e.noTicket ? 'NO TICKET' : (e.ticket || '—');
+            if (!ticketMap[key]) ticketMap[key] = { mins: 0, count: 0 };
+            ticketMap[key].mins += (e.hh || 0) * 60 + (e.mm || 0);
+            ticketMap[key].count++;
+        });
+    });
+
+    const tickets = Object.entries(ticketMap).sort((a, b) => b[1].mins - a[1].mins).slice(0, 25);
+    const tbody = document.getElementById('stats-tickets-tbody');
+    if (!tickets.length) {
+        tbody.innerHTML = '<tr><td colspan="4" class="stats-empty">No data for this range</td></tr>';
+        return;
+    }
+    tbody.innerHTML = tickets.map(([ticket, { mins, count }], i) => `<tr>
+        <td class="stats-rank">${i + 1}</td>
+        <td class="stats-mono">${escHtml(ticket)}</td>
+        <td>${count}</td>
+        <td class="stats-mono">${minsToHHMM(mins)}</td>
+    </tr>`).join('');
+}
+
+function renderTypesBreakdown(days) {
+    const typeMap = {};
+    days.forEach(day => {
+        (day.entries || []).forEach(e => {
+            const key = e.type || 'jira';
+            if (!typeMap[key]) typeMap[key] = 0;
+            typeMap[key] += (e.hh || 0) * 60 + (e.mm || 0);
+        });
+    });
+
+    const totalMins = Object.values(typeMap).reduce((s, v) => s + v, 0);
+    const types = Object.entries(typeMap).sort((a, b) => b[1] - a[1]);
+    const container = document.getElementById('stats-types-list');
+
+    if (!types.length) {
+        container.innerHTML = '<div class="stats-empty">No data for this range</div>';
+        return;
+    }
+    container.innerHTML = types.map(([type, mins]) => {
+        const pct = totalMins > 0 ? Math.round(mins / totalMins * 100) : 0;
+        const typeObj = state.ticketTypes?.find(t => t.id === type);
+        const label = typeObj?.label || 'Other';
+        const color = typeObj?.color || '#808080';
+        return `<div class="stats-type-row">
+            <span class="stats-type-label">${escHtml(label)}</span>
+            <div class="stats-type-bar-wrap">
+                <div class="stats-type-bar" style="width:${pct}%;background:${escHtml(color)}"></div>
+            </div>
+            <span class="stats-mono">${minsToHHMM(mins)}</span>
+            <span class="stats-type-pct">${pct}%</span>
+        </div>`;
+    }).join('');
+}
+
+function renderHolidays(days) {
+    const leaveDays = days.filter(d => d.isHoliday).sort((a, b) => b.date.localeCompare(a.date));
+
+    const getLabel = day => {
+        const typeObj = state.leaveTypes?.find(t => t.id === day.leaveTypeId);
+        return typeObj?.label || day.holidayLabel || 'Holiday';
+    };
+
+    // Summary by type
+    const leaveMap = {};
+    leaveDays.forEach(day => {
+        const label = getLabel(day);
+        if (!leaveMap[label]) leaveMap[label] = 0;
+        leaveMap[label]++;
+    });
+
+    const tbody = document.getElementById('stats-holidays-tbody');
+    const summaryEntries = Object.entries(leaveMap).sort((a, b) => b[1] - a[1]);
+
+    if (!summaryEntries.length) {
+        tbody.innerHTML = '<tr><td colspan="2" class="stats-empty">No leave days in this range</td></tr>';
+        document.getElementById('stats-holidays-history-tbody').innerHTML =
+            '<tr><td colspan="2" class="stats-empty">No leave days in this range</td></tr>';
+        return;
+    }
+
+    const total = summaryEntries.reduce((s, [, v]) => s + v, 0);
+    tbody.innerHTML = summaryEntries.map(([label, count]) => `<tr>
+        <td>${escHtml(label)}</td>
+        <td class="stats-mono">${count} day${count !== 1 ? 's' : ''}</td>
+    </tr>`).join('') + `<tr class="stats-total-row">
+        <td>Total</td>
+        <td class="stats-mono">${total} day${total !== 1 ? 's' : ''}</td>
+    </tr>`;
+
+    // History list (newest first)
+    const historyTbody = document.getElementById('stats-holidays-history-tbody');
+    historyTbody.innerHTML = leaveDays.map(day => {
+        const date = new Date(day.date + 'T00:00:00');
+        const fmtDate = date.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' });
+        return `<tr>
+            <td>${escHtml(fmtDate)}</td>
+            <td>${escHtml(getLabel(day))}</td>
+        </tr>`;
+    }).join('');
+}

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -19,3 +19,4 @@
 @import './search.css';
 @import './animations.css';
 @import './settings.css';
+@import './stats.css';

--- a/src/renderer/styles/stats.css
+++ b/src/renderer/styles/stats.css
@@ -1,0 +1,209 @@
+/* ── STATS & INSIGHTS ── */
+
+/* ── TOOLBAR (tabs + range filter) ── */
+
+.stats-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  gap: 12px;
+}
+
+.stats-tabs {
+  display: flex;
+  gap: 2px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
+  padding: 3px;
+}
+
+.stats-tab {
+  background: none;
+  border: none;
+  border-radius: calc(var(--radius-sm) - 2px);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 5px 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.stats-tab:hover {
+  color: var(--text-primary);
+}
+
+.stats-tab.active {
+  background: var(--bg-card);
+  color: var(--text-primary);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+}
+
+[data-theme="light"] .stats-tab.active {
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+}
+
+.stats-filter-tabs {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.stats-filter-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 4px 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.stats-filter-btn:hover {
+  border-color: var(--border-accent);
+  color: var(--text-primary);
+}
+
+.stats-filter-btn.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #111;
+}
+
+[data-theme="light"] .stats-filter-btn.active {
+  color: #fff;
+}
+
+[data-theme="light"] .stats-tabs {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="light"] .stats-tab.active {
+  background: #ffffff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] .stats-tab:not(.active):hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+/* ── TAB PANELS ── */
+
+.stats-tab-panel {
+  display: none;
+}
+
+.stats-tab-panel.active {
+  display: block;
+}
+
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.84rem;
+}
+
+.stats-table th {
+  text-align: left;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0 10px 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.stats-table td {
+  padding: 8px 10px 8px 0;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.stats-table tr:last-child td {
+  border-bottom: none;
+}
+
+.stats-table tr:hover td {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+[data-theme="light"] .stats-table tr:hover td {
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.stats-mono {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.82rem;
+  color: var(--text-primary);
+}
+
+.stats-rank {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  width: 28px;
+}
+
+.stats-empty {
+  color: var(--text-muted);
+  font-size: 0.83rem;
+  text-align: center;
+  padding: 16px 0;
+}
+
+.stats-total-row td {
+  font-weight: 600;
+  color: var(--text-primary);
+  border-top: 1px solid var(--border-accent) !important;
+  border-bottom: none !important;
+}
+
+/* ── TYPE BREAKDOWN ── */
+
+.stats-type-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.stats-type-row:last-child {
+  border-bottom: none;
+}
+
+.stats-type-label {
+  font-size: 0.83rem;
+  color: var(--text-primary);
+  min-width: 100px;
+}
+
+.stats-type-bar-wrap {
+  flex: 1;
+  height: 6px;
+  background: var(--border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.stats-type-bar {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.4s ease;
+  min-width: 2px;
+}
+
+.stats-type-pct {
+  font-size: 0.76rem;
+  color: var(--text-muted);
+  min-width: 36px;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- Add Stats & Insights modal accessible from the sidebar with tabbed navigation (Weekly / Tickets / By Type / Holidays)
- Range filter (Last 4W / 8W / All Time) applies to whichever tab is active
- Holidays tab shows a summary by leave type plus a full chronological leave history
- Also fixes holiday-day null-pointer bug from #124 (`?.` on notes button)

## Changes
| File | Change |
|------|--------|
| `src/renderer/modules/stats.js` | New module — data aggregation and rendering for all four tabs |
| `src/renderer/styles/stats.css` | New stylesheet — toolbar, segmented tabs, tables, type bar chart |
| `src/renderer/index.html` | Stats modal markup, sidebar menu item |
| `src/renderer/main.js` | Import and init stats module |
| `src/renderer/modules/sidebar.js` | Wire up `#menu-stats` click handler |
| `src/renderer/modules/render.js` | Fix null `querySelector` crash on holiday day cards |
| `src/renderer/modules/report.js` | Remove notes block from TXT output |
| `src/renderer/styles/main.css` | Import `stats.css` |

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #123

🤖 Generated with [Claude Code](https://claude.ai/claude-code)