### PR TITLE
feat(tm-142): replace HH/MM split inputs with freeform time field

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -249,15 +249,11 @@
                 placeholder="e.g. JIRA-123 or #123" />
               <div class="form-text text-muted">Use # prefix for Service Desk tickets</div>
             </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Hours (HH)</label>
-              <input type="number" id="modal-hh" class="form-control dark-input text-center" min="0" max="23"
-                placeholder="00" />
-            </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Minutes (MM)</label>
-              <input type="number" id="modal-mm" class="form-control dark-input text-center" min="0" max="59" step="1"
-                placeholder="00">
+            <div class="col-12 col-md-6 col-lg-4">
+              <label class="form-label label-text">Time</label>
+              <input type="text" id="modal-time" class="form-control dark-input"
+                placeholder="e.g. 2:30, 90m, 1.5h" autocomplete="off" />
+              <div class="invalid-feedback" id="modal-time-error"></div>
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
@@ -357,13 +353,11 @@
               <label class="form-label label-text">Ticket / Reference ID</label>
               <input type="text" id="recurring-ticket" class="form-control dark-input" placeholder="e.g. JIRA-123 or #123" />
             </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Hours (HH)</label>
-              <input type="number" id="recurring-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="00" />
-            </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Minutes (MM)</label>
-              <input type="number" id="recurring-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" />
+            <div class="col-12 col-md-6 col-lg-4">
+              <label class="form-label label-text">Time</label>
+              <input type="text" id="recurring-time" class="form-control dark-input"
+                placeholder="e.g. 2:30, 90m, 1.5h" autocomplete="off" />
+              <div class="invalid-feedback" id="recurring-time-error"></div>
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
@@ -484,13 +478,11 @@
               <label class="form-label label-text">Ticket / Reference ID</label>
               <input type="text" id="scheduled-form-ticket" class="form-control dark-input" placeholder="e.g. JIRA-123 or #123" />
             </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Hours (HH)</label>
-              <input type="number" id="scheduled-form-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="00" />
-            </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Minutes (MM)</label>
-              <input type="number" id="scheduled-form-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" />
+            <div class="col-12 col-md-6 col-lg-4">
+              <label class="form-label label-text">Time</label>
+              <input type="text" id="scheduled-form-time" class="form-control dark-input"
+                placeholder="e.g. 2:30, 90m, 1.5h" autocomplete="off" />
+              <div class="invalid-feedback" id="scheduled-form-time-error"></div>
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
@@ -801,12 +793,9 @@
           <!-- Daily Target -->
           <div class="mb-4">
             <label class="form-label label-text">Daily Target</label>
-            <div class="d-flex align-items-center gap-2">
-              <input type="number" id="onb-target-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="08" style="max-width:64px" />
-              <span class="label-text">hrs</span>
-              <input type="number" id="onb-target-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" style="max-width:64px" />
-              <span class="label-text">min</span>
-            </div>
+            <input type="text" id="onb-target-time" class="form-control dark-input"
+              placeholder="e.g. 8h, 7:30, 450m" autocomplete="off" />
+            <div class="invalid-feedback" id="onb-target-time-error"></div>
           </div>
 
           <button class="btn btn-gradient w-100 btn-ripple" id="btn-onb-submit" disabled>

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -1,8 +1,9 @@
-import { state, WEEK_DAYS } from './state.js';
+import { state, WEEK_DAYS, MAX_DAY_MINS } from './state.js';
 import { saveState } from './store.js';
 import { showToast, showConfirm } from './toast.js';
 import { updateSummary } from './summary.js';
 import { populateTypeSelect } from './ticket-types.js';
+import { parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 // Circular — resolved at call time
 import { rerenderDayCard, renderAll } from './render.js';
 import { updateNoTicketBanner } from './no-ticket-reminder.js';
@@ -17,6 +18,14 @@ export function initEntryModal() {
     document.getElementById('modal-no-ticket').addEventListener('change', function () {
         document.getElementById('modal-ticket-wrap').style.display = this.checked ? 'none' : '';
         if (!this.checked) document.getElementById('modal-ticket').value = '';
+    });
+
+    // Validate time field on blur — no rewrite, preserve what user typed
+    document.getElementById('modal-time').addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value) : null;
+        this.classList.toggle('is-invalid', !!err);
+        document.getElementById('modal-time-error').textContent = err || '';
+        updateEntryDayTotal();
     });
 }
 
@@ -81,8 +90,7 @@ export function openEntryModal(dayIdx, entryIdx) {
         noTicketToggle.checked = !!e.noTicket;
         document.getElementById('modal-ticket-wrap').style.display = e.noTicket ? 'none' : '';
         document.getElementById('modal-ticket').value = e.noTicket ? '' : (e.ticket || '');
-        document.getElementById('modal-hh').value = e.hh ?? 0;
-        document.getElementById('modal-mm').value = String(e.mm ?? 0).padStart(2, '0');
+        document.getElementById('modal-time').value = e.timeRaw || fmtTimeInput(e.hh ?? 0, e.mm ?? 0);
         populateTypeSelect(document.getElementById('modal-type'), e.type || state.ticketTypes[0]?.id || 'jira');
         document.getElementById('modal-desc').value = e.desc || '';
         document.getElementById('modal-group-id').value = e.groupId || '';
@@ -117,9 +125,8 @@ export function updateEntryDayTotal() {
         return sum + (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0);
     }, 0);
 
-    const addHH = parseInt(document.getElementById('modal-hh').value) || 0;
-    const addMM = parseInt(document.getElementById('modal-mm').value) || 0;
-    const addMins = addHH * 60 + addMM;
+    const timeParsed = parseTimeInput(document.getElementById('modal-time').value);
+    const addMins = timeParsed ? timeParsed.hh * 60 + timeParsed.mm : 0;
     const newTotalMins = baseMins + addMins;
 
     const fmt = (mins) => `${String(Math.floor(mins / 60)).padStart(2, '0')}:${String(mins % 60).padStart(2, '0')}`;
@@ -171,8 +178,8 @@ export function clearEntryModal() {
     document.getElementById('modal-logged').checked = false;
     document.getElementById('modal-ticket-wrap').style.display = '';
     document.getElementById('modal-ticket').value = '';
-    document.getElementById('modal-hh').value = '';
-    document.getElementById('modal-mm').value = '00';
+    document.getElementById('modal-time').value = '';
+    document.getElementById('modal-time').classList.remove('is-invalid');
     populateTypeSelect(document.getElementById('modal-type'), state.ticketTypes[0]?.id || 'jira');
     document.getElementById('modal-desc').value = '';
     document.getElementById('modal-group-id').value = '';
@@ -182,45 +189,32 @@ export function clearEntryModal() {
 export function saveEntryInternal() {
     const dayIdx = parseInt(document.getElementById('modal-day-index').value);
     const entryIdx = parseInt(document.getElementById('modal-entry-index').value);
-    const hhInput = document.getElementById('modal-hh');
-    const mmInput = document.getElementById('modal-mm');
+    const timeInput = document.getElementById('modal-time');
     const ticketInput = document.getElementById('modal-ticket');
     const descInput = document.getElementById('modal-desc');
 
-    const hh = parseInt(hhInput.value) || 0;
-    const mm = parseInt(mmInput.value) || 0;
+    const timeParsed = parseTimeInput(timeInput.value);
+    const hh = timeParsed ? timeParsed.hh : 0;
+    const mm = timeParsed ? timeParsed.mm : 0;
     const tkt = ticketInput.value.trim();
     const desc = descInput.value.trim();
 
     const isNoTicket = document.getElementById('modal-no-ticket').checked;
     let hasError = false;
 
-    [ticketInput, descInput, hhInput, mmInput].forEach(el => el.classList.remove('is-invalid'));
+    [ticketInput, descInput, timeInput].forEach(el => el.classList.remove('is-invalid'));
 
     if (!isNoTicket && !tkt) { ticketInput.classList.add('is-invalid'); hasError = true; }
     if (!desc) { descInput.classList.add('is-invalid'); hasError = true; }
-    if (hh === 0 && mm === 0) {
-        hhInput.classList.add('is-invalid');
-        mmInput.classList.add('is-invalid');
+    if (!timeParsed || (hh === 0 && mm === 0)) {
+        timeInput.classList.add('is-invalid');
         hasError = true;
     }
 
     if (hasError) {
         showToast('Please fill in all required fields (Ticket, Description, Time).', 'danger');
+        return false;
     }
-
-    if (hh > 24) {
-        hhInput.classList.add('is-invalid');
-        showToast('Hours cannot exceed 24.', 'danger');
-        hasError = true;
-    }
-    if (mm > 59) {
-        mmInput.classList.add('is-invalid');
-        showToast('Minutes cannot exceed 59.', 'danger');
-        hasError = true;
-    }
-
-    if (hasError) return false;
 
     let totalMinsForDay = (hh * 60) + mm;
     const day = state.days[dayIdx];
@@ -231,6 +225,14 @@ export function saveEntryInternal() {
                 totalMinsForDay += (parseInt(existingEntry.hh) || 0) * 60 + (parseInt(existingEntry.mm) || 0);
             }
         });
+    }
+
+    if (totalMinsForDay > MAX_DAY_MINS) {
+        const maxH = Math.floor(MAX_DAY_MINS / 60);
+        const totalH = Math.floor(totalMinsForDay / 60);
+        const totalM = totalMinsForDay % 60;
+        showToast(`Cannot log more than ${maxH}h in a single day. Total would be ${totalH}h ${totalM}m.`, 'danger');
+        return false;
     }
 
     if (totalMinsForDay > state.dailyTargetMins) {
@@ -255,13 +257,15 @@ export function commitEntry(dayIdx, entryIdx) {
     const groupType = document.getElementById('modal-group-type-ref').value;
     const isNoTicket = document.getElementById('modal-no-ticket').checked;
     const tkt = isNoTicket ? 'NO-TICKET' : document.getElementById('modal-ticket').value.trim();
-    const hh = parseInt(document.getElementById('modal-hh').value) || 0;
-    const mm = parseInt(document.getElementById('modal-mm').value) || 0;
+    const timeRaw = document.getElementById('modal-time').value.trim();
+    const timeParsed = parseTimeInput(timeRaw);
+    const hh = timeParsed ? timeParsed.hh : 0;
+    const mm = timeParsed ? timeParsed.mm : 0;
     const type = document.getElementById('modal-type').value;
     const desc = document.getElementById('modal-desc').value.trim();
 
     const isLogged = document.getElementById('modal-logged').checked;
-    const entry = { ticket: tkt, hh, mm, type, desc };
+    const entry = { ticket: tkt, hh, mm, timeRaw, type, desc };
     if (isNoTicket) entry.noTicket = true;
     if (isLogged) entry.logged = true;
     if (groupId) { entry.groupId = groupId; entry.groupType = groupType; }

--- a/src/renderer/modules/header.js
+++ b/src/renderer/modules/header.js
@@ -68,17 +68,5 @@ export function bindHeaderEvents() {
     document.getElementById('btn-delete-entry').addEventListener('click', deleteEntry);
     document.getElementById('btn-make-regular').addEventListener('click', makeRegularEntry);
 
-    [
-        ['modal-hh',          'modal-mm'],
-        ['recurring-hh',      'recurring-mm'],
-        ['scheduled-form-hh', 'scheduled-form-mm'],
-    ].forEach(([hhId, mmId]) => {
-        document.getElementById(hhId).addEventListener('input', function () {
-            if (this.value.length >= 2) document.getElementById(mmId).focus();
-        });
-    });
-
-    ['modal-hh', 'modal-mm'].forEach(id => {
-        document.getElementById(id).addEventListener('input', updateEntryDayTotal);
-    });
+    document.getElementById('modal-time').addEventListener('input', updateEntryDayTotal);
 }

--- a/src/renderer/modules/onboarding.js
+++ b/src/renderer/modules/onboarding.js
@@ -2,9 +2,10 @@
    ONBOARDING — first-run setup modal
    ============================================================= */
 
-import { state } from './state.js';
+import { state, MAX_TARGET_MINS } from './state.js';
 import { saveState } from './store.js';
 import { updateSheetDetailsDisplay } from './settings.js';
+import { parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 
 let _modalInst = null;
 
@@ -15,15 +16,16 @@ export function needsOnboarding() {
 export function initOnboarding() {
     const nameInput  = document.getElementById('onb-name');
     const submitBtn  = document.getElementById('btn-onb-submit');
-    const hhInput    = document.getElementById('onb-target-hh');
-    const mmInput    = document.getElementById('onb-target-mm');
+    const timeInput  = document.getElementById('onb-target-time');
 
     nameInput.addEventListener('input', () => {
         submitBtn.disabled = nameInput.value.trim() === '';
     });
 
-    hhInput.addEventListener('input', function () {
-        if (this.value.length >= 2) mmInput.focus();
+    timeInput.addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value, MAX_TARGET_MINS) : null;
+        this.classList.toggle('is-invalid', !!err);
+        document.getElementById('onb-target-time-error').textContent = err || '';
     });
 
     submitBtn.addEventListener('click', async () => {
@@ -31,8 +33,9 @@ export function initOnboarding() {
         if (!name) return;
 
         const title = document.getElementById('onb-report-title').value.trim();
-        const hh    = parseInt(hhInput.value) || 8;
-        const mm    = parseInt(mmInput.value) || 0;
+        const timeParsed = parseTimeInput(timeInput.value);
+        const hh    = timeParsed ? timeParsed.hh : 8;
+        const mm    = timeParsed ? timeParsed.mm : 0;
         const mins  = hh * 60 + mm;
 
         state.employeeName    = name;
@@ -53,8 +56,7 @@ export function showOnboarding() {
         // Pre-fill defaults
         document.getElementById('onb-report-title').value = state.reportTitle || 'Booked hours in Jira and Service Desk';
         const tgt = state.dailyTargetMins || 480;
-        document.getElementById('onb-target-hh').value = Math.floor(tgt / 60);
-        document.getElementById('onb-target-mm').value = tgt % 60;
+        document.getElementById('onb-target-time').value = fmtTimeInput(Math.floor(tgt / 60), tgt % 60);
         document.getElementById('onb-name').value = '';
         document.getElementById('btn-onb-submit').disabled = true;
 

--- a/src/renderer/modules/recurring.js
+++ b/src/renderer/modules/recurring.js
@@ -1,7 +1,7 @@
 import { state, RECURRING_DAY_NAMES, DAY_IDX_TO_NAME } from './state.js';
 import { saveState } from './store.js';
 import { showToast } from './toast.js';
-import { escHtml, fmtDate } from './utils.js';
+import { escHtml, fmtDate, parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 import { getTypeById, populateTypeSelect } from './ticket-types.js';
 import { getDateFromWeek, getWeekStrFromDate } from './week.js';
 // Circular — resolved at call time
@@ -110,6 +110,12 @@ export function initRecurring() {
 
     document.getElementById('btn-save-recurring').addEventListener('click', saveRecurringRule);
 
+    document.getElementById('recurring-time').addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value) : null;
+        this.classList.toggle('is-invalid', !!err);
+        document.getElementById('recurring-time-error').textContent = err || '';
+    });
+
     document.querySelectorAll('.recurring-day-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             btn.classList.toggle('selected');
@@ -180,8 +186,9 @@ function renderRecurringList() {
 function openRecurringForm(rule) {
     document.getElementById('recurring-form-id').value = rule ? rule.id : '';
     document.getElementById('recurring-ticket').value = rule ? rule.ticket : '';
-    document.getElementById('recurring-hh').value = rule ? rule.hh : '';
-    document.getElementById('recurring-mm').value = rule ? String(rule.mm || 0).padStart(2, '0') : '00';
+    const timeEl = document.getElementById('recurring-time');
+    timeEl.value = rule ? (rule.timeRaw || fmtTimeInput(rule.hh, rule.mm)) : '';
+    timeEl.classList.remove('is-invalid');
     populateTypeSelect(document.getElementById('recurring-type'), rule ? rule.type : (state.ticketTypes[0]?.id || 'jira'));
     document.getElementById('recurring-desc').value = rule ? rule.desc : '';
     document.getElementById('recurringFormTitle').innerHTML =
@@ -193,7 +200,7 @@ function openRecurringForm(rule) {
     syncAllDaysCheckbox();
 
     [document.getElementById('recurring-ticket'), document.getElementById('recurring-desc'),
-     document.getElementById('recurring-hh'), document.getElementById('recurring-mm')]
+     document.getElementById('recurring-time')]
         .forEach(el => el.classList.remove('is-invalid'));
 
     recurringFormModal.show();
@@ -201,22 +208,23 @@ function openRecurringForm(rule) {
 
 function saveRecurringRule() {
     const ticket = document.getElementById('recurring-ticket').value.trim();
-    const hh = parseInt(document.getElementById('recurring-hh').value) || 0;
-    const mm = parseInt(document.getElementById('recurring-mm').value) || 0;
+    const timeRaw = document.getElementById('recurring-time').value.trim();
+    const timeParsed = parseTimeInput(timeRaw);
+    const hh = timeParsed ? timeParsed.hh : 0;
+    const mm = timeParsed ? timeParsed.mm : 0;
     const type = document.getElementById('recurring-type').value;
     const desc = document.getElementById('recurring-desc').value.trim();
     const selectedDays = [...document.querySelectorAll('.recurring-day-btn.selected')].map(b => b.dataset.day);
 
     let hasError = false;
     [document.getElementById('recurring-ticket'), document.getElementById('recurring-desc'),
-     document.getElementById('recurring-hh'), document.getElementById('recurring-mm')]
+     document.getElementById('recurring-time')]
         .forEach(el => el.classList.remove('is-invalid'));
 
     if (!ticket) { document.getElementById('recurring-ticket').classList.add('is-invalid'); hasError = true; }
     if (!desc) { document.getElementById('recurring-desc').classList.add('is-invalid'); hasError = true; }
-    if (hh === 0 && mm === 0) {
-        document.getElementById('recurring-hh').classList.add('is-invalid');
-        document.getElementById('recurring-mm').classList.add('is-invalid');
+    if (!timeParsed || (hh === 0 && mm === 0)) {
+        document.getElementById('recurring-time').classList.add('is-invalid');
         hasError = true;
     }
     if (selectedDays.length === 0) { showToast('Select at least one day.', 'danger'); hasError = true; }
@@ -226,11 +234,11 @@ function saveRecurringRule() {
     if (existingId) {
         const rule = state.recurringTasks.find(r => r.id === existingId);
         if (rule) {
-            Object.assign(rule, { ticket, hh, mm, type, desc, days: selectedDays });
+            Object.assign(rule, { ticket, hh, mm, timeRaw, type, desc, days: selectedDays });
             updateRecurringEntriesFromToday(rule);
         }
     } else {
-        const rule = { id: 'rec_' + Date.now(), ticket, hh, mm, type, desc, days: selectedDays };
+        const rule = { id: 'rec_' + Date.now(), ticket, hh, mm, timeRaw, type, desc, days: selectedDays };
         state.recurringTasks.push(rule);
         populateRecurringForWeek(getDateFromWeek(state.weekValue || getWeekStrFromDate(new Date())));
     }

--- a/src/renderer/modules/scheduled.js
+++ b/src/renderer/modules/scheduled.js
@@ -1,7 +1,7 @@
 import { state } from './state.js';
 import { saveState } from './store.js';
 import { showToast } from './toast.js';
-import { escHtml, fmtDate } from './utils.js';
+import { escHtml, fmtDate, parseTimeInput, timeInputError } from './utils.js';
 import { getTypeById, populateTypeSelect } from './ticket-types.js';
 // Circular — resolved at call time
 import { rerenderDayCard } from './render.js';
@@ -52,6 +52,12 @@ export function initScheduledTasks() {
     });
 
     document.getElementById('btn-save-scheduled').addEventListener('click', saveScheduledTask);
+
+    document.getElementById('scheduled-form-time').addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value) : null;
+        this.classList.toggle('is-invalid', !!err);
+        document.getElementById('scheduled-form-time-error').textContent = err || '';
+    });
 
     const closeForm = () => {
         scheduledFormModal.hide();
@@ -176,8 +182,9 @@ function openScheduledForm() {
     dateInput.classList.remove('is-invalid');
     document.getElementById('scheduled-form-ticket').value = '';
     document.getElementById('scheduled-form-ticket').classList.remove('is-invalid');
-    document.getElementById('scheduled-form-hh').value = '';
-    document.getElementById('scheduled-form-mm').value = '00';
+    const timeEl = document.getElementById('scheduled-form-time');
+    timeEl.value = '';
+    timeEl.classList.remove('is-invalid');
     populateTypeSelect(document.getElementById('scheduled-form-type'), state.ticketTypes[0]?.id || 'jira');
     document.getElementById('scheduled-form-desc').value = '';
     document.getElementById('scheduled-form-desc').classList.remove('is-invalid');
@@ -191,17 +198,22 @@ function saveScheduledTask() {
     const scheduledDate = dateInput.value;
     const tkt = ticketInput.value.trim();
     const desc = descInput.value.trim();
-    const hh = parseInt(document.getElementById('scheduled-form-hh').value) || 0;
-    const mm = parseInt(document.getElementById('scheduled-form-mm').value) || 0;
+    const timeParsed = parseTimeInput(document.getElementById('scheduled-form-time').value);
+    const hh = timeParsed ? timeParsed.hh : 0;
+    const mm = timeParsed ? timeParsed.mm : 0;
     const type = document.getElementById('scheduled-form-type').value;
 
     let hasError = false;
-    [dateInput, ticketInput, descInput].forEach(el => el.classList.remove('is-invalid'));
+    [dateInput, ticketInput, descInput, document.getElementById('scheduled-form-time')]
+        .forEach(el => el.classList.remove('is-invalid'));
 
     if (!scheduledDate) { dateInput.classList.add('is-invalid'); hasError = true; }
     if (!tkt) { ticketInput.classList.add('is-invalid'); hasError = true; }
     if (!desc) { descInput.classList.add('is-invalid'); hasError = true; }
-    if (hh === 0 && mm === 0) { hasError = true; }
+    if (!timeParsed || (hh === 0 && mm === 0)) {
+        document.getElementById('scheduled-form-time').classList.add('is-invalid');
+        hasError = true;
+    }
 
     if (hasError) { showToast('Please fill in all required fields.', 'danger'); return; }
 

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -2,7 +2,7 @@
    SETTINGS — full-screen modal shell, nav routing, dirty state
    ============================================================= */
 
-import { state, APP_VERSION } from './state.js';
+import { state, APP_VERSION, MAX_TARGET_MINS } from './state.js';
 import { saveState } from './store.js';
 import { showToast } from './toast.js';
 import { updateSummary } from './summary.js';
@@ -13,6 +13,7 @@ import { renderTicketTypesSection } from './ticket-types.js';
 import { renderLeaveTypesSection } from './leave-types.js';
 import { renderErrorLogSection } from './error-log.js';
 import { openRestoreFromJson, openRestoreFromTxt } from './restore.js';
+import { parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -199,8 +200,6 @@ function renderSection(section) {
 
 function renderGeneral(el) {
     const tgt = state.dailyTargetMins || 480;
-    const hhVal = Math.floor(tgt / 60);
-    const mmVal = tgt % 60;
 
     el.innerHTML = `
         <div class="settings-section-header">
@@ -222,15 +221,11 @@ function renderGeneral(el) {
                         value="${escHtml(state.employeeName || '')}" />
                 </div>
                 <div class="settings-form-group">
-                    <label class="label-text">Daily Target</label>
-                    <div class="d-flex align-items-center gap-2">
-                        <input type="number" id="settings-target-hh" class="form-control dark-input text-center"
-                            min="0" max="23" placeholder="08" value="${hhVal}" style="max-width:64px" />
-                        <span class="label-text">hrs</span>
-                        <input type="number" id="settings-target-mm" class="form-control dark-input text-center"
-                            min="0" max="59" placeholder="00" value="${mmVal}" style="max-width:64px" />
-                        <span class="label-text">min</span>
-                    </div>
+                    <label class="label-text" for="settings-target-time">Daily Target</label>
+                    <input type="text" id="settings-target-time" class="form-control dark-input"
+                        placeholder="e.g. 8h, 7:30, 450m"
+                        value="${escHtml(fmtTimeInput(Math.floor(tgt / 60), tgt % 60))}" style="max-width:160px" />
+                    <div class="invalid-feedback" id="settings-target-time-error"></div>
                 </div>
                 <div class="settings-form-actions">
                     <button class="btn btn-gradient px-4" id="btn-save-general">
@@ -244,21 +239,30 @@ function renderGeneral(el) {
     const markGeneralDirty = () => markDirty('general');
     el.querySelector('#settings-report-title').addEventListener('input', markGeneralDirty);
     el.querySelector('#settings-emp-name').addEventListener('input', markGeneralDirty);
-    el.querySelector('#settings-target-hh').addEventListener('input', markGeneralDirty);
-    el.querySelector('#settings-target-mm').addEventListener('input', markGeneralDirty);
+    el.querySelector('#settings-target-time').addEventListener('input', markGeneralDirty);
 
-    // HH auto-advance to MM
-    el.querySelector('#settings-target-hh').addEventListener('input', function () {
-        if (this.value.length >= 2) el.querySelector('#settings-target-mm').focus();
+    // Validate on blur — no rewrite
+    el.querySelector('#settings-target-time').addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value, MAX_TARGET_MINS) : null;
+        this.classList.toggle('is-invalid', !!err);
+        el.querySelector('#settings-target-time-error').textContent = err || '';
     });
 
     // Save
     el.querySelector('#btn-save-general').addEventListener('click', () => {
         const title = el.querySelector('#settings-report-title').value.trim();
         const name  = el.querySelector('#settings-emp-name').value.trim();
-        const hh    = parseInt(el.querySelector('#settings-target-hh').value) || 0;
-        const mm    = parseInt(el.querySelector('#settings-target-mm').value) || 0;
-        const mins  = hh * 60 + mm;
+        const timeEl = el.querySelector('#settings-target-time');
+        const timeParsed = parseTimeInput(timeEl.value);
+        const mins  = timeParsed ? timeParsed.hh * 60 + timeParsed.mm : 0;
+        const timeErr = timeEl.value.trim() ? timeInputError(timeEl.value, MAX_TARGET_MINS) : null;
+
+        if (timeErr) {
+            timeEl.classList.add('is-invalid');
+            el.querySelector('#settings-target-time-error').textContent = timeErr;
+            showToast(timeErr, 'danger');
+            return;
+        }
 
         state.reportTitle    = title;
         state.employeeName   = name;

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -8,6 +8,8 @@ export const LS_KEY = 'timesheetState_v1';
 export const RECURRING_DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 export const DAY_IDX_TO_NAME = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri' };
 export const SEARCH_PAGE_SIZE = 10;
+export const MAX_DAY_MINS = 840;        // 14h hard cap per day
+export const MAX_TARGET_MINS = 840;     // 14h max for daily target setting
 
 export const DEFAULT_LEAVE_TYPES = [
     { id: 'offshore-holiday', label: 'Offshore Holiday', paid: false },

--- a/src/renderer/modules/utils.js
+++ b/src/renderer/modules/utils.js
@@ -37,6 +37,102 @@ export function fmtSearchDate(dateStr) {
     return `${days[d.getDay()]} ${d.getDate()} ${months[d.getMonth()]}`;
 }
 
+// Parse a freeform time string → { hh, mm } or null
+// Supported: "2:30", "2h 30m", "2h30m", "90m", "1.5h", "2h", "30m", "30", "2"
+// Maximum: 24:00 (1440 minutes total)
+export function parseTimeInput(str) {
+    if (!str) return null;
+    const s = str.trim();
+    if (!s) return null;
+
+    let m;
+    const cap = (hh, mm) => (hh * 60 + mm <= 1440) ? { hh, mm } : null;
+
+    // H:MM or HH:MM
+    m = s.match(/^(\d{1,3}):(\d{2})$/);
+    if (m) {
+        const hh = parseInt(m[1], 10);
+        const mm = parseInt(m[2], 10);
+        if (mm > 59) return null;
+        return cap(hh, mm);
+    }
+
+    // XhYm or Xh Ym (e.g. 2h30m, 2h 30m)
+    m = s.match(/^(\d+)\s*h\s*(\d+)\s*m$/i);
+    if (m) {
+        const hh = parseInt(m[1], 10);
+        const mm = parseInt(m[2], 10);
+        if (mm > 59) return null;
+        return cap(hh, mm);
+    }
+
+    // X.Yh decimal hours — must come before plain Xh (e.g. 1.5h)
+    m = s.match(/^(\d+\.\d+)\s*h$/i);
+    if (m) {
+        const totalMins = Math.round(parseFloat(m[1]) * 60);
+        return cap(Math.floor(totalMins / 60), totalMins % 60);
+    }
+
+    // Xh (e.g. 2h)
+    m = s.match(/^(\d+)\s*h$/i);
+    if (m) return cap(parseInt(m[1], 10), 0);
+
+    // Xm — total minutes (e.g. 90m → 1h 30m)
+    m = s.match(/^(\d+)\s*m$/i);
+    if (m) {
+        const totalMins = parseInt(m[1], 10);
+        return cap(Math.floor(totalMins / 60), totalMins % 60);
+    }
+
+    // Bare integer: < 24 → treat as hours, >= 24 → treat as total minutes
+    m = s.match(/^(\d+)$/);
+    if (m) {
+        const n = parseInt(m[1], 10);
+        if (n < 24) return cap(n, 0);
+        return cap(Math.floor(n / 60), n % 60);
+    }
+
+    return null;
+}
+
+// Returns a human-readable error string for an invalid time input, or null if valid.
+// maxMins: optional upper bound (default 1440 = 24h). Pass 840 for daily-target fields.
+export function timeInputError(str, maxMins = 1440) {
+    if (!str || !str.trim()) return null; // empty is handled separately
+    const s = str.trim();
+    const parsed = parseTimeInput(s);
+
+    if (parsed) {
+        // Parsed OK against the 24h cap — now check the caller's cap
+        const total = parsed.hh * 60 + parsed.mm;
+        if (total > maxMins) {
+            const h = Math.floor(maxMins / 60);
+            const m = maxMins % 60;
+            return `Maximum is ${m ? `${h}h ${m}m` : `${h}h`} (e.g. 8h, 2:30, 90m)`;
+        }
+        return null;
+    }
+
+    // parseTimeInput returned null — either unrecognised format or > 24h
+    const looksLikeTime = /^(\d+):(\d{2})$/.test(s)
+        || /^(\d+)\s*h\s*(\d+)\s*m$/i.test(s)
+        || /^(\d+\.\d+)\s*h$/i.test(s)
+        || /^(\d+)\s*h$/i.test(s)
+        || /^(\d+)\s*m$/i.test(s)
+        || /^\d+$/.test(s);
+    if (looksLikeTime) {
+        const h = Math.floor(maxMins / 60);
+        const m = maxMins % 60;
+        return `Maximum is ${m ? `${h}h ${m}m` : `${h}h`} (e.g. 8h, 2:30, 90m)`;
+    }
+    return 'Use a format like 2:30, 2h 30m, 90m, or 1.5h';
+}
+
+// Format hh + mm → "H:MM" for display in the freeform time field
+export function fmtTimeInput(hh, mm) {
+    return `${parseInt(hh) || 0}:${String(parseInt(mm) || 0).padStart(2, '0')}`;
+}
+
 export function padTicket(ticket) {
     const target = 11;
     if (ticket.length < target) return ticket + ' '.repeat(target - ticket.length);


### PR DESCRIPTION
## Summary
- Replace all 5 HH/MM split input pairs with a single freeform text field accepting formats like `2:30`, `2h 30m`, `90m`, `1.5h`, bare integers
- Store `timeRaw` on entries and recurring rules to restore the user's original typed format on edit-open (no forced normalisation)
- Add 24h hard cap per individual entry and 14h cap for daily target setting, with descriptive `invalid-feedback` messages explaining why input is invalid
- Add 14h hard day total cap that blocks saving (toast error) instead of just prompting a confirm dialog

## Changes
- `src/renderer/modules/utils.js` — added `parseTimeInput`, `fmtTimeInput`, `timeInputError(str, maxMins)` helpers
- `src/renderer/modules/state.js` — added `MAX_DAY_MINS` (840) and `MAX_TARGET_MINS` (840) constants
- `src/renderer/modules/entry-modal.js` — freeform time field, `timeRaw` storage/restore, 14h hard day cap
- `src/renderer/modules/recurring.js` — freeform time field with `timeRaw` storage/restore
- `src/renderer/modules/scheduled.js` — freeform time field
- `src/renderer/modules/onboarding.js` — freeform daily target field with 14h cap
- `src/renderer/modules/settings.js` — freeform daily target field with 14h cap on blur and save
- `src/renderer/modules/header.js` — removed stale HH/MM element references that blocked app init
- `src/renderer/index.html` — replaced 4 HH+MM input pairs with single text inputs; added `invalid-feedback` divs

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] All time formats accepted: `2:30`, `2h 30m`, `2h30m`, `90m`, `1.5h`, `2h`, `30`
- [ ] Edit-open restores original typed format (not normalised)
- [ ] `40h` rejected with "Maximum is 24h" message on entry field
- [ ] `15h` rejected with "Maximum is 14h" message on daily target field
- [ ] Day total over 14h blocked with toast error
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #142

🤖 Generated with [Claude Code](https://claude.ai/claude-code)