### PR TITLE
feat(tm-134): add restore from JSON backup with conflict resolution

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -270,6 +270,16 @@ ipcMain.handle('install-update', () => autoUpdater.quitAndInstall());
 // ── IPC: backup ──────────────────────────────────────────
 ipcMain.handle('backup:export', () => writeBackupFile());
 ipcMain.handle('backup:get-folder', () => getBackupFolder());
+ipcMain.handle('backup:open-json', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    filters: [{ name: 'Backup Files', extensions: ['json'] }],
+    properties: ['openFile'],
+    title: 'Open Backup File',
+  });
+  if (result.canceled || !result.filePaths.length) return null;
+  const raw = fs.readFileSync(result.filePaths[0], 'utf8');
+  return JSON.parse(raw);
+});
 ipcMain.handle('backup:choose-folder', async () => {
   const result = await dialog.showOpenDialog(mainWindow, {
     properties: ['openDirectory', 'createDirectory'],

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -18,6 +18,7 @@ contextBridge.exposeInMainWorld('app', {
 contextBridge.exposeInMainWorld('backup', {
     export:       () => ipcRenderer.invoke('backup:export'),
     getFolder:    () => ipcRenderer.invoke('backup:get-folder'),
+    openJsonFile: () => ipcRenderer.invoke('backup:open-json'),
     chooseFolder: () => ipcRenderer.invoke('backup:choose-folder'),
 });
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -919,6 +919,28 @@
     </div>
   </div>
 
+  <!-- RESTORE CONFLICT MODAL -->
+  <div class="modal fade" id="restoreConflictModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+      <div class="modal-content rc-modal-content">
+        <div class="modal-header rc-modal-header">
+          <div>
+            <h5 class="modal-title rc-modal-title" id="rc-modal-title">Restore — Review Conflicts</h5>
+            <p class="rc-modal-subtitle" id="rc-modal-subtitle"></p>
+          </div>
+          <button type="button" class="btn-close btn-close-white" id="btn-rc-close" aria-label="Close"></button>
+        </div>
+        <div class="modal-body rc-modal-body" id="rc-modal-body"></div>
+        <div class="modal-footer rc-modal-footer">
+          <button class="btn btn-outline-light btn-sm px-3" id="btn-rc-cancel">Cancel</button>
+          <button class="btn btn-outline-light btn-sm px-3" id="btn-rc-back" style="display:none">Back</button>
+          <button class="btn btn-gradient px-4" id="btn-rc-preview">Preview Merge</button>
+          <button class="btn btn-gradient px-4" id="btn-rc-confirm" style="display:none">Confirm Restore</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="main.js"></script>
 </body>

--- a/src/renderer/modules/restore.js
+++ b/src/renderer/modules/restore.js
@@ -1,0 +1,419 @@
+/* =============================================================
+   RESTORE — JSON backup restore with conflict resolution
+   ============================================================= */
+
+import { state } from './state.js';
+import { saveState } from './store.js';
+import { showToast, showConfirm } from './toast.js';
+import { escHtml } from './utils.js';
+import { renderAll } from './render.js';
+import { updateSummary } from './summary.js';
+
+let _modalInst  = null;
+let _cleanDays  = {};
+let _resolutions = [];  // [{ date, currentDay, incomingDay, same[], conflicts[], mineOnly[], theirsOnly[] }]
+
+/* ── PUBLIC ENTRY POINT ─────────────────────────────────────── */
+export async function openRestoreFromJson() {
+    let parsed;
+    try {
+        parsed = await window.backup.openJsonFile();
+    } catch (e) {
+        showToast('Could not read file. Is this a valid backup?', 'danger');
+        return;
+    }
+    if (!parsed) return; // user cancelled
+
+    if (!parsed.data || typeof parsed.data !== 'object') {
+        showToast('Invalid backup file — missing data field.', 'danger');
+        return;
+    }
+
+    const incoming = parsed.data.allDaysByDate || {};
+    if (Object.keys(incoming).length === 0) {
+        showToast('Backup file contains no timesheet data.', 'danger');
+        return;
+    }
+
+    const { cleanDays, conflictDays } = _diffBackup(incoming);
+    const totalDays = Object.keys(cleanDays).length + conflictDays.length;
+
+    if (conflictDays.length === 0) {
+        showConfirm(
+            `Restore ${totalDays} day(s) from backup with no conflicts. Existing entries for these days will be overwritten. Proceed?`,
+            () => _applyRestore(cleanDays)
+        );
+        return;
+    }
+
+    _cleanDays   = cleanDays;
+    _resolutions = conflictDays.map(({ date, current, incoming: inc }) =>
+        _buildResolution(date, current, inc));
+    _showModal();
+}
+
+/* ── DIFF ───────────────────────────────────────────────────── */
+function _diffBackup(incoming) {
+    const current     = state.allDaysByDate;
+    const cleanDays   = {};
+    const conflictDays = [];
+
+    for (const [date, incomingDay] of Object.entries(incoming)) {
+        if (!incomingDay) continue;
+        const currentDay        = current[date];
+        const hasCurrentEntries = currentDay && (currentDay.entries || []).length > 0;
+
+        if (!hasCurrentEntries) {
+            cleanDays[date] = incomingDay;
+            continue;
+        }
+
+        if (_daysIdentical(currentDay, incomingDay)) {
+            cleanDays[date] = incomingDay;
+        } else {
+            conflictDays.push({ date, current: currentDay, incoming: incomingDay });
+        }
+    }
+
+    conflictDays.sort((a, b) => a.date < b.date ? -1 : 1);
+    return { cleanDays, conflictDays };
+}
+
+function _daysIdentical(a, b) {
+    const sort = arr => [...(arr || [])].sort((x, y) =>
+        JSON.stringify(x) < JSON.stringify(y) ? -1 : 1);
+    return JSON.stringify(sort(a.entries)) === JSON.stringify(sort(b.entries)) &&
+           !!a.isHoliday === !!b.isHoliday &&
+           (a.holidayLabel || '') === (b.holidayLabel || '');
+}
+
+function _entryKey(e) {
+    return `${(e.ticket || '').toLowerCase()}|${e.type || ''}`;
+}
+
+function _entriesIdentical(a, b) {
+    return a.ticket === b.ticket && a.hh === b.hh && a.mm === b.mm &&
+           a.type  === b.type   && (a.desc || '') === (b.desc || '');
+}
+
+function _buildResolution(date, currentDay, incomingDay) {
+    const currentEntries  = currentDay.entries  || [];
+    const incomingEntries = incomingDay.entries || [];
+
+    const same       = [];
+    const conflicts  = [];
+    const mineOnly   = [];
+    const theirsOnly = [];
+
+    const usedCurrentIdx  = new Set();
+    const usedIncomingIdx = new Set();
+
+    // Pass 1: exact matches → same (auto-kept)
+    incomingEntries.forEach((theirs, i) => {
+        const j = currentEntries.findIndex((mine, idx) =>
+            !usedCurrentIdx.has(idx) && _entriesIdentical(mine, theirs));
+        if (j >= 0) {
+            same.push(theirs);
+            usedCurrentIdx.add(j);
+            usedIncomingIdx.add(i);
+        }
+    });
+
+    // Pass 2: same ticket+type but different values → conflict
+    incomingEntries.forEach((theirs, i) => {
+        if (usedIncomingIdx.has(i)) return;
+        const key = _entryKey(theirs);
+        const j   = currentEntries.findIndex((mine, idx) =>
+            !usedCurrentIdx.has(idx) && _entryKey(mine) === key);
+        if (j >= 0) {
+            conflicts.push({ mine: currentEntries[j], theirs, choice: 'theirs' });
+            usedCurrentIdx.add(j);
+            usedIncomingIdx.add(i);
+        }
+    });
+
+    // Pass 3: remaining incoming → theirs-only (new in backup)
+    incomingEntries.forEach((entry, i) => {
+        if (!usedIncomingIdx.has(i)) theirsOnly.push({ entry, keep: true });
+    });
+
+    // Pass 4: remaining current → mine-only (removed in backup)
+    currentEntries.forEach((entry, j) => {
+        if (!usedCurrentIdx.has(j)) mineOnly.push({ entry, keep: false });
+    });
+
+    return { date, currentDay, incomingDay, same, conflicts, mineOnly, theirsOnly };
+}
+
+/* ── MODAL LIFECYCLE ────────────────────────────────────────── */
+function _showModal() {
+    const modalEl = document.getElementById('restoreConflictModal');
+    if (!_modalInst) {
+        _modalInst = new bootstrap.Modal(modalEl, { backdrop: 'static', keyboard: false });
+        document.getElementById('btn-rc-close').addEventListener('click',   () => _modalInst.hide());
+        document.getElementById('btn-rc-cancel').addEventListener('click',  () => _modalInst.hide());
+        document.getElementById('btn-rc-back').addEventListener('click',    _showConflictView);
+        document.getElementById('btn-rc-preview').addEventListener('click', _showPreviewView);
+        document.getElementById('btn-rc-confirm').addEventListener('click', _confirmRestore);
+    }
+    _showConflictView();
+    _modalInst.show();
+}
+
+function _showConflictView() {
+    const cleanCount    = Object.keys(_cleanDays).length;
+    const conflictCount = _resolutions.length;
+    document.getElementById('rc-modal-title').textContent    = 'Restore — Review Conflicts';
+    document.getElementById('rc-modal-subtitle').textContent =
+        `${conflictCount} day(s) need review · ${cleanCount} day(s) will merge automatically`;
+    document.getElementById('btn-rc-preview').style.display = '';
+    document.getElementById('btn-rc-confirm').style.display = 'none';
+    document.getElementById('btn-rc-back').style.display    = 'none';
+    _renderConflictBody();
+}
+
+function _showPreviewView() {
+    document.getElementById('rc-modal-title').textContent    = 'Restore — Preview';
+    document.getElementById('rc-modal-subtitle').textContent = 'Review the final result before applying.';
+    document.getElementById('btn-rc-preview').style.display = 'none';
+    document.getElementById('btn-rc-confirm').style.display = '';
+    document.getElementById('btn-rc-back').style.display    = '';
+    _renderPreviewBody();
+}
+
+/* ── CONFLICT BODY ──────────────────────────────────────────── */
+function _renderConflictBody() {
+    const body = document.getElementById('rc-modal-body');
+    const cleanCount = Object.keys(_cleanDays).length;
+
+    const daysHtml = _resolutions.map((res, dayIdx) => {
+        const hasChoices = res.conflicts.length > 0 || res.mineOnly.length > 0 || res.theirsOnly.length > 0;
+        return `
+        <div class="rc-day-block">
+            <div class="rc-day-header">
+                <span class="rc-day-label">${escHtml(_fmtDate(res.date))}</span>
+                ${hasChoices ? `
+                <div class="rc-day-shortcuts">
+                    <button class="btn btn-sm btn-outline-light rc-use-mine" data-day="${dayIdx}">Use all mine</button>
+                    <button class="btn btn-sm btn-outline-light rc-use-theirs" data-day="${dayIdx}">Use all theirs</button>
+                </div>` : ''}
+            </div>
+            <div class="rc-entries">
+                ${_renderSameEntries(res.same)}
+                ${res.conflicts.map((c, ci) => _renderConflictEntry(dayIdx, ci, c)).join('')}
+                ${res.mineOnly.map((m, mi) => _renderMineOnlyEntry(dayIdx, mi, m)).join('')}
+                ${res.theirsOnly.map((t, ti) => _renderTheirsOnlyEntry(dayIdx, ti, t)).join('')}
+            </div>
+        </div>`;
+    }).join('');
+
+    const cleanNote = cleanCount > 0 ? `
+        <div class="rc-clean-note">
+            <i class="bi bi-check-circle-fill me-2" style="color:var(--success)"></i>
+            ${cleanCount} additional day(s) will be merged automatically with no conflicts.
+        </div>` : '';
+
+    body.innerHTML = daysHtml + cleanNote;
+    _bindConflictEvents(body);
+}
+
+function _renderSameEntries(entries) {
+    return entries.map(e => `
+        <div class="rc-entry rc-entry-same">
+            <i class="bi bi-check2 rc-entry-icon" style="color:var(--success)"></i>
+            <span class="rc-entry-ticket">${escHtml(e.ticket || '—')}</span>
+            <span class="rc-entry-time">${escHtml(e.hh || '0')}h ${escHtml(e.mm || '00')}m</span>
+            <span class="rc-entry-type">${escHtml(e.type || '')}</span>
+            <span class="rc-entry-desc">${escHtml(e.desc || '')}</span>
+            <span class="rc-entry-badge rc-badge-same">Unchanged</span>
+        </div>`).join('');
+}
+
+function _renderConflictEntry(dayIdx, ci, { mine, theirs, choice }) {
+    return `
+    <div class="rc-entry-conflict">
+        <div class="rc-conflict-label">
+            <i class="bi bi-exclamation-triangle-fill me-1" style="color:var(--warning)"></i>
+            Conflict — ${escHtml(theirs.ticket || mine.ticket || '—')}
+        </div>
+        <div class="rc-conflict-sides">
+            <div class="rc-conflict-side ${choice === 'mine' || choice === 'both' ? 'rc-side-selected' : 'rc-side-dim'}">
+                <div class="rc-side-header">Current (mine)</div>
+                <div class="rc-side-entry">
+                    <span class="rc-entry-time">${escHtml(mine.hh || '0')}h ${escHtml(mine.mm || '00')}m</span>
+                    <span class="rc-entry-type">${escHtml(mine.type || '')}</span>
+                    <span class="rc-entry-desc">${escHtml(mine.desc || '')}</span>
+                </div>
+            </div>
+            <div class="rc-conflict-side ${choice === 'theirs' || choice === 'both' ? 'rc-side-selected' : 'rc-side-dim'}">
+                <div class="rc-side-header">Backup (theirs)</div>
+                <div class="rc-side-entry">
+                    <span class="rc-entry-time">${escHtml(theirs.hh || '0')}h ${escHtml(theirs.mm || '00')}m</span>
+                    <span class="rc-entry-type">${escHtml(theirs.type || '')}</span>
+                    <span class="rc-entry-desc">${escHtml(theirs.desc || '')}</span>
+                </div>
+            </div>
+        </div>
+        <div class="rc-conflict-actions">
+            <button class="btn btn-sm rc-choice-btn ${choice === 'mine'   ? 'active' : ''}" data-day="${dayIdx}" data-ci="${ci}" data-choice="mine">Keep Mine</button>
+            <button class="btn btn-sm rc-choice-btn ${choice === 'theirs' ? 'active' : ''}" data-day="${dayIdx}" data-ci="${ci}" data-choice="theirs">Keep Theirs</button>
+            <button class="btn btn-sm rc-choice-btn ${choice === 'both'   ? 'active' : ''}" data-day="${dayIdx}" data-ci="${ci}" data-choice="both">Keep Both</button>
+        </div>
+    </div>`;
+}
+
+function _renderMineOnlyEntry(dayIdx, mi, { entry, keep }) {
+    return `
+    <div class="rc-entry ${keep ? 'rc-entry-kept' : 'rc-entry-discarded'}">
+        <i class="bi bi-dash-circle rc-entry-icon" style="color:var(--text-muted)"></i>
+        <span class="rc-entry-ticket">${escHtml(entry.ticket || '—')}</span>
+        <span class="rc-entry-time">${escHtml(entry.hh || '0')}h ${escHtml(entry.mm || '00')}m</span>
+        <span class="rc-entry-type">${escHtml(entry.type || '')}</span>
+        <span class="rc-entry-desc">${escHtml(entry.desc || '')}</span>
+        <span class="rc-entry-badge rc-badge-mine">Mine only</span>
+        <button class="btn btn-sm rc-toggle-mine ${keep ? 'active' : ''}" data-day="${dayIdx}" data-mi="${mi}">
+            ${keep ? 'Keep' : 'Discard'}
+        </button>
+    </div>`;
+}
+
+function _renderTheirsOnlyEntry(dayIdx, ti, { entry, keep }) {
+    return `
+    <div class="rc-entry ${keep ? 'rc-entry-kept' : 'rc-entry-discarded'}">
+        <i class="bi bi-plus-circle rc-entry-icon" style="color:var(--accent-light)"></i>
+        <span class="rc-entry-ticket">${escHtml(entry.ticket || '—')}</span>
+        <span class="rc-entry-time">${escHtml(entry.hh || '0')}h ${escHtml(entry.mm || '00')}m</span>
+        <span class="rc-entry-type">${escHtml(entry.type || '')}</span>
+        <span class="rc-entry-desc">${escHtml(entry.desc || '')}</span>
+        <span class="rc-entry-badge rc-badge-theirs">New in backup</span>
+        <button class="btn btn-sm rc-toggle-theirs ${keep ? 'active' : ''}" data-day="${dayIdx}" data-ti="${ti}">
+            ${keep ? 'Include' : 'Skip'}
+        </button>
+    </div>`;
+}
+
+function _bindConflictEvents(body) {
+    body.querySelectorAll('.rc-use-mine').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const res = _resolutions[+btn.dataset.day];
+            res.conflicts.forEach(c  => { c.choice = 'mine'; });
+            res.mineOnly.forEach(m   => { m.keep   = true;   });
+            res.theirsOnly.forEach(t => { t.keep   = false;  });
+            _renderConflictBody();
+        });
+    });
+
+    body.querySelectorAll('.rc-use-theirs').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const res = _resolutions[+btn.dataset.day];
+            res.conflicts.forEach(c  => { c.choice = 'theirs'; });
+            res.mineOnly.forEach(m   => { m.keep   = false;    });
+            res.theirsOnly.forEach(t => { t.keep   = true;     });
+            _renderConflictBody();
+        });
+    });
+
+    body.querySelectorAll('.rc-choice-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            _resolutions[+btn.dataset.day].conflicts[+btn.dataset.ci].choice = btn.dataset.choice;
+            _renderConflictBody();
+        });
+    });
+
+    body.querySelectorAll('.rc-toggle-mine').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const m = _resolutions[+btn.dataset.day].mineOnly[+btn.dataset.mi];
+            m.keep = !m.keep;
+            _renderConflictBody();
+        });
+    });
+
+    body.querySelectorAll('.rc-toggle-theirs').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const t = _resolutions[+btn.dataset.day].theirsOnly[+btn.dataset.ti];
+            t.keep = !t.keep;
+            _renderConflictBody();
+        });
+    });
+}
+
+/* ── PREVIEW BODY ───────────────────────────────────────────── */
+function _renderPreviewBody() {
+    const body       = document.getElementById('rc-modal-body');
+    const merged     = _buildMergedDays();
+    const cleanCount = Object.keys(_cleanDays).length;
+
+    const resolvedHtml = _resolutions.map(res => {
+        const entries = merged[res.date]?.entries || [];
+        return `
+        <div class="rc-preview-day">
+            <div class="rc-preview-day-header">${escHtml(_fmtDate(res.date))}</div>
+            ${entries.length === 0
+                ? '<div class="rc-preview-entry rc-preview-empty">No entries</div>'
+                : entries.map(e => `
+                    <div class="rc-preview-entry">
+                        <span class="rc-entry-ticket">${escHtml(e.ticket || '—')}</span>
+                        <span class="rc-entry-time">${escHtml(e.hh || '0')}h ${escHtml(e.mm || '00')}m</span>
+                        <span class="rc-entry-type">${escHtml(e.type || '')}</span>
+                        <span class="rc-entry-desc">${escHtml(e.desc || '')}</span>
+                    </div>`).join('')}
+        </div>`;
+    }).join('');
+
+    body.innerHTML = `
+        <div class="rc-preview-summary">
+            <i class="bi bi-check2-all me-2" style="color:var(--success)"></i>
+            <strong>${_resolutions.length}</strong> conflict day(s) resolved &nbsp;·&nbsp;
+            <strong>${cleanCount}</strong> day(s) auto-merged &nbsp;·&nbsp;
+            <strong>${_resolutions.length + cleanCount}</strong> total days ready to restore
+        </div>
+        <p class="rc-preview-section-title">Resolved days — final entries</p>
+        ${resolvedHtml}
+        ${cleanCount > 0 ? `<div class="rc-clean-note mt-3"><i class="bi bi-check-circle-fill me-2" style="color:var(--success)"></i>${cleanCount} additional day(s) merged automatically.</div>` : ''}`;
+}
+
+/* ── MERGE & APPLY ──────────────────────────────────────────── */
+function _buildMergedDays() {
+    const merged = { ..._cleanDays };
+
+    for (const res of _resolutions) {
+        const entries = [
+            ...res.same,
+            ...res.conflicts.flatMap(c => {
+                if (c.choice === 'mine')   return [c.mine];
+                if (c.choice === 'theirs') return [c.theirs];
+                return [c.mine, c.theirs]; // both
+            }),
+            ...res.mineOnly.filter(m  => m.keep).map(m  => m.entry),
+            ...res.theirsOnly.filter(t => t.keep).map(t => t.entry),
+        ];
+        merged[res.date] = { ...res.incomingDay, entries };
+    }
+
+    return merged;
+}
+
+async function _confirmRestore() {
+    _modalInst.hide();
+    await _applyRestore(_buildMergedDays());
+}
+
+async function _applyRestore(mergedDays) {
+    try {
+        state.allDaysByDate = { ...state.allDaysByDate, ...mergedDays };
+        await saveState();
+        renderAll();
+        updateSummary();
+        showToast('Restore complete.', 'success');
+    } catch (e) {
+        showToast('Restore failed. Check error logs.', 'danger');
+    }
+}
+
+/* ── UTILS ──────────────────────────────────────────────────── */
+function _fmtDate(dateStr) {
+    try {
+        return new Date(dateStr + 'T00:00:00')
+            .toLocaleDateString(undefined, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+    } catch (_) { return dateStr; }
+}

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -12,6 +12,7 @@ import { applyTheme } from './theme.js';
 import { renderTicketTypesSection } from './ticket-types.js';
 import { renderLeaveTypesSection } from './leave-types.js';
 import { renderErrorLogSection } from './error-log.js';
+import { openRestoreFromJson } from './restore.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -653,7 +654,7 @@ function renderRestore(el) {
                         Import a <code>.json</code> backup file exported by this app.
                         If the backup contains weeks you already have data for, you'll be shown a side-by-side merge review before anything is applied.
                     </p>
-                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-json" disabled>
+                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-json">
                         <i class="bi bi-file-earmark-code me-1"></i> Choose Backup File (.json)
                     </button>
                 </div>
@@ -670,6 +671,8 @@ function renderRestore(el) {
                 </div>
             </div>
         </div>`;
+
+    el.querySelector('#btn-restore-json').addEventListener('click', () => openRestoreFromJson());
 }
 
 function _renderMarkdown(md) {

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -20,3 +20,4 @@
 @import './animations.css';
 @import './settings.css';
 @import './stats.css';
+@import './restore.css';

--- a/src/renderer/styles/restore.css
+++ b/src/renderer/styles/restore.css
@@ -1,0 +1,349 @@
+/* ── RESTORE CONFLICT MODAL ── */
+
+.rc-modal-content {
+  background: var(--bg-base);
+  border: 1px solid var(--border-accent);
+}
+
+.rc-modal-header {
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 24px;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.rc-modal-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 2px;
+}
+
+.rc-modal-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.rc-modal-body {
+  padding: 20px 24px;
+  background: var(--bg-base);
+}
+
+.rc-modal-footer {
+  background: var(--bg-card);
+  border-top: 1px solid var(--border);
+  padding: 12px 24px;
+  gap: 8px;
+}
+
+/* ── DAY BLOCKS ── */
+
+.rc-day-block {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  margin-bottom: 16px;
+  background: var(--bg-card);
+}
+
+.rc-day-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: var(--bg-card-hover);
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.rc-day-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.rc-day-shortcuts {
+  display: flex;
+  gap: 6px;
+}
+
+.rc-day-shortcuts .btn {
+  font-size: 0.75rem;
+  padding: 2px 10px;
+  opacity: 0.8;
+}
+
+.rc-day-shortcuts .btn:hover {
+  opacity: 1;
+}
+
+/* ── ENTRY ROWS ── */
+
+.rc-entries {
+  display: flex;
+  flex-direction: column;
+}
+
+.rc-entry {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+  font-size: 0.83rem;
+}
+
+.rc-entry:last-child {
+  border-bottom: none;
+}
+
+.rc-entry-same {
+  opacity: 0.6;
+}
+
+.rc-entry-kept {
+  background: rgba(34, 211, 160, 0.04);
+}
+
+.rc-entry-discarded {
+  opacity: 0.4;
+  text-decoration: line-through;
+}
+
+.rc-entry-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.rc-entry-ticket {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  min-width: 80px;
+}
+
+.rc-entry-time {
+  color: var(--accent-light);
+  font-size: 0.8rem;
+  min-width: 60px;
+}
+
+.rc-entry-type {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  min-width: 70px;
+}
+
+.rc-entry-desc {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rc-entry-badge {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-radius: 4px;
+  padding: 1px 6px;
+  flex-shrink: 0;
+}
+
+.rc-badge-same {
+  background: rgba(100, 116, 139, 0.15);
+  color: var(--text-muted);
+}
+
+.rc-badge-mine {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.rc-badge-theirs {
+  background: rgba(34, 211, 160, 0.12);
+  color: var(--success);
+}
+
+/* ── CONFLICT ENTRY ── */
+
+.rc-entry-conflict {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(251, 191, 36, 0.04);
+}
+
+.rc-entry-conflict:last-child {
+  border-bottom: none;
+}
+
+.rc-conflict-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--warning, #fbbf24);
+  margin-bottom: 8px;
+}
+
+.rc-conflict-sides {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.rc-conflict-side {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.rc-side-selected {
+  border-color: var(--success);
+  background: rgba(34, 211, 160, 0.06);
+}
+
+.rc-side-dim {
+  opacity: 0.45;
+}
+
+.rc-side-header {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.rc-side-entry {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 0.82rem;
+}
+
+.rc-conflict-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.rc-choice-btn {
+  font-size: 0.75rem;
+  padding: 3px 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 20px;
+  transition: all 0.15s;
+}
+
+.rc-choice-btn:hover {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.rc-choice-btn.active {
+  border-color: var(--success);
+  background: rgba(34, 211, 160, 0.12);
+  color: var(--success);
+  font-weight: 600;
+}
+
+/* ── MINE/THEIRS TOGGLE BUTTONS ── */
+
+.rc-toggle-mine,
+.rc-toggle-theirs {
+  font-size: 0.72rem;
+  padding: 2px 10px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 20px;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+
+.rc-toggle-mine.active,
+.rc-toggle-theirs.active {
+  border-color: var(--success);
+  color: var(--success);
+  background: rgba(34, 211, 160, 0.08);
+}
+
+/* ── CLEAN NOTE ── */
+
+.rc-clean-note {
+  font-size: 0.83rem;
+  color: var(--text-secondary);
+  padding: 10px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  margin-top: 4px;
+}
+
+/* ── PREVIEW ── */
+
+.rc-preview-summary {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  padding: 12px 16px;
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  margin-bottom: 20px;
+}
+
+.rc-preview-section-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 12px;
+}
+
+.rc-preview-day {
+  margin-bottom: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-card);
+}
+
+.rc-preview-day-header {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding: 8px 14px;
+  background: var(--bg-card-hover);
+  border-bottom: 1px solid var(--border);
+}
+
+.rc-preview-entry {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 7px 14px;
+  font-size: 0.82rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.rc-preview-entry:last-child {
+  border-bottom: none;
+}
+
+.rc-preview-empty {
+  color: var(--text-muted);
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
- Opens a `.json` backup file via system dialog, parses and diffs it against current store data
- Days with no existing entries or identical entries are auto-merged; days with differing entries open the conflict resolution modal
- Conflict modal shows each conflicting day with per-entry choices (Keep Mine / Keep Theirs / Keep Both) and day-level shortcuts (Use all mine / Use all theirs)
- Preview Merge step shows the final resolved result before any data is written; Confirm applies the merge to the store and re-renders

## Changes
- `src/main/index.js` — added `backup:open-json` IPC handler (file dialog + JSON parse)
- `src/preload/index.js` — exposed `window.backup.openJsonFile()`
- `src/renderer/index.html` — added `#restoreConflictModal` shell (modal-xl, scrollable)
- `src/renderer/modules/restore.js` — new module: diff engine, 3-pass entry matcher, conflict resolution state, modal rendering, preview, merge & apply
- `src/renderer/modules/settings.js` — imported `openRestoreFromJson`, enabled and wired "Choose Backup File (.json)" button
- `src/renderer/styles/restore.css` — new: full styles for conflict modal, day blocks, entry rows, choice buttons, preview
- `src/renderer/styles/main.css` — added `@import './restore.css'`

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Restore from JSON with no conflicts shows confirm dialog and applies cleanly
- [ ] Restore from JSON with conflicts opens modal with correct diff
- [ ] Keep Mine / Keep Theirs / Keep Both choices work correctly
- [ ] Use all mine / Use all theirs shortcuts update all entries in a day
- [ ] Preview Merge shows accurate final state
- [ ] Confirm Restore applies changes and re-renders the app
- [ ] Cancel at any point leaves store untouched
- [ ] Invalid/corrupt JSON shows error toast
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #134

🤖 Generated with [Claude Code](https://claude.ai/claude-code)