### PR TITLE
feat(tm-135): add restore from TXT report with conflict resolution

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -288,6 +288,143 @@ ipcMain.handle('backup:choose-folder', async () => {
   if (result.canceled || !result.filePaths.length) return null;
   return result.filePaths[0];
 });
+ipcMain.handle('backup:open-txt', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    filters: [{ name: 'Timesheet Report', extensions: ['txt'] }],
+    properties: ['openFile'],
+    title: 'Open TXT Report',
+  });
+  if (result.canceled || !result.filePaths.length) return null;
+  const raw = fs.readFileSync(result.filePaths[0], 'utf8');
+  try {
+    return parseTxtReport(raw);
+  } catch (e) {
+    return { error: e.message || 'Failed to parse TXT report.' };
+  }
+});
+
+// ── TXT REPORT PARSER ────────────────────────────────────
+function parseTxtReport(text) {
+  const MONTH_MAP = {
+    Jan: '01', Feb: '02', Mar: '03', Apr: '04', May: '05', Jun: '06',
+    Jul: '07', Aug: '08', Sep: '09', Oct: '10', Nov: '11', Dec: '12',
+  };
+
+  function parseDisplayDate(str) {
+    // DD-Mon-YYYY → YYYY-MM-DD
+    const m = str.match(/^(\d{2})-([A-Za-z]{3})-(\d{4})$/);
+    if (!m) return null;
+    const month = MONTH_MAP[m[2]];
+    if (!month) return null;
+    return `${m[3]}-${month}-${m[1]}`;
+  }
+
+  const lines = text.split(/\r?\n/);
+  const allDaysByDate = {};
+  let currentDate = null;
+  let isHoliday = false;
+  let holidayLabelSet = false;
+
+  // Regex to identify a day header line: DD-Mon-YYYY :
+  const DAY_HEADER = /^(\d{2}-[A-Za-z]{3}-\d{4}) :(.*)/;
+  // Regex to strip leading roman numeral: i), ii), iii), etc.
+  const ROMAN_PREFIX = /^[ivxlcdm]+\)\s*/i;
+  // Regex to extract (HH:MM) time token
+  const TIME_TOKEN = /\((\d{1,2}):(\d{2})\)/;
+
+  let lineIdx = 0;
+
+  // Skip title line (first non-empty line) and separator
+  while (lineIdx < lines.length && lines[lineIdx].trim() === '') lineIdx++;
+  lineIdx++; // skip title
+  while (lineIdx < lines.length && lines[lineIdx].trim() === '') lineIdx++;
+  if (lineIdx < lines.length && lines[lineIdx].trim().startsWith('---')) lineIdx++; // skip separator
+
+  for (; lineIdx < lines.length; lineIdx++) {
+    const raw = lines[lineIdx];
+
+    // Day header
+    const headerMatch = raw.match(DAY_HEADER);
+    if (headerMatch) {
+      const isoDate = parseDisplayDate(headerMatch[1]);
+      if (!isoDate) continue;
+      currentDate = isoDate;
+      const rest = headerMatch[2].trim();
+      isHoliday = rest === '' || !/\d{2}:\d{2}/.test(rest);
+      holidayLabelSet = false;
+      if (!allDaysByDate[currentDate]) {
+        allDaysByDate[currentDate] = {
+          date: currentDate,
+          isHoliday,
+          entries: [],
+        };
+      }
+      continue;
+    }
+
+    // Tab-indented line (entry or holiday label)
+    if (currentDate && raw.startsWith('\t')) {
+      const stripped = raw.replace(/^\t/, '').replace(ROMAN_PREFIX, '');
+
+      if (isHoliday) {
+        // First indented line on a holiday day = the leave label
+        if (!holidayLabelSet) {
+          allDaysByDate[currentDate].holidayLabel = stripped.trim();
+          holidayLabelSet = true;
+        }
+        continue;
+      }
+
+      // Normal entry: ticket (11 chars padded), then (HH:MM), then optional " - desc"
+      const timeMatch = stripped.match(TIME_TOKEN);
+      if (!timeMatch) {
+        // Continuation line for previous entry's multi-line desc
+        const day = allDaysByDate[currentDate];
+        if (day.entries.length > 0) {
+          const last = day.entries[day.entries.length - 1];
+          last.desc = (last.desc ? last.desc + '\n' : '') + stripped.trim();
+        }
+        continue;
+      }
+
+      const timeIdx = stripped.indexOf(timeMatch[0]);
+      const ticket = stripped.substring(0, timeIdx).trim();
+      const hh = String(parseInt(timeMatch[1], 10));
+      const mm = String(timeMatch[2]).padStart(2, '0');
+
+      // Everything after the time token
+      const afterTime = stripped.substring(timeIdx + timeMatch[0].length).trim();
+      // Desc starts after "- " if present
+      const desc = afterTime.startsWith('- ')
+        ? afterTime.substring(2).trim()
+        : afterTime;
+
+      allDaysByDate[currentDate].entries.push({
+        ticket,
+        hh,
+        mm,
+        type: 'jira',
+        desc,
+      });
+      continue;
+    }
+
+    // Continuation line for multi-line desc (deeply indented, no tab prefix captured above)
+    if (currentDate && !isHoliday && raw.startsWith('  ') && raw.trim() !== '') {
+      const day = allDaysByDate[currentDate];
+      if (day.entries.length > 0) {
+        const last = day.entries[day.entries.length - 1];
+        last.desc = (last.desc ? last.desc + '\n' : '') + raw.trim();
+      }
+    }
+  }
+
+  if (Object.keys(allDaysByDate).length === 0) {
+    throw new Error('No timesheet days found in this file.');
+  }
+
+  return allDaysByDate;
+}
 
 // ── IPC: app control ─────────────────────────────────────
 ipcMain.handle('app-quit', () => { isQuitting = true; app.quit(); });

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -19,6 +19,7 @@ contextBridge.exposeInMainWorld('backup', {
     export:       () => ipcRenderer.invoke('backup:export'),
     getFolder:    () => ipcRenderer.invoke('backup:get-folder'),
     openJsonFile: () => ipcRenderer.invoke('backup:open-json'),
+    openTxtFile:  () => ipcRenderer.invoke('backup:open-txt'),
     chooseFolder: () => ipcRenderer.invoke('backup:choose-folder'),
 });
 

--- a/src/renderer/modules/restore.js
+++ b/src/renderer/modules/restore.js
@@ -8,12 +8,51 @@ import { showToast, showConfirm } from './toast.js';
 import { escHtml } from './utils.js';
 import { renderAll } from './render.js';
 import { updateSummary } from './summary.js';
+import { buildWeekDays, getDateFromWeek } from './week.js';
 
 let _modalInst  = null;
 let _cleanDays  = {};
 let _resolutions = [];  // [{ date, currentDay, incomingDay, same[], conflicts[], mineOnly[], theirsOnly[] }]
 
-/* ── PUBLIC ENTRY POINT ─────────────────────────────────────── */
+/* ── PUBLIC ENTRY POINTS ────────────────────────────────────── */
+export async function openRestoreFromTxt() {
+    let parsed;
+    try {
+        parsed = await window.backup.openTxtFile();
+    } catch (e) {
+        showToast('Could not read file. Is this a Timesheet Manager report?', 'danger');
+        return;
+    }
+    if (!parsed) return; // user cancelled
+
+    if (parsed.error) {
+        showToast(`${parsed.error} Is this a Timesheet Manager report?`, 'danger');
+        return;
+    }
+
+    const incoming = parsed;
+    if (typeof incoming !== 'object' || Object.keys(incoming).length === 0) {
+        showToast('No timesheet data found in this file. Is this a Timesheet Manager report?', 'danger');
+        return;
+    }
+
+    const { cleanDays, conflictDays } = _diffBackup(incoming);
+    const totalDays = Object.keys(cleanDays).length + conflictDays.length;
+
+    if (conflictDays.length === 0) {
+        showConfirm(
+            `Restore ${totalDays} day(s) from TXT report with no conflicts. Existing entries for these days will be overwritten. Proceed?`,
+            () => _applyRestore(cleanDays)
+        );
+        return;
+    }
+
+    _cleanDays   = cleanDays;
+    _resolutions = conflictDays.map(({ date, current, incoming: inc }) =>
+        _buildResolution(date, current, inc));
+    _showModal();
+}
+
 export async function openRestoreFromJson() {
     let parsed;
     try {
@@ -401,6 +440,12 @@ async function _confirmRestore() {
 async function _applyRestore(mergedDays) {
     try {
         state.allDaysByDate = { ...state.allDaysByDate, ...mergedDays };
+        // Rebuild state.days so renderAll picks up the restored day objects
+        // for the currently displayed week (spread creates new objects, old
+        // references in state.days would otherwise still point to stale data).
+        if (state.weekValue) {
+            state.days = buildWeekDays(getDateFromWeek(state.weekValue));
+        }
         await saveState();
         renderAll();
         updateSummary();

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -12,7 +12,7 @@ import { applyTheme } from './theme.js';
 import { renderTicketTypesSection } from './ticket-types.js';
 import { renderLeaveTypesSection } from './leave-types.js';
 import { renderErrorLogSection } from './error-log.js';
-import { openRestoreFromJson } from './restore.js';
+import { openRestoreFromJson, openRestoreFromTxt } from './restore.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -665,7 +665,7 @@ function renderRestore(el) {
                         Import a <code>.txt</code> timesheet report downloaded from this app.
                         Conflicting weeks will go through the same merge review as a JSON restore.
                     </p>
-                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-txt" disabled>
+                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-txt">
                         <i class="bi bi-file-earmark-text me-1"></i> Choose Report File (.txt)
                     </button>
                 </div>
@@ -673,6 +673,7 @@ function renderRestore(el) {
         </div>`;
 
     el.querySelector('#btn-restore-json').addEventListener('click', () => openRestoreFromJson());
+    el.querySelector('#btn-restore-txt').addEventListener('click', () => openRestoreFromTxt());
 }
 
 function _renderMarkdown(md) {


### PR DESCRIPTION
## Summary
- Parse the app's own generated `.txt` timesheet reports and restore entries from them
- Reuse the existing JSON restore conflict-resolution diff and modal flow for TXT restores
- Fix a bug in `_applyRestore` where `state.days` wasn't rebuilt after merge, causing the current week to not re-render (affected JSON restore too)

## Changes
- **`src/main/index.js`** — Added `parseTxtReport()` (parses `DD-Mon-YYYY` day headers, tab-indented roman-numeral entries, holiday labels) and `backup:open-txt` IPC handler with `.txt` file picker
- **`src/preload/index.js`** — Exposed `window.backup.openTxtFile()` in the context bridge
- **`src/renderer/modules/restore.js`** — Added `openRestoreFromTxt()` entry point; imported `buildWeekDays`/`getDateFromWeek` to fix `_applyRestore` so `state.days` is rebuilt after merging
- **`src/renderer/modules/settings.js`** — Imported `openRestoreFromTxt`, removed `disabled` from the TXT button, wired its click handler

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Download TXT report, clear the week, restore from TXT — entries reappear correctly
- [ ] Malformed TXT shows error toast with hint
- [ ] Conflict resolution modal appears when restoring over existing data
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #135

🤖 Generated with [Claude Code](https://claude.ai/claude-code)