### PR TITLE
feat(tm-132): add Backup & Restore section to Settings navigation

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -874,6 +874,21 @@
                 <span>Error Logs</span>
               </div>
             </div>
+            <div class="settings-nav-item settings-nav-parent" data-section="backup-restore">
+              <i class="bi bi-shield-check"></i>
+              <span>Backup &amp; Restore</span>
+              <i class="bi bi-chevron-right settings-nav-chevron"></i>
+            </div>
+            <div class="settings-nav-sub" id="sub-backup-restore">
+              <div class="settings-nav-subitem" data-section="backup">
+                <i class="bi bi-cloud-arrow-up"></i>
+                <span>Backup</span>
+              </div>
+              <div class="settings-nav-subitem" data-section="restore">
+                <i class="bi bi-cloud-arrow-down"></i>
+                <span>Restore</span>
+              </div>
+            </div>
             <div class="settings-nav-item" data-section="about">
               <i class="bi bi-info-circle"></i>
               <span>About</span>

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -15,18 +15,22 @@ import { renderErrorLogSection } from './error-log.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
-    'general':       { parent: null,         label: 'General',       isParent: false },
-    'appearance':    { parent: null,         label: 'Appearance',    isParent: false },
-    'notifications': { parent: null,         label: 'Notifications', isParent: false },
-    'management':    { parent: null,         label: 'Management',    isParent: true  },
-    'ticket-types':  { parent: 'management', label: 'Ticket Types',  isParent: false },
-    'leave-types':   { parent: 'management', label: 'Leave Types',   isParent: false },
-    'developer':     { parent: null,         label: 'Developer',     isParent: true  },
-    'error-logs':    { parent: 'developer',  label: 'Error Logs',    isParent: false },
-    'about':         { parent: null,         label: 'About',         isParent: false },
+    'general':        { parent: null,             label: 'General',           isParent: false },
+    'appearance':     { parent: null,             label: 'Appearance',        isParent: false },
+    'notifications':  { parent: null,             label: 'Notifications',     isParent: false },
+    'management':     { parent: null,             label: 'Management',        isParent: true  },
+    'ticket-types':   { parent: 'management',     label: 'Ticket Types',      isParent: false },
+    'leave-types':    { parent: 'management',     label: 'Leave Types',       isParent: false },
+    'developer':      { parent: null,             label: 'Developer',         isParent: true  },
+    'error-logs':     { parent: 'developer',      label: 'Error Logs',        isParent: false },
+    'backup-restore': { parent: null,             label: 'Backup & Restore',  isParent: true  },
+    'backup':         { parent: 'backup-restore', label: 'Backup',            isParent: false },
+    'restore':        { parent: 'backup-restore', label: 'Restore',           isParent: false },
+    'about':          { parent: null,             label: 'About',             isParent: false },
 };
 
-const NOTIFICATION_KEY = 'notificationSettings';
+const NOTIFICATION_KEY   = 'notificationSettings';
+const BACKUP_SETTINGS_KEY = 'backupSettings';
 
 /* ── STATE ──────────────────────────────────────────────── */
 let currentSection = 'general';
@@ -183,9 +187,12 @@ function renderSection(section) {
         case 'management':     return renderManagement(el);
         case 'ticket-types': return renderTicketTypes(el);
         case 'leave-types':  return renderLeaveTypes(el);
-        case 'developer':    return renderDeveloper(el);
-        case 'error-logs':   return renderErrorLogs(el);
-        case 'about':        return renderAbout(el);
+        case 'developer':      return renderDeveloper(el);
+        case 'error-logs':     return renderErrorLogs(el);
+        case 'backup-restore': return renderBackupRestore(el);
+        case 'backup':         return renderBackup(el);
+        case 'restore':        return renderRestore(el);
+        case 'about':          return renderAbout(el);
     }
 }
 
@@ -436,6 +443,210 @@ function renderDeveloper(el) {
 
 function renderErrorLogs(el) {
     renderErrorLogSection(el, navigateTo);
+}
+
+/* ── BACKUP & RESTORE ────────────────────────────────────── */
+
+function renderBackupRestore(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Backup &amp; Restore</h2>
+            <p class="settings-section-desc">Protect your data and recover from a backup when needed.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="settings-mgmt-cards">
+                <div class="settings-mgmt-card" data-nav="backup">
+                    <div class="settings-mgmt-card-icon">
+                        <i class="bi bi-cloud-arrow-up-fill"></i>
+                    </div>
+                    <div class="settings-mgmt-card-body">
+                        <div class="settings-mgmt-card-title">Backup</div>
+                        <div class="settings-mgmt-card-desc">Manually back up your data or configure automatic scheduled backups</div>
+                    </div>
+                    <i class="bi bi-chevron-right settings-mgmt-card-arrow"></i>
+                </div>
+                <div class="settings-mgmt-card" data-nav="restore">
+                    <div class="settings-mgmt-card-icon">
+                        <i class="bi bi-cloud-arrow-down-fill"></i>
+                    </div>
+                    <div class="settings-mgmt-card-body">
+                        <div class="settings-mgmt-card-title">Restore</div>
+                        <div class="settings-mgmt-card-desc">Restore timesheet data from a JSON backup or a downloaded TXT report</div>
+                    </div>
+                    <i class="bi bi-chevron-right settings-mgmt-card-arrow"></i>
+                </div>
+            </div>
+        </div>`;
+    el.querySelectorAll('.settings-mgmt-card[data-nav]').forEach(card => {
+        card.addEventListener('click', () => navigateTo(card.dataset.nav));
+    });
+}
+
+async function renderBackup(el) {
+    const saved          = await window.electronStore.get(BACKUP_SETTINGS_KEY) || {};
+    const enabled        = saved.enabled !== false;
+    const frequency      = saved.frequency || 'weekly';
+    const dayOfWeek      = saved.dayOfWeek ?? 1;
+    const hour           = saved.hour ?? 9;
+    const minute         = saved.minute ?? 0;
+    const retentionDays  = saved.retentionDays ?? 30;
+    const lastBackupAt   = saved.lastBackupAt || null;
+    const folder         = saved.folder || '';
+    const timeVal        = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Backup</h2>
+            <p class="settings-section-desc">Save a copy of all your timesheet data to a local file.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="settings-form">
+                <div class="settings-form-group">
+                    <label class="label-text">Manual Backup</label>
+                    <button class="btn btn-gradient px-4" id="btn-backup-now" disabled>
+                        <i class="bi bi-cloud-arrow-up me-1"></i> Backup Now
+                    </button>
+                    <p class="form-text mt-1" style="color:var(--text-secondary)">
+                        ${lastBackupAt
+                            ? `Last backup: ${new Date(lastBackupAt).toLocaleString()}`
+                            : 'No backups created yet.'}
+                    </p>
+                </div>
+                <hr class="settings-divider">
+                <div class="settings-form-group">
+                    <label class="label-text">Auto-backup</label>
+                    <div class="form-check form-switch mt-1">
+                        <input class="form-check-input" type="checkbox" id="backup-enabled" ${enabled ? 'checked' : ''} />
+                        <label class="form-check-label label-text" for="backup-enabled">
+                            Automatically back up on app launch
+                        </label>
+                    </div>
+                </div>
+                <div id="backup-auto-config" style="${enabled ? '' : 'opacity:0.4;pointer-events:none'}">
+                    <div class="settings-form d-flex flex-column gap-4">
+                        <div class="settings-form-group">
+                            <label class="label-text" for="backup-frequency">Frequency</label>
+                            <select id="backup-frequency" class="form-control dark-input" style="max-width:180px">
+                                <option value="daily"   ${frequency === 'daily'   ? 'selected' : ''}>Daily</option>
+                                <option value="weekly"  ${frequency === 'weekly'  ? 'selected' : ''}>Weekly</option>
+                                <option value="monthly" ${frequency === 'monthly' ? 'selected' : ''}>Monthly</option>
+                            </select>
+                        </div>
+                        <div class="settings-form-group" id="backup-dow-group" style="${frequency === 'weekly' ? '' : 'display:none'}">
+                            <label class="label-text" for="backup-dow">Day of Week</label>
+                            <select id="backup-dow" class="form-control dark-input" style="max-width:180px">
+                                <option value="1" ${dayOfWeek === 1 ? 'selected' : ''}>Monday</option>
+                                <option value="2" ${dayOfWeek === 2 ? 'selected' : ''}>Tuesday</option>
+                                <option value="3" ${dayOfWeek === 3 ? 'selected' : ''}>Wednesday</option>
+                                <option value="4" ${dayOfWeek === 4 ? 'selected' : ''}>Thursday</option>
+                                <option value="5" ${dayOfWeek === 5 ? 'selected' : ''}>Friday</option>
+                            </select>
+                        </div>
+                        <div class="settings-form-group">
+                            <label class="label-text" for="backup-time">Check Time (on app launch)</label>
+                            <input type="time" id="backup-time" class="form-control dark-input" value="${timeVal}" style="max-width:140px" />
+                            <p class="form-text" style="color:var(--text-secondary)">
+                                Auto-backup runs when the app is launched at or after this time on the scheduled day.
+                            </p>
+                        </div>
+                        <div class="settings-form-group">
+                            <label class="label-text" for="backup-retention">Retain backups for</label>
+                            <div class="d-flex align-items-center gap-2">
+                                <input type="number" id="backup-retention" class="form-control dark-input text-center"
+                                    min="1" max="30" value="${retentionDays}" style="max-width:72px" />
+                                <span class="label-text">days &nbsp;<span style="color:var(--text-muted);font-size:0.8rem">(max 30)</span></span>
+                            </div>
+                        </div>
+                        <div class="settings-form-group">
+                            <label class="label-text">Backup Folder</label>
+                            <div class="d-flex align-items-center gap-2 flex-wrap">
+                                <span id="backup-folder-display" style="color:var(--text-secondary);font-size:0.82rem;word-break:break-all">
+                                    ${folder || 'Default: Documents/TimesheetBackups'}
+                                </span>
+                                <button class="btn btn-sm btn-outline-light" id="btn-backup-folder" disabled>
+                                    <i class="bi bi-folder me-1"></i> Change
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="settings-form-actions">
+                    <button class="btn btn-gradient px-4" id="btn-save-backup">
+                        <i class="bi bi-check-lg me-1"></i> Save
+                    </button>
+                </div>
+            </div>
+        </div>`;
+
+    const enabledToggle = el.querySelector('#backup-enabled');
+    const autoConfig    = el.querySelector('#backup-auto-config');
+    const freqSelect    = el.querySelector('#backup-frequency');
+    const dowGroup      = el.querySelector('#backup-dow-group');
+
+    enabledToggle.addEventListener('change', () => {
+        autoConfig.style.opacity       = enabledToggle.checked ? '1' : '0.4';
+        autoConfig.style.pointerEvents = enabledToggle.checked ? '' : 'none';
+        markDirty('backup');
+    });
+
+    freqSelect.addEventListener('change', () => {
+        dowGroup.style.display = freqSelect.value === 'weekly' ? '' : 'none';
+        markDirty('backup');
+    });
+
+    el.querySelector('#backup-time').addEventListener('change', () => markDirty('backup'));
+    el.querySelector('#backup-retention').addEventListener('input', () => markDirty('backup'));
+
+    el.querySelector('#btn-save-backup').addEventListener('click', async () => {
+        const [hh, mm]   = (el.querySelector('#backup-time').value || '09:00').split(':').map(Number);
+        const retention  = Math.min(30, Math.max(1, parseInt(el.querySelector('#backup-retention').value) || 30));
+        const dowEl      = el.querySelector('#backup-dow');
+        const current    = await window.electronStore.get(BACKUP_SETTINGS_KEY) || {};
+        await window.electronStore.set(BACKUP_SETTINGS_KEY, {
+            ...current,
+            enabled:        el.querySelector('#backup-enabled').checked,
+            frequency:      freqSelect.value,
+            dayOfWeek:      dowEl ? parseInt(dowEl.value) : 1,
+            hour:           hh || 9,
+            minute:         mm || 0,
+            retentionDays:  retention,
+        });
+        clearDirty();
+        showToast('Backup settings saved.', 'success');
+    });
+}
+
+function renderRestore(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Restore</h2>
+            <p class="settings-section-desc">Restore your timesheet data from a previously exported file.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="settings-form">
+                <div class="settings-form-group">
+                    <label class="label-text">Restore from Backup File</label>
+                    <p class="form-text" style="color:var(--text-secondary)">
+                        Import a <code>.json</code> backup file exported by this app.
+                        If the backup contains weeks you already have data for, you'll be shown a side-by-side merge review before anything is applied.
+                    </p>
+                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-json" disabled>
+                        <i class="bi bi-file-earmark-code me-1"></i> Choose Backup File (.json)
+                    </button>
+                </div>
+                <hr class="settings-divider">
+                <div class="settings-form-group">
+                    <label class="label-text">Restore from TXT Report</label>
+                    <p class="form-text" style="color:var(--text-secondary)">
+                        Import a <code>.txt</code> timesheet report downloaded from this app.
+                        Conflicting weeks will go through the same merge review as a JSON restore.
+                    </p>
+                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-txt" disabled>
+                        <i class="bi bi-file-earmark-text me-1"></i> Choose Report File (.txt)
+                    </button>
+                </div>
+            </div>
+        </div>`;
 }
 
 function _renderMarkdown(md) {

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -493,6 +493,14 @@
   padding: 6px 8px;
 }
 
+/* ── BACKUP & RESTORE ── */
+
+.settings-divider {
+  border-color: var(--border);
+  opacity: 1;
+  margin: 4px 0;
+}
+
 /* ── ABOUT ── */
 
 .about-app-card {


### PR DESCRIPTION
## Summary
- Adds **Backup & Restore** as a collapsible parent section in the Settings modal nav, with **Backup** and **Restore** as child pages
- Backup page includes manual backup button, auto-backup toggle, and full schedule config (frequency, day of week, time, retention) — settings persisted to `backupSettings` in electron-store
- Restore page has two clearly described entry points: restore from `.json` backup and restore from `.txt` report
- Buttons that depend on unimplemented engines (#133, #134, #135) are rendered but disabled

## Changes
- `src/renderer/index.html` — added Backup & Restore parent nav item + Backup/Restore sub-items
- `src/renderer/modules/settings.js` — added `backup-restore`, `backup`, `restore` to `SECTION_META`; added `BACKUP_SETTINGS_KEY`; added `renderBackupRestore()`, `renderBackup()`, `renderRestore()` functions; wired into `renderSection()` switch
- `src/renderer/styles/settings.css` — added `.settings-divider` class for section separators

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Backup & Restore appears in Settings nav and expands correctly
- [ ] Backup sub-page renders with all config fields
- [ ] Restore sub-page renders with both buttons
- [ ] Save in Backup page persists to electron-store under `backupSettings`
- [ ] Navigating away with unsaved changes triggers dirty-state guard
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #132

🤖 Generated with [Claude Code](https://claude.ai/claude-code)