### PR TITLE
feat(tm-133): add backup engine with manual backup and auto-backup

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,12 +1,101 @@
-const { app, BrowserWindow, Menu, shell, ipcMain, screen, Tray, nativeImage, Notification } = require('electron');
+const { app, BrowserWindow, Menu, shell, ipcMain, screen, Tray, nativeImage, Notification, dialog } = require('electron');
 const path = require('path');
+const fs   = require('fs');
 const Store = require('electron-store');
 const { autoUpdater } = require('electron-updater');
 
 const store = new Store();
-const WINDOW_BOUNDS_KEY = 'windowBounds';
-const LS_KEY = 'timesheetState_v1';
-const NOTIFICATION_KEY = 'notificationSettings';
+const WINDOW_BOUNDS_KEY   = 'windowBounds';
+const LS_KEY              = 'timesheetState_v1';
+const NOTIFICATION_KEY    = 'notificationSettings';
+const BACKUP_SETTINGS_KEY = 'backupSettings';
+
+// ── BACKUP HELPERS ───────────────────────────────────────
+function getDefaultBackupFolder() {
+  return path.join(app.getPath('documents'), 'TimesheetBackups');
+}
+
+function getBackupFolder() {
+  const settings = store.get(BACKUP_SETTINGS_KEY) || {};
+  return settings.folder || getDefaultBackupFolder();
+}
+
+function writeBackupFile() {
+  const folder = getBackupFolder();
+  if (!fs.existsSync(folder)) fs.mkdirSync(folder, { recursive: true });
+
+  const now      = new Date();
+  const pad      = n => String(n).padStart(2, '0');
+  const stamp    = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+  const filePath = path.join(folder, `timesheet-backup-${stamp}.json`);
+
+  const backup = {
+    version:    app.getVersion(),
+    exportedAt: now.toISOString(),
+    data:       store.get(LS_KEY) || {},
+  };
+  fs.writeFileSync(filePath, JSON.stringify(backup, null, 2), 'utf8');
+
+  const settings = store.get(BACKUP_SETTINGS_KEY) || {};
+  store.set(BACKUP_SETTINGS_KEY, { ...settings, lastBackupAt: now.toISOString() });
+
+  return { filePath, exportedAt: now.toISOString() };
+}
+
+function pruneOldBackups() {
+  const folder = getBackupFolder();
+  if (!fs.existsSync(folder)) return;
+
+  const settings      = store.get(BACKUP_SETTINGS_KEY) || {};
+  const retentionDays = settings.retentionDays ?? 30;
+  const cutoff        = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+
+  fs.readdirSync(folder)
+    .filter(f => f.startsWith('timesheet-backup-') && f.endsWith('.json'))
+    .forEach(file => {
+      const filePath = path.join(folder, file);
+      try {
+        if (fs.statSync(filePath).mtimeMs < cutoff) fs.unlinkSync(filePath);
+      } catch (_) { /* skip */ }
+    });
+}
+
+function isBackupDue() {
+  const settings  = store.get(BACKUP_SETTINGS_KEY) || {};
+  if (settings.enabled === false) return false;
+
+  const frequency  = settings.frequency  || 'weekly';
+  const dayOfWeek  = settings.dayOfWeek  ?? 1;   // 1=Mon … 5=Fri (matches JS getDay())
+  const hour       = settings.hour       ?? 9;
+  const lastBackup = settings.lastBackupAt ? new Date(settings.lastBackupAt) : null;
+  const now        = new Date();
+
+  if (now.getHours() < hour) return false;
+  if (!lastBackup) return true;
+
+  if (frequency === 'daily') {
+    return lastBackup.toDateString() !== now.toDateString();
+  }
+  if (frequency === 'weekly') {
+    if (now.getDay() !== dayOfWeek) return false;
+    return lastBackup < new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  }
+  if (frequency === 'monthly') {
+    return lastBackup.getMonth() !== now.getMonth() ||
+           lastBackup.getFullYear() !== now.getFullYear();
+  }
+  return false;
+}
+
+function checkAutoBackup() {
+  try {
+    if (!isBackupDue()) return;
+    writeBackupFile();
+    pruneOldBackups();
+  } catch (e) {
+    console.warn('[backup] Auto-backup failed:', e.message);
+  }
+}
 
 // Disable auto-download — we control when to download
 autoUpdater.autoDownload = false;
@@ -178,6 +267,18 @@ ipcMain.handle('check-for-updates', () => autoUpdater.checkForUpdates());
 ipcMain.handle('download-update', () => autoUpdater.downloadUpdate());
 ipcMain.handle('install-update', () => autoUpdater.quitAndInstall());
 
+// ── IPC: backup ──────────────────────────────────────────
+ipcMain.handle('backup:export', () => writeBackupFile());
+ipcMain.handle('backup:get-folder', () => getBackupFolder());
+ipcMain.handle('backup:choose-folder', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    properties: ['openDirectory', 'createDirectory'],
+    title: 'Choose Backup Folder',
+  });
+  if (result.canceled || !result.filePaths.length) return null;
+  return result.filePaths[0];
+});
+
 // ── IPC: app control ─────────────────────────────────────
 ipcMain.handle('app-quit', () => { isQuitting = true; app.quit(); });
 
@@ -218,9 +319,10 @@ app.whenReady().then(() => {
   createTray();
   scheduleNotifications();
 
-  // Check for updates silently after window is ready
+  // Check for updates and run auto-backup silently after window is ready
   mainWindow.webContents.once('did-finish-load', () => {
     autoUpdater.checkForUpdates();
+    checkAutoBackup();
   });
 
   app.on('activate', function () {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -15,6 +15,12 @@ contextBridge.exposeInMainWorld('app', {
     quit: () => ipcRenderer.invoke('app-quit'),
 });
 
+contextBridge.exposeInMainWorld('backup', {
+    export:       () => ipcRenderer.invoke('backup:export'),
+    getFolder:    () => ipcRenderer.invoke('backup:get-folder'),
+    chooseFolder: () => ipcRenderer.invoke('backup:choose-folder'),
+});
+
 contextBridge.exposeInMainWorld('updater', {
     checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
     downloadUpdate: () => ipcRenderer.invoke('download-update'),

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -503,10 +503,10 @@ async function renderBackup(el) {
             <div class="settings-form">
                 <div class="settings-form-group">
                     <label class="label-text">Manual Backup</label>
-                    <button class="btn btn-gradient px-4" id="btn-backup-now" disabled>
+                    <button class="btn btn-gradient px-4" id="btn-backup-now">
                         <i class="bi bi-cloud-arrow-up me-1"></i> Backup Now
                     </button>
-                    <p class="form-text mt-1" style="color:var(--text-secondary)">
+                    <p class="form-text mt-1" id="backup-last-info" style="color:var(--text-secondary)">
                         ${lastBackupAt
                             ? `Last backup: ${new Date(lastBackupAt).toLocaleString()}`
                             : 'No backups created yet.'}
@@ -563,7 +563,7 @@ async function renderBackup(el) {
                                 <span id="backup-folder-display" style="color:var(--text-secondary);font-size:0.82rem;word-break:break-all">
                                     ${folder || 'Default: Documents/TimesheetBackups'}
                                 </span>
-                                <button class="btn btn-sm btn-outline-light" id="btn-backup-folder" disabled>
+                                <button class="btn btn-sm btn-outline-light" id="btn-backup-folder">
                                     <i class="bi bi-folder me-1"></i> Change
                                 </button>
                             </div>
@@ -596,6 +596,29 @@ async function renderBackup(el) {
 
     el.querySelector('#backup-time').addEventListener('change', () => markDirty('backup'));
     el.querySelector('#backup-retention').addEventListener('input', () => markDirty('backup'));
+
+    el.querySelector('#btn-backup-now').addEventListener('click', async () => {
+        const btn = el.querySelector('#btn-backup-now');
+        btn.disabled = true;
+        try {
+            const result = await window.backup.export();
+            el.querySelector('#backup-last-info').textContent =
+                `Last backup: ${new Date(result.exportedAt).toLocaleString()}`;
+            showToast(`Backup saved to ${result.filePath}`, 'success');
+        } catch (e) {
+            showToast('Backup failed. Check error logs.', 'error');
+        } finally {
+            btn.disabled = false;
+        }
+    });
+
+    el.querySelector('#btn-backup-folder').addEventListener('click', async () => {
+        const chosen = await window.backup.chooseFolder();
+        if (!chosen) return;
+        const current = await window.electronStore.get(BACKUP_SETTINGS_KEY) || {};
+        await window.electronStore.set(BACKUP_SETTINGS_KEY, { ...current, folder: chosen });
+        el.querySelector('#backup-folder-display').textContent = chosen;
+    });
 
     el.querySelector('#btn-save-backup').addEventListener('click', async () => {
         const [hh, mm]   = (el.querySelector('#backup-time').value || '09:00').split(':').map(Number);


### PR DESCRIPTION
## Summary
- Backup engine inlined directly in `main/index.js` (required by electron-vite's single-bundle build — separate files aren't resolved at runtime)
- Manual **Backup Now** button is fully functional: writes a timestamped `.json` file to the backup folder and updates the last-backup display
- Auto-backup runs silently on app launch when the configured schedule is due (daily / weekly on chosen day / monthly), gated by a configured hour
- Old backup files are pruned automatically after each backup run based on the retention setting (max 30 days)
- **Change Folder** button opens a system folder picker and immediately persists the new path to `backupSettings`

## Changes
- `src/main/index.js` — added `fs` import, `BACKUP_SETTINGS_KEY` constant, and inline helpers: `getBackupFolder`, `writeBackupFile`, `pruneOldBackups`, `isBackupDue`, `checkAutoBackup`; registered `backup:export`, `backup:get-folder`, `backup:choose-folder` IPC handlers; call `checkAutoBackup()` on `did-finish-load`
- `src/preload/index.js` — expose `window.backup` (`export`, `getFolder`, `chooseFolder`) via context bridge
- `src/renderer/modules/settings.js` — remove `disabled` from Backup Now and Change Folder buttons; add click handlers with loading state, toast feedback, and live UI updates

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Backup Now creates a valid `.json` file in Documents/TimesheetBackups
- [ ] Last backup time updates after manual backup
- [ ] Change Folder opens picker and updates display
- [ ] Auto-backup fires on Monday launch (or daily/monthly per config)
- [ ] Files older than retention period are pruned after backup
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #133

🤖 Generated with [Claude Code](https://claude.ai/claude-code)