### PR TITLE
feat(tm-140): add clipboard ticket detection with configurable pattern

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu, shell, ipcMain, screen, Tray, nativeImage, Notification, dialog } = require('electron');
+const { app, BrowserWindow, Menu, shell, ipcMain, screen, Tray, nativeImage, Notification, dialog, clipboard } = require('electron');
 const path = require('path');
 const fs   = require('fs');
 const Store = require('electron-store');
@@ -425,6 +425,9 @@ function parseTxtReport(text) {
 
   return allDaysByDate;
 }
+
+// ── IPC: clipboard ───────────────────────────────────────
+ipcMain.handle('clipboard:read', () => clipboard.readText());
 
 // ── IPC: app control ─────────────────────────────────────
 ipcMain.handle('app-quit', () => { isQuitting = true; app.quit(); });

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -15,6 +15,10 @@ contextBridge.exposeInMainWorld('app', {
     quit: () => ipcRenderer.invoke('app-quit'),
 });
 
+contextBridge.exposeInMainWorld('nativeClipboard', {
+    readText: () => ipcRenderer.invoke('clipboard:read'),
+});
+
 contextBridge.exposeInMainWorld('backup', {
     export:       () => ipcRenderer.invoke('backup:export'),
     getFolder:    () => ipcRenderer.invoke('backup:get-folder'),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -625,6 +625,7 @@
           <div class="cheatsheet-group">
             <div class="cheatsheet-group-label">Entries</div>
             <div class="cheatsheet-row"><kbd>N</kbd> <span>Add new entry to expanded day</span></div>
+            <div class="cheatsheet-row"><kbd>Ctrl</kbd><kbd>V</kbd> <span>Open entry modal pre-filled with clipboard ticket</span></div>
             <div class="cheatsheet-row"><kbd>T</kbd> <span>Open notes for expanded day</span></div>
             <div class="cheatsheet-row"><kbd>Enter</kbd> <span>Save entry (inside entry modal)</span></div>
             <div class="cheatsheet-row"><kbd>Alt</kbd><kbd>N</kbd> <span>Open entry modal with no-ticket toggled on</span></div>

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -20,6 +20,33 @@ export function initEntryModal() {
     });
 }
 
+/* ── CLIPBOARD TICKET DETECTION ─────────────────────────── */
+export async function readClipboardTicket() {
+    try {
+        const text = await window.nativeClipboard.readText();
+        if (!text) return null;
+
+        const types = state.ticketTypes || [];
+
+        // Try each type's configured ticketPattern first
+        for (const type of types) {
+            if (!type.ticketPattern) continue;
+            try {
+                const m = new RegExp(type.ticketPattern).exec(text);
+                if (m) return { ticket: m[0], typeId: type.id };
+            } catch (_) { /* skip invalid stored pattern */ }
+        }
+
+        // Generic fallback: Jira-style KEY-123
+        const generic = /\b([A-Z][A-Z0-9]+-\d+)\b/.exec(text);
+        if (generic) return { ticket: generic[1], typeId: null };
+
+        return null;
+    } catch (_) {
+        return null;
+    }
+}
+
 export function openEntryModal(dayIdx, entryIdx) {
     document.getElementById('modal-day-index').value = dayIdx;
     document.getElementById('modal-entry-index').value = entryIdx;
@@ -35,6 +62,19 @@ export function openEntryModal(dayIdx, entryIdx) {
         copyToBtn.style.display = 'none';
         makeRegularBtn.style.display = 'none';
         title.innerHTML = `<i class="bi bi-plus-circle me-2"></i>Add Entry — ${WEEK_DAYS[dayIdx]}`;
+
+        // Auto-fill ticket from clipboard
+        readClipboardTicket().then(result => {
+            if (!result) return;
+            const ticketEl = document.getElementById('modal-ticket');
+            const typeEl   = document.getElementById('modal-type');
+            if (ticketEl && !ticketEl.value) {
+                ticketEl.value = result.ticket;
+            }
+            if (result.typeId && typeEl) {
+                typeEl.value = result.typeId;
+            }
+        });
     } else {
         const e = state.days[dayIdx].entries[entryIdx];
         const noTicketToggle = document.getElementById('modal-no-ticket');

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -2,7 +2,7 @@ import { state } from './state.js';
 import { showToast } from './toast.js';
 import { escHtml } from './utils.js';
 import { renderStarredList } from './star.js';
-import { saveEntry, openEntryModal } from './entry-modal.js';
+import { saveEntry, openEntryModal, readClipboardTicket } from './entry-modal.js';
 import { toggleDay, renderAll, openDayNotesModal } from './render.js';
 import { openStatsModal } from './stats.js';
 import { changeWeekBy, setCurrentWeek } from './week.js';
@@ -277,6 +277,23 @@ export function initKeyboard() {
         if (e.ctrlKey && (e.key === 'p' || e.key === 'P')) {
             e.preventDefault();
             doPrint();
+        }
+
+        if (e.ctrlKey && (e.key === 'v' || e.key === 'V')) {
+            const expandedIdx = state.days.findIndex(d => d.expanded);
+            if (expandedIdx === -1) return;
+            readClipboardTicket().then(result => {
+                if (!result) return;
+                e.preventDefault();
+                openEntryModal(expandedIdx, -1);
+                // Wait for modal to render before setting values
+                document.getElementById('entryModal').addEventListener('shown.bs.modal', () => {
+                    const ticketEl = document.getElementById('modal-ticket');
+                    const typeEl   = document.getElementById('modal-type');
+                    if (ticketEl) ticketEl.value = result.ticket;
+                    if (result.typeId && typeEl) typeEl.value = result.typeId;
+                }, { once: true });
+            });
         }
     });
 }

--- a/src/renderer/modules/ticket-types.js
+++ b/src/renderer/modules/ticket-types.js
@@ -136,6 +136,23 @@ function _buildForm(editingType, formTypeId) {
                 <input type="text" id="tt-form-prefixtext" class="form-control dark-input"
                     placeholder="e.g. (Service desk) " value="${escHtml(t?.prefixText || '')}" maxlength="100" />
             </div>
+            <div class="settings-form-group">
+                <div class="d-flex align-items-center gap-2">
+                    <input type="checkbox" id="tt-form-haspattern" class="form-check-input" ${t?.ticketPattern ? 'checked' : ''} />
+                    <label class="label-text mb-0" for="tt-form-haspattern">Match clipboard ticket pattern</label>
+                </div>
+            </div>
+            <div class="settings-form-group" id="tt-form-pattern-row" style="${t?.ticketPattern ? '' : 'display:none'}">
+                <label class="label-text" for="tt-form-pattern">Pattern <span style="color:var(--text-secondary);font-weight:normal">(regex, e.g. <code>#\\d+</code> or <code>[A-Z]+-\\d+</code>)</span></label>
+                <input type="text" id="tt-form-pattern" class="form-control dark-input font-monospace"
+                    placeholder="e.g. #\\d+" value="${escHtml(t?.ticketPattern || '')}" maxlength="100" />
+                <div id="tt-form-pattern-error" class="tt-pattern-error" style="display:none"></div>
+                <div class="tt-pattern-preview" id="tt-form-pattern-preview" style="${t?.ticketPattern ? '' : 'display:none'}">
+                    <input type="text" id="tt-form-pattern-sample" class="form-control dark-input"
+                        placeholder="Test value, e.g. #1234" style="margin-top:6px" />
+                    <span id="tt-form-pattern-result" class="tt-pattern-result"></span>
+                </div>
+            </div>
             <div class="settings-form-actions d-flex gap-2">
                 <button class="btn btn-gradient px-4" id="tt-form-save">
                     <i class="bi bi-check-lg me-1"></i>${isNew ? 'Add' : 'Save'}
@@ -145,16 +162,84 @@ function _buildForm(editingType, formTypeId) {
         </div>`;
 }
 
+function _validatePattern(pattern) {
+    if (!pattern) return null; // empty = no pattern, valid
+    if (pattern.length > 100) return 'Pattern must be 100 characters or fewer.';
+
+    // 1. Syntax check
+    try { new RegExp(pattern); } catch (e) {
+        return `Invalid regex syntax: ${e.message}`;
+    }
+
+    // 2. ReDoS heuristic — nested quantifiers like (a+)+, (.+)+, (?:x+)+
+    if (/\([^)]*[+*?]\)[+*?]/.test(pattern)) {
+        return 'Pattern contains nested quantifiers that may freeze the app. Simplify it (e.g. use \\d+ instead of (\\d+)+).';
+    }
+
+    // 3. Execution timeout — run against adversarial string
+    const adversarial = 'a'.repeat(200) + 'b';
+    const start = Date.now();
+    try { new RegExp(pattern).test(adversarial); } catch (_) { /* already caught above */ }
+    if (Date.now() - start > 50) {
+        return 'Pattern is too slow — try simplifying it.';
+    }
+
+    return null; // valid
+}
+
 function _bindForm(formEl, editingType, el, navigate) {
-    const colorInput  = formEl.querySelector('#tt-form-color');
-    const colorVal    = formEl.querySelector('#tt-form-color-val');
-    const hasPrefixCb = formEl.querySelector('#tt-form-hasprefix');
-    const prefixRow   = formEl.querySelector('#tt-form-prefix-row');
+    const colorInput    = formEl.querySelector('#tt-form-color');
+    const colorVal      = formEl.querySelector('#tt-form-color-val');
+    const hasPrefixCb   = formEl.querySelector('#tt-form-hasprefix');
+    const prefixRow     = formEl.querySelector('#tt-form-prefix-row');
+    const hasPatternCb  = formEl.querySelector('#tt-form-haspattern');
+    const patternRow    = formEl.querySelector('#tt-form-pattern-row');
+    const patternInput  = formEl.querySelector('#tt-form-pattern');
+    const patternError  = formEl.querySelector('#tt-form-pattern-error');
+    const patternPreview = formEl.querySelector('#tt-form-pattern-preview');
+    const sampleInput   = formEl.querySelector('#tt-form-pattern-sample');
+    const patternResult = formEl.querySelector('#tt-form-pattern-result');
 
     colorInput.addEventListener('input', () => { colorVal.textContent = colorInput.value; });
+
     hasPrefixCb.addEventListener('change', () => {
         prefixRow.style.display = hasPrefixCb.checked ? '' : 'none';
     });
+
+    hasPatternCb.addEventListener('change', () => {
+        patternRow.style.display    = hasPatternCb.checked ? '' : 'none';
+        patternPreview.style.display = hasPatternCb.checked ? '' : 'none';
+        if (!hasPatternCb.checked) {
+            patternInput.value = '';
+            patternError.style.display = 'none';
+            patternResult.textContent = '';
+        }
+    });
+
+    const updatePreview = () => {
+        const pattern = patternInput.value.trim();
+        const sample  = sampleInput?.value || '';
+        if (!pattern || !sample) { patternResult.textContent = ''; return; }
+        try {
+            const match = new RegExp(pattern).exec(sample);
+            if (match) {
+                patternResult.textContent = `✓ Matched: "${match[0]}"`;
+                patternResult.style.color = 'var(--success)';
+            } else {
+                patternResult.textContent = '✗ No match';
+                patternResult.style.color = 'var(--danger, #f87171)';
+            }
+        } catch (_) {
+            patternResult.textContent = '';
+        }
+    };
+
+    patternInput?.addEventListener('input', () => {
+        patternError.style.display = 'none';
+        patternPreview.style.display = patternInput.value.trim() ? '' : 'none';
+        updatePreview();
+    });
+    sampleInput?.addEventListener('input', updatePreview);
 
     formEl.querySelector('#tt-form-save').addEventListener('click', () => {
         const labelInput = formEl.querySelector('#tt-form-label');
@@ -162,16 +247,29 @@ function _bindForm(formEl, editingType, el, navigate) {
         if (!label) { labelInput.classList.add('is-invalid'); return; }
         labelInput.classList.remove('is-invalid');
 
-        const color      = colorInput.value;
-        const hasPrefix  = hasPrefixCb.checked;
-        const prefixText = hasPrefix ? (formEl.querySelector('#tt-form-prefixtext').value) : '';
+        const color         = colorInput.value;
+        const hasPrefix     = hasPrefixCb.checked;
+        const prefixText    = hasPrefix ? (formEl.querySelector('#tt-form-prefixtext').value) : '';
+        const ticketPattern = hasPatternCb.checked ? patternInput.value.trim() : '';
+
+        // Validate pattern before saving
+        if (ticketPattern) {
+            const err = _validatePattern(ticketPattern);
+            if (err) {
+                patternError.textContent = err;
+                patternError.style.display = '';
+                patternInput.focus();
+                return;
+            }
+        }
+        patternError.style.display = 'none';
 
         if (editingType) {
             const type = state.ticketTypes.find(t => t.id === editingType.id);
-            if (type) { type.label = label; type.color = color; type.hasPrefix = hasPrefix; type.prefixText = prefixText; }
+            if (type) { type.label = label; type.color = color; type.hasPrefix = hasPrefix; type.prefixText = prefixText; type.ticketPattern = ticketPattern; }
         } else {
             const id = 'type_' + Date.now();
-            state.ticketTypes.push({ id, label, color, hasPrefix, prefixText });
+            state.ticketTypes.push({ id, label, color, hasPrefix, prefixText, ticketPattern });
         }
 
         saveState();

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -422,6 +422,18 @@
   cursor: pointer;
 }
 
+.tt-pattern-error {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: var(--danger, #f87171);
+}
+
+.tt-pattern-result {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.8rem;
+}
+
 /* ── ERROR LOGS ── */
 
 .el-toolbar {


### PR DESCRIPTION
## Summary
- When opening a new entry modal, automatically reads the clipboard and pre-fills the ticket field (and selects the matching type) if a ticket pattern is detected
- New global **Ctrl+V** shortcut: when a day is expanded and no modal is open, opens the entry modal pre-filled with the clipboard ticket
- Each ticket type in Settings can now configure an optional regex pattern for clipboard matching (e.g. `#\d+` for Service Desk), with a live preview and 3-layer safety validation

## Changes
- **`src/main/index.js`** — Added `clipboard:read` IPC handler using Electron's native `clipboard` module
- **`src/preload/index.js`** — Exposed `window.nativeClipboard.readText()` in the context bridge
- **`src/renderer/modules/entry-modal.js`** — Added `readClipboardTicket()`: tries each type's `ticketPattern` in order, falls back to generic `[A-Z][A-Z0-9]+-\d+`; auto-fills ticket + type on new entry open
- **`src/renderer/modules/sidebar.js`** — Added `Ctrl+V` handler in `initKeyboard`; opens entry modal pre-filled if a ticket is found in clipboard
- **`src/renderer/modules/ticket-types.js`** — Added `ticketPattern` field to ticket type form with live match preview; `_validatePattern()` runs syntax check, ReDoS nested-quantifier heuristic, and 50ms execution timeout before saving
- **`src/renderer/styles/settings.css`** — Styles for pattern error message and match result indicator
- **`src/renderer/index.html`** — Added `Ctrl+V` to the keyboard cheatsheet

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Copy `TM-101` → open new entry → ticket field auto-filled, Jira type selected
- [ ] Copy `TM-101` → press Ctrl+V (day expanded) → modal opens pre-filled
- [ ] Ctrl+V with no ticket in clipboard → does nothing
- [ ] Settings → Ticket Types → add pattern `#\d+` to Service Desk → copy `#1234` → new entry auto-selects Service Desk
- [ ] Invalid regex blocked with inline error
- [ ] Nested quantifier `(a+)+` blocked with inline error
- [ ] Pattern > 100 chars blocked
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #140

🤖 Generated with [Claude Code](https://claude.ai/claude-code)