### PR TITLE
feat(tm-129): add day status badge below date when card is expanded

### DIFF
--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -224,6 +224,30 @@ export function buildDayCard(day, dayIdx) {
         topRightBadge = `<span class="day-hours-total zero">No entries</span>`;
     }
 
+    const targetMins = state.dailyTargetMins || 480;
+    let statusBadge = '';
+    if (day.expanded && !day.isHoliday) {
+        const remaining = targetMins - totalMins;
+        let label, color;
+        if (totalMins === 0) {
+            const th = Math.floor(targetMins / 60), tm = targetMins % 60;
+            label = tm > 0 ? `${th}h ${tm}m left` : `${th}h left`;
+            color = 'var(--text-secondary)';
+        } else if (remaining > 0) {
+            const rh = Math.floor(remaining / 60), rm = remaining % 60;
+            label = rm > 0 ? `${rh}h ${rm}m left` : `${rh}h left`;
+            color = totalMins / targetMins < 0.8 ? 'var(--warning)' : 'var(--success)';
+        } else if (remaining === 0) {
+            label = 'Finished';
+            color = '#4ade80';
+        } else {
+            const oh = Math.floor(-remaining / 60), om = (-remaining) % 60;
+            label = om > 0 ? `+${oh}h ${om}m OT` : `+${oh}h OT`;
+            color = '#4ade80';
+        }
+        statusBadge = `<span class="day-status-badge" style="color:${color}">${label}</span>`;
+    }
+
     wrap.innerHTML = `
     <div class="day-card-header" data-day="${dayIdx}">
       <div class="day-badge">
@@ -231,6 +255,7 @@ export function buildDayCard(day, dayIdx) {
         <div>
           <div class="day-name">${dayName}</div>
           <div class="day-date">${displayDate}</div>
+          ${statusBadge}
         </div>
       </div>
       <div class="day-controls">

--- a/src/renderer/styles/cards.css
+++ b/src/renderer/styles/cards.css
@@ -136,6 +136,30 @@
   }
 }
 
+.day-progress-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.day-status-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  display: inline-block;
+  animation: statusBadgeFadeIn 0.25s ease both;
+}
+
+@keyframes statusBadgeFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .day-status-badge { animation: none; }
+}
+
 .day-name {
   font-weight: 600;
   font-size: 0.92rem;


### PR DESCRIPTION
## Summary
- Adds a status badge below the date in each day card header when the card is expanded
- Badge shows remaining time (`Xh XXm left`), `Finished`, or overtime (`+Xh XXm OT`)
- Badge is hidden when the card is collapsed; fades in with animation on expand
- Colour follows existing arc logic: warning (yellow) for <80% progress, success (green) for ≥80%, finished, and overtime

## Changes
- `src/renderer/modules/render.js` — added status label computation in `buildDayCard`; inserted `.day-status-badge` span below `.day-date`
- `src/renderer/styles/cards.css` — added `.day-status-badge` styles, `statusBadgeFadeIn` keyframe, and reduced-motion media query

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #129

🤖 Generated with [Claude Code](https://claude.ai/claude-code)