### PR TITLE
feat(tm-144): add logged/unlogged breakdown, quick-view copy, and edited indicator

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -427,7 +427,8 @@ function parseTxtReport(text) {
 }
 
 // ── IPC: clipboard ───────────────────────────────────────
-ipcMain.handle('clipboard:read', () => clipboard.readText());
+ipcMain.handle('clipboard:read',  () => clipboard.readText());
+ipcMain.handle('clipboard:write', (_, text) => clipboard.writeText(text));
 
 // ── IPC: app control ─────────────────────────────────────
 ipcMain.handle('app-quit', () => { isQuitting = true; app.quit(); });

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -16,7 +16,8 @@ contextBridge.exposeInMainWorld('app', {
 });
 
 contextBridge.exposeInMainWorld('nativeClipboard', {
-    readText: () => ipcRenderer.invoke('clipboard:read'),
+    readText:  () => ipcRenderer.invoke('clipboard:read'),
+    writeText: (text) => ipcRenderer.invoke('clipboard:write', text),
 });
 
 contextBridge.exposeInMainWorld('backup', {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -79,6 +79,66 @@
         <!-- Week Range & Employee Info -->
         <div class="card glass-card mb-4 position-sticky" style="top: 85px;">
           <div class="card-body">
+
+            <!-- 1. WEEKLY SUMMARY -->
+            <h5 class="section-label mb-3"><i class="bi bi-bar-chart-line me-2"></i>Weekly Summary</h5>
+            <div class="d-flex flex-column gap-3 mb-4">
+              <div class="total-chip w-100 mt-0 text-center" id="total-hours-chip">
+                <div class="week-progress-fill" id="week-progress-fill"></div>
+                <span class="total-chip-label">Total Hours</span>
+                <span class="total-chip-value" id="total-hours">00:00</span>
+              </div>
+              <div class="d-flex gap-3">
+                <div class="total-chip flex-fill text-center px-2">
+                  <span class="total-chip-label" style="font-size:0.65rem">Work Days</span>
+                  <span class="total-chip-value fs-4" id="total-days">0</span>
+                </div>
+                <div class="total-chip flex-fill text-center px-2">
+                  <span class="total-chip-label" style="font-size:0.65rem">Entries</span>
+                  <span class="total-chip-value fs-4" id="total-entries">0</span>
+                </div>
+              </div>
+              <!-- Logged / Unlogged breakdown -->
+              <div class="logged-breakdown" id="logged-breakdown">
+                <div class="lb-row">
+                  <span class="lb-dot lb-dot-logged"></span>
+                  <span class="lb-label">Logged</span>
+                  <span class="lb-hours" id="lb-logged-hours">0:00</span>
+                  <span class="lb-entries" id="lb-logged-entries">0 entries</span>
+                </div>
+                <div class="lb-row">
+                  <span class="lb-dot lb-dot-unlogged"></span>
+                  <span class="lb-label">Unlogged</span>
+                  <span class="lb-hours" id="lb-unlogged-hours">0:00</span>
+                  <span class="lb-entries" id="lb-unlogged-entries">0 entries</span>
+                </div>
+              </div>
+            </div>
+
+            <hr class="border-secondary my-3 opacity-25">
+
+            <!-- 2. WEEK SWITCHER -->
+            <div class="mb-3">
+              <label class="form-label label-text">Timesheet Week</label>
+              <div class="d-flex align-items-stretch gap-2 mb-2">
+                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-prev-week" title="Previous Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
+                  <i class="bi bi-chevron-left"></i>
+                </button>
+                <input type="week" id="week-picker" class="form-control dark-input m-0 flex-grow-1" />
+                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-next-week" title="Next Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
+                  <i class="bi bi-chevron-right"></i>
+                </button>
+              </div>
+              <div class="form-text text-muted mt-1" id="week-display-label">Select a week</div>
+            </div>
+
+            <button class="btn btn-outline-accent w-100 mb-4" id="btn-autofill-week">
+              <i class="bi bi-calendar-week me-1"></i> Use Current Week
+            </button>
+
+            <hr class="border-secondary my-3 opacity-25">
+
+            <!-- 3. SHEET DETAILS -->
             <div class="d-flex align-items-center justify-content-between mb-3">
               <h5 class="section-label mb-0"><i class="bi bi-person-badge me-2"></i>Sheet Details</h5>
               <button class="btn btn-sm btn-outline-accent px-2 py-1" id="btn-edit-sheet-details" title="Edit in Settings">
@@ -96,50 +156,11 @@
               <div class="sheet-detail-value" id="display-emp-name">—</div>
             </div>
 
-            <div class="mb-3">
-              <label class="form-label label-text">Timesheet Week</label>
-              <div class="d-flex align-items-stretch gap-2 mb-2">
-                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-prev-week" title="Previous Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
-                  <i class="bi bi-chevron-left"></i>
-                </button>
-                <input type="week" id="week-picker" class="form-control dark-input m-0 flex-grow-1" />
-                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-next-week" title="Next Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
-                  <i class="bi bi-chevron-right"></i>
-                </button>
-              </div>
-              <div class="form-text text-muted mt-1" id="week-display-label">Select a week</div>
-            </div>
-
-            <button class="btn btn-outline-accent w-100" id="btn-autofill-week">
-              <i class="bi bi-calendar-week me-1"></i> Use Current Week
-            </button>
-
-            <div class="mb-3 mt-3">
+            <div class="mb-1">
               <div class="label-text">Daily Target</div>
               <div class="sheet-detail-value" id="display-daily-target">—</div>
             </div>
 
-            <hr class="border-secondary my-4 opacity-25">
-
-            <!-- Totals Area inside the sidebar -->
-            <h5 class="section-label mb-3"><i class="bi bi-bar-chart-line me-2"></i>Weekly Summary</h5>
-            <div class="d-flex flex-column gap-3">
-              <div class="total-chip w-100 mt-0 text-center" id="total-hours-chip">
-                <div class="week-progress-fill" id="week-progress-fill"></div>
-                <span class="total-chip-label">Total Hours</span>
-                <span class="total-chip-value" id="total-hours">00:00</span>
-              </div>
-              <div class="d-flex gap-3">
-                <div class="total-chip flex-fill text-center px-2">
-                  <span class="total-chip-label" style="font-size:0.65rem">Work Days</span>
-                  <span class="total-chip-value fs-4" id="total-days">0</span>
-                </div>
-                <div class="total-chip flex-fill text-center px-2">
-                  <span class="total-chip-label" style="font-size:0.65rem">Entries</span>
-                  <span class="total-chip-value fs-4" id="total-entries">0</span>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
       </div> <!-- /LEFT COLUMN -->

--- a/src/renderer/modules/context-menu.js
+++ b/src/renderer/modules/context-menu.js
@@ -170,13 +170,30 @@ export function showEntryQuickView(dayIdx, entryIdx, btnEl) {
 
     const typeLabel = getTypeLabel(entry.type);
     const hhmm = `${String(entry.hh || 0).padStart(2,'0')}:${String(entry.mm || 0).padStart(2,'0')}`;
+    const statusRow = entry.loggedUpdated
+        ? `<div class="qv-row qv-status-row"><span class="qv-label">Status</span><span class="qv-updated-badge"><i class="bi bi-pencil-fill"></i> (updated)</span></div>`
+        : entry.logged
+            ? `<div class="qv-row qv-status-row"><span class="qv-label">Status</span><span class="qv-logged-badge"><i class="bi bi-journal-check"></i> Logged</span></div>`
+            : '';
 
     qv.innerHTML = `
+        <div class="qv-header">
+          <span class="qv-title">Entry</span>
+          <button class="qv-copy-btn" title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
+        </div>
         <div class="qv-row"><span class="qv-label">Ticket</span><span class="qv-value">${escHtml(entry.ticket || '—')}</span></div>
         <div class="qv-row"><span class="qv-label">Type</span><span class="qv-value">${escHtml(typeLabel)}</span></div>
         <div class="qv-row"><span class="qv-label">Time</span><span class="qv-value">${hhmm}</span></div>
-        <div class="qv-row"><span class="qv-label">Desc</span><span class="qv-desc">${escHtml(entry.desc || '—')}</span></div>`;
+        <div class="qv-row"><span class="qv-label">Desc</span><span class="qv-desc">${escHtml(entry.desc || '—')}</span></div>
+        ${statusRow}`;
     qv.dataset.for = `${dayIdx}-${entryIdx}`;
+
+    qv.querySelector('.qv-copy-btn').addEventListener('click', () => {
+        const text = `${entry.ticket || '—'} | ${hhmm} | ${typeLabel}\n${entry.desc || ''}`;
+        window.nativeClipboard?.writeText
+            ? window.nativeClipboard.writeText(text).then(() => showToast('Copied to clipboard.', 'success'))
+            : navigator.clipboard.writeText(text).then(() => showToast('Copied to clipboard.', 'success'));
+    });
 
     const rect = btnEl.getBoundingClientRect();
     qv.style.display = 'block';

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -276,6 +276,8 @@ export function commitEntry(dayIdx, entryIdx) {
         const existing = state.days[dayIdx].entries[entryIdx];
         if (existing && existing.recurringId) entry.recurringId = existing.recurringId;
         if (existing && existing.isScheduled) entry.isScheduled = existing.isScheduled;
+        // If it was logged before but not re-marked logged now, flag it as updated
+        if (existing && existing.logged && !isLogged) entry.loggedUpdated = true;
         // logged is NOT carried over from existing — modal already pre-unchecked it (auto-unmark on edit)
         state.days[dayIdx].entries[entryIdx] = entry;
     }

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -180,7 +180,7 @@ export function buildEntriesHTML(entries, dayIdx) {
 
             const rowI = rowIndex++;
             return `
-    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}${e.noTicket ? ' entry-no-ticket' : ''}${e.logged ? ' entry-logged' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
+    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}${e.noTicket ? ' entry-no-ticket' : ''}${e.logged ? ' entry-logged' : ''}${e.loggedUpdated ? ' entry-logged-updated' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
       <span class="drag-handle" title="Drag to reorder"><i class="bi bi-grip-vertical"></i></span>
       <span class="entry-num entry-num-roman">${rStr}</span>
       ${ticketHtml}
@@ -193,6 +193,7 @@ export function buildEntriesHTML(entries, dayIdx) {
         <button class="entry-btn-logged ${loggedClass}" title="${loggedTitle}"><i class="bi ${loggedIcon}"></i></button>
         <button class="entry-btn-star ${starClass}" title="${e.starred ? 'Unstar' : 'Star'}"><i class="bi ${starIcon}"></i></button>
       </div>
+      ${e.loggedUpdated ? '<span class="entry-updated-label">edited</span>' : ''}
     </div>`;
         }).join('');
 

--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -79,7 +79,9 @@ export function generateDayTxt(day, useHHMM = false) {
                     }
 
                     const showDesc = !(group.type === 'desc_group' && !isLast);
-                    const loggedMark = (!useHHMM && e.logged) ? '  (✓ logged)' : '';
+                    const loggedMark = !useHHMM
+                        ? e.loggedUpdated ? '  (updated)' : e.logged ? '  (✓ logged)' : ''
+                        : '';
 
                     if (!showDesc) {
                         lines.push(`${indent}${rStr}${ticket} ${timeStr}${loggedMark}`);

--- a/src/renderer/modules/star.js
+++ b/src/renderer/modules/star.js
@@ -26,6 +26,7 @@ export function toggleEntryLogged(dayIdx, entryIdx, btnEl) {
     const entry = state.days[dayIdx]?.entries[entryIdx];
     if (!entry) return;
     entry.logged = !entry.logged;
+    if (entry.logged) delete entry.loggedUpdated; // re-marking clears the updated flag
     btnEl.classList.toggle('logged', entry.logged);
     btnEl.querySelector('i').className = entry.logged ? 'bi bi-journal-check' : 'bi bi-journal';
     btnEl.title = entry.logged ? 'Logged to timesheet — click to unmark' : 'Mark as logged to timesheet';

--- a/src/renderer/modules/summary.js
+++ b/src/renderer/modules/summary.js
@@ -11,6 +11,10 @@ export function updateSummary() {
     let workingDays = 0;
     let totalEntries = 0;
     let holidayCount = 0;
+    let loggedMins = 0;
+    let loggedCount = 0;
+    let unloggedMins = 0;
+    let unloggedCount = 0;
 
     state.days.forEach(day => {
         if (day.isHoliday) {
@@ -20,6 +24,11 @@ export function updateSummary() {
             if (m > 0) workingDays++;
             totalMins += m;
             totalEntries += (day.entries || []).length;
+            (day.entries || []).forEach(e => {
+                const mins = (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0);
+                if (e.logged) { loggedMins += mins; loggedCount++; }
+                else          { unloggedMins += mins; unloggedCount++; }
+            });
         }
     });
 
@@ -43,5 +52,16 @@ export function updateSummary() {
             fill.style.width = pct.toFixed(1) + '%';
             fill.classList.toggle('over', isOver);
         }
+    }
+
+    // Logged / unlogged breakdown
+    const fmt = (m) => `${Math.floor(m / 60)}:${String(m % 60).padStart(2, '0')}`;
+    const breakdown = document.getElementById('logged-breakdown');
+    if (breakdown) {
+        breakdown.style.display = totalEntries > 0 ? '' : 'none';
+        document.getElementById('lb-logged-hours').textContent   = fmt(loggedMins);
+        document.getElementById('lb-logged-entries').textContent = `${loggedCount} ${loggedCount === 1 ? 'entry' : 'entries'}`;
+        document.getElementById('lb-unlogged-hours').textContent   = fmt(unloggedMins);
+        document.getElementById('lb-unlogged-entries').textContent = `${unloggedCount} ${unloggedCount === 1 ? 'entry' : 'entries'}`;
     }
 }

--- a/src/renderer/styles/context-menu.css
+++ b/src/renderer/styles/context-menu.css
@@ -119,6 +119,62 @@
   word-break: break-word;
 }
 
+.qv-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.qv-title {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.qv-copy-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  line-height: 1.4;
+  transition: background 0.15s, color 0.15s;
+}
+
+.qv-copy-btn:hover {
+  background: var(--bg-input);
+  color: var(--text-primary);
+}
+
+.qv-status-row {
+  margin-top: 4px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.qv-logged-badge {
+  font-size: 0.72rem;
+  color: #22d3a0;
+  font-weight: 600;
+}
+
+.qv-updated-badge {
+  font-size: 0.72rem;
+  color: #fb923c;
+  font-weight: 600;
+}
+
 /* ── CHEATSHEET ── */
 
 .cheatsheet-group {

--- a/src/renderer/styles/entries.css
+++ b/src/renderer/styles/entries.css
@@ -420,7 +420,7 @@
   bottom: 3px;
   right: 8px;
   font-size: 0.62rem;
-  color: #fb923c;
+  color: #9ca3af;
   opacity: 0.85;
   pointer-events: none;
   line-height: 1;

--- a/src/renderer/styles/entries.css
+++ b/src/renderer/styles/entries.css
@@ -414,3 +414,14 @@
   color: var(--warning);
   opacity: 0.85;
 }
+
+.entry-updated-label {
+  position: absolute;
+  bottom: 3px;
+  right: 8px;
+  font-size: 0.62rem;
+  color: #fb923c;
+  opacity: 0.85;
+  pointer-events: none;
+  line-height: 1;
+}

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -58,3 +58,51 @@
   color: #d4d4d4;
   line-height: 1.2;
 }
+
+/* ── LOGGED / UNLOGGED BREAKDOWN ── */
+
+.logged-breakdown {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lb-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.78rem;
+}
+
+.lb-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.lb-dot-logged   { background: #22d3a0; }
+.lb-dot-unlogged { background: #f87171; }
+
+.lb-label {
+  color: var(--text-secondary);
+  min-width: 58px;
+}
+
+.lb-hours {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  color: #d4d4d4;
+  min-width: 38px;
+}
+
+.lb-entries {
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+[data-theme="light"] .lb-hours { color: #1a1a2e; }


### PR DESCRIPTION
## Summary
- Weekly summary sidebar now shows a logged vs unlogged hours/entry breakdown with green/red dot indicators (#144)
- Entry quick-view popover has a copy-to-clipboard button and a Status row showing Logged or (updated) state (#145)
- Entries edited after being logged show an "edited" label at the bottom-right of the row (WhatsApp-style, no height change), "(updated)" text in the day preview modal and quick-view status row (#146)
- Sidebar panel reordered: Weekly Summary → Week Switcher → Sheet Details

## Changes
- `src/renderer/modules/summary.js` — compute loggedMins/unloggedMins/counts, render breakdown panel
- `src/renderer/index.html` — add breakdown HTML, reorder sidebar sections
- `src/renderer/styles/layout.css` — styles for `.logged-breakdown`, `.lb-row`, `.lb-dot`, `.lb-hours`, `.lb-entries`
- `src/renderer/modules/context-menu.js` — quick-view copy button, Status row with logged/updated badge
- `src/renderer/styles/context-menu.css` — styles for `.qv-header`, `.qv-copy-btn`, `.qv-status-row`, `.qv-logged-badge`, `.qv-updated-badge`
- `src/renderer/modules/entry-modal.js` — set `loggedUpdated: true` when editing a previously-logged entry
- `src/renderer/modules/star.js` — clear `loggedUpdated` when entry is re-marked as logged
- `src/renderer/modules/render.js` — render `.entry-updated-label` at bottom-right of row
- `src/renderer/styles/entries.css` — absolute-positioned `.entry-updated-label` style
- `src/renderer/modules/report.js` — append `(updated)` in day preview text alongside `(✓ logged)`
- `src/main/index.js` — add `clipboard:write` IPC handler
- `src/preload/index.js` — expose `nativeClipboard.writeText`

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Log an entry, edit it, verify "edited" label appears at row bottom-right
- [ ] Re-mark as logged, verify "edited" label disappears
- [ ] Open quick-view, verify Status row shows correct state
- [ ] Open day preview modal, verify `(updated)` appears after description
- [ ] Copy button copies ticket/time/desc to clipboard
- [ ] Logged/unlogged breakdown updates correctly in sidebar
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #144
Closes #145
Closes #146

🤖 Generated with [Claude Code](https://claude.ai/claude-code)