### PR TITLE
chore: release v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timesheet-manager",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Weekly Jira & Service Desk Time Tracking Application",
   "main": "out/main/index.js",
   "scripts": {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu, shell, ipcMain, screen, Tray, nativeImage, Notification, dialog } = require('electron');
+const { app, BrowserWindow, Menu, shell, ipcMain, screen, Tray, nativeImage, Notification, dialog, clipboard } = require('electron');
 const path = require('path');
 const fs   = require('fs');
 const Store = require('electron-store');
@@ -425,6 +425,9 @@ function parseTxtReport(text) {
 
   return allDaysByDate;
 }
+
+// ── IPC: clipboard ───────────────────────────────────────
+ipcMain.handle('clipboard:read', () => clipboard.readText());
 
 // ── IPC: app control ─────────────────────────────────────
 ipcMain.handle('app-quit', () => { isQuitting = true; app.quit(); });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -288,6 +288,143 @@ ipcMain.handle('backup:choose-folder', async () => {
   if (result.canceled || !result.filePaths.length) return null;
   return result.filePaths[0];
 });
+ipcMain.handle('backup:open-txt', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    filters: [{ name: 'Timesheet Report', extensions: ['txt'] }],
+    properties: ['openFile'],
+    title: 'Open TXT Report',
+  });
+  if (result.canceled || !result.filePaths.length) return null;
+  const raw = fs.readFileSync(result.filePaths[0], 'utf8');
+  try {
+    return parseTxtReport(raw);
+  } catch (e) {
+    return { error: e.message || 'Failed to parse TXT report.' };
+  }
+});
+
+// ── TXT REPORT PARSER ────────────────────────────────────
+function parseTxtReport(text) {
+  const MONTH_MAP = {
+    Jan: '01', Feb: '02', Mar: '03', Apr: '04', May: '05', Jun: '06',
+    Jul: '07', Aug: '08', Sep: '09', Oct: '10', Nov: '11', Dec: '12',
+  };
+
+  function parseDisplayDate(str) {
+    // DD-Mon-YYYY → YYYY-MM-DD
+    const m = str.match(/^(\d{2})-([A-Za-z]{3})-(\d{4})$/);
+    if (!m) return null;
+    const month = MONTH_MAP[m[2]];
+    if (!month) return null;
+    return `${m[3]}-${month}-${m[1]}`;
+  }
+
+  const lines = text.split(/\r?\n/);
+  const allDaysByDate = {};
+  let currentDate = null;
+  let isHoliday = false;
+  let holidayLabelSet = false;
+
+  // Regex to identify a day header line: DD-Mon-YYYY :
+  const DAY_HEADER = /^(\d{2}-[A-Za-z]{3}-\d{4}) :(.*)/;
+  // Regex to strip leading roman numeral: i), ii), iii), etc.
+  const ROMAN_PREFIX = /^[ivxlcdm]+\)\s*/i;
+  // Regex to extract (HH:MM) time token
+  const TIME_TOKEN = /\((\d{1,2}):(\d{2})\)/;
+
+  let lineIdx = 0;
+
+  // Skip title line (first non-empty line) and separator
+  while (lineIdx < lines.length && lines[lineIdx].trim() === '') lineIdx++;
+  lineIdx++; // skip title
+  while (lineIdx < lines.length && lines[lineIdx].trim() === '') lineIdx++;
+  if (lineIdx < lines.length && lines[lineIdx].trim().startsWith('---')) lineIdx++; // skip separator
+
+  for (; lineIdx < lines.length; lineIdx++) {
+    const raw = lines[lineIdx];
+
+    // Day header
+    const headerMatch = raw.match(DAY_HEADER);
+    if (headerMatch) {
+      const isoDate = parseDisplayDate(headerMatch[1]);
+      if (!isoDate) continue;
+      currentDate = isoDate;
+      const rest = headerMatch[2].trim();
+      isHoliday = rest === '' || !/\d{2}:\d{2}/.test(rest);
+      holidayLabelSet = false;
+      if (!allDaysByDate[currentDate]) {
+        allDaysByDate[currentDate] = {
+          date: currentDate,
+          isHoliday,
+          entries: [],
+        };
+      }
+      continue;
+    }
+
+    // Tab-indented line (entry or holiday label)
+    if (currentDate && raw.startsWith('\t')) {
+      const stripped = raw.replace(/^\t/, '').replace(ROMAN_PREFIX, '');
+
+      if (isHoliday) {
+        // First indented line on a holiday day = the leave label
+        if (!holidayLabelSet) {
+          allDaysByDate[currentDate].holidayLabel = stripped.trim();
+          holidayLabelSet = true;
+        }
+        continue;
+      }
+
+      // Normal entry: ticket (11 chars padded), then (HH:MM), then optional " - desc"
+      const timeMatch = stripped.match(TIME_TOKEN);
+      if (!timeMatch) {
+        // Continuation line for previous entry's multi-line desc
+        const day = allDaysByDate[currentDate];
+        if (day.entries.length > 0) {
+          const last = day.entries[day.entries.length - 1];
+          last.desc = (last.desc ? last.desc + '\n' : '') + stripped.trim();
+        }
+        continue;
+      }
+
+      const timeIdx = stripped.indexOf(timeMatch[0]);
+      const ticket = stripped.substring(0, timeIdx).trim();
+      const hh = String(parseInt(timeMatch[1], 10));
+      const mm = String(timeMatch[2]).padStart(2, '0');
+
+      // Everything after the time token
+      const afterTime = stripped.substring(timeIdx + timeMatch[0].length).trim();
+      // Desc starts after "- " if present
+      const desc = afterTime.startsWith('- ')
+        ? afterTime.substring(2).trim()
+        : afterTime;
+
+      allDaysByDate[currentDate].entries.push({
+        ticket,
+        hh,
+        mm,
+        type: 'jira',
+        desc,
+      });
+      continue;
+    }
+
+    // Continuation line for multi-line desc (deeply indented, no tab prefix captured above)
+    if (currentDate && !isHoliday && raw.startsWith('  ') && raw.trim() !== '') {
+      const day = allDaysByDate[currentDate];
+      if (day.entries.length > 0) {
+        const last = day.entries[day.entries.length - 1];
+        last.desc = (last.desc ? last.desc + '\n' : '') + raw.trim();
+      }
+    }
+  }
+
+  if (Object.keys(allDaysByDate).length === 0) {
+    throw new Error('No timesheet days found in this file.');
+  }
+
+  return allDaysByDate;
+}
 
 // ── IPC: app control ─────────────────────────────────────
 ipcMain.handle('app-quit', () => { isQuitting = true; app.quit(); });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,12 +1,101 @@
-const { app, BrowserWindow, Menu, shell, ipcMain, screen, Tray, nativeImage, Notification } = require('electron');
+const { app, BrowserWindow, Menu, shell, ipcMain, screen, Tray, nativeImage, Notification, dialog } = require('electron');
 const path = require('path');
+const fs   = require('fs');
 const Store = require('electron-store');
 const { autoUpdater } = require('electron-updater');
 
 const store = new Store();
-const WINDOW_BOUNDS_KEY = 'windowBounds';
-const LS_KEY = 'timesheetState_v1';
-const NOTIFICATION_KEY = 'notificationSettings';
+const WINDOW_BOUNDS_KEY   = 'windowBounds';
+const LS_KEY              = 'timesheetState_v1';
+const NOTIFICATION_KEY    = 'notificationSettings';
+const BACKUP_SETTINGS_KEY = 'backupSettings';
+
+// ── BACKUP HELPERS ───────────────────────────────────────
+function getDefaultBackupFolder() {
+  return path.join(app.getPath('documents'), 'TimesheetBackups');
+}
+
+function getBackupFolder() {
+  const settings = store.get(BACKUP_SETTINGS_KEY) || {};
+  return settings.folder || getDefaultBackupFolder();
+}
+
+function writeBackupFile() {
+  const folder = getBackupFolder();
+  if (!fs.existsSync(folder)) fs.mkdirSync(folder, { recursive: true });
+
+  const now      = new Date();
+  const pad      = n => String(n).padStart(2, '0');
+  const stamp    = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+  const filePath = path.join(folder, `timesheet-backup-${stamp}.json`);
+
+  const backup = {
+    version:    app.getVersion(),
+    exportedAt: now.toISOString(),
+    data:       store.get(LS_KEY) || {},
+  };
+  fs.writeFileSync(filePath, JSON.stringify(backup, null, 2), 'utf8');
+
+  const settings = store.get(BACKUP_SETTINGS_KEY) || {};
+  store.set(BACKUP_SETTINGS_KEY, { ...settings, lastBackupAt: now.toISOString() });
+
+  return { filePath, exportedAt: now.toISOString() };
+}
+
+function pruneOldBackups() {
+  const folder = getBackupFolder();
+  if (!fs.existsSync(folder)) return;
+
+  const settings      = store.get(BACKUP_SETTINGS_KEY) || {};
+  const retentionDays = settings.retentionDays ?? 30;
+  const cutoff        = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+
+  fs.readdirSync(folder)
+    .filter(f => f.startsWith('timesheet-backup-') && f.endsWith('.json'))
+    .forEach(file => {
+      const filePath = path.join(folder, file);
+      try {
+        if (fs.statSync(filePath).mtimeMs < cutoff) fs.unlinkSync(filePath);
+      } catch (_) { /* skip */ }
+    });
+}
+
+function isBackupDue() {
+  const settings  = store.get(BACKUP_SETTINGS_KEY) || {};
+  if (settings.enabled === false) return false;
+
+  const frequency  = settings.frequency  || 'weekly';
+  const dayOfWeek  = settings.dayOfWeek  ?? 1;   // 1=Mon … 5=Fri (matches JS getDay())
+  const hour       = settings.hour       ?? 9;
+  const lastBackup = settings.lastBackupAt ? new Date(settings.lastBackupAt) : null;
+  const now        = new Date();
+
+  if (now.getHours() < hour) return false;
+  if (!lastBackup) return true;
+
+  if (frequency === 'daily') {
+    return lastBackup.toDateString() !== now.toDateString();
+  }
+  if (frequency === 'weekly') {
+    if (now.getDay() !== dayOfWeek) return false;
+    return lastBackup < new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  }
+  if (frequency === 'monthly') {
+    return lastBackup.getMonth() !== now.getMonth() ||
+           lastBackup.getFullYear() !== now.getFullYear();
+  }
+  return false;
+}
+
+function checkAutoBackup() {
+  try {
+    if (!isBackupDue()) return;
+    writeBackupFile();
+    pruneOldBackups();
+  } catch (e) {
+    console.warn('[backup] Auto-backup failed:', e.message);
+  }
+}
 
 // Disable auto-download — we control when to download
 autoUpdater.autoDownload = false;
@@ -178,6 +267,18 @@ ipcMain.handle('check-for-updates', () => autoUpdater.checkForUpdates());
 ipcMain.handle('download-update', () => autoUpdater.downloadUpdate());
 ipcMain.handle('install-update', () => autoUpdater.quitAndInstall());
 
+// ── IPC: backup ──────────────────────────────────────────
+ipcMain.handle('backup:export', () => writeBackupFile());
+ipcMain.handle('backup:get-folder', () => getBackupFolder());
+ipcMain.handle('backup:choose-folder', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    properties: ['openDirectory', 'createDirectory'],
+    title: 'Choose Backup Folder',
+  });
+  if (result.canceled || !result.filePaths.length) return null;
+  return result.filePaths[0];
+});
+
 // ── IPC: app control ─────────────────────────────────────
 ipcMain.handle('app-quit', () => { isQuitting = true; app.quit(); });
 
@@ -218,9 +319,10 @@ app.whenReady().then(() => {
   createTray();
   scheduleNotifications();
 
-  // Check for updates silently after window is ready
+  // Check for updates and run auto-backup silently after window is ready
   mainWindow.webContents.once('did-finish-load', () => {
     autoUpdater.checkForUpdates();
+    checkAutoBackup();
   });
 
   app.on('activate', function () {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -427,7 +427,8 @@ function parseTxtReport(text) {
 }
 
 // ── IPC: clipboard ───────────────────────────────────────
-ipcMain.handle('clipboard:read', () => clipboard.readText());
+ipcMain.handle('clipboard:read',  () => clipboard.readText());
+ipcMain.handle('clipboard:write', (_, text) => clipboard.writeText(text));
 
 // ── IPC: app control ─────────────────────────────────────
 ipcMain.handle('app-quit', () => { isQuitting = true; app.quit(); });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -270,6 +270,16 @@ ipcMain.handle('install-update', () => autoUpdater.quitAndInstall());
 // ── IPC: backup ──────────────────────────────────────────
 ipcMain.handle('backup:export', () => writeBackupFile());
 ipcMain.handle('backup:get-folder', () => getBackupFolder());
+ipcMain.handle('backup:open-json', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    filters: [{ name: 'Backup Files', extensions: ['json'] }],
+    properties: ['openFile'],
+    title: 'Open Backup File',
+  });
+  if (result.canceled || !result.filePaths.length) return null;
+  const raw = fs.readFileSync(result.filePaths[0], 'utf8');
+  return JSON.parse(raw);
+});
 ipcMain.handle('backup:choose-folder', async () => {
   const result = await dialog.showOpenDialog(mainWindow, {
     properties: ['openDirectory', 'createDirectory'],

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -15,6 +15,12 @@ contextBridge.exposeInMainWorld('app', {
     quit: () => ipcRenderer.invoke('app-quit'),
 });
 
+contextBridge.exposeInMainWorld('backup', {
+    export:       () => ipcRenderer.invoke('backup:export'),
+    getFolder:    () => ipcRenderer.invoke('backup:get-folder'),
+    chooseFolder: () => ipcRenderer.invoke('backup:choose-folder'),
+});
+
 contextBridge.exposeInMainWorld('updater', {
     checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
     downloadUpdate: () => ipcRenderer.invoke('download-update'),

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -15,6 +15,10 @@ contextBridge.exposeInMainWorld('app', {
     quit: () => ipcRenderer.invoke('app-quit'),
 });
 
+contextBridge.exposeInMainWorld('nativeClipboard', {
+    readText: () => ipcRenderer.invoke('clipboard:read'),
+});
+
 contextBridge.exposeInMainWorld('backup', {
     export:       () => ipcRenderer.invoke('backup:export'),
     getFolder:    () => ipcRenderer.invoke('backup:get-folder'),

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -16,7 +16,8 @@ contextBridge.exposeInMainWorld('app', {
 });
 
 contextBridge.exposeInMainWorld('nativeClipboard', {
-    readText: () => ipcRenderer.invoke('clipboard:read'),
+    readText:  () => ipcRenderer.invoke('clipboard:read'),
+    writeText: (text) => ipcRenderer.invoke('clipboard:write', text),
 });
 
 contextBridge.exposeInMainWorld('backup', {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -18,6 +18,7 @@ contextBridge.exposeInMainWorld('app', {
 contextBridge.exposeInMainWorld('backup', {
     export:       () => ipcRenderer.invoke('backup:export'),
     getFolder:    () => ipcRenderer.invoke('backup:get-folder'),
+    openJsonFile: () => ipcRenderer.invoke('backup:open-json'),
     chooseFolder: () => ipcRenderer.invoke('backup:choose-folder'),
 });
 

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -19,6 +19,7 @@ contextBridge.exposeInMainWorld('backup', {
     export:       () => ipcRenderer.invoke('backup:export'),
     getFolder:    () => ipcRenderer.invoke('backup:get-folder'),
     openJsonFile: () => ipcRenderer.invoke('backup:open-json'),
+    openTxtFile:  () => ipcRenderer.invoke('backup:open-txt'),
     chooseFolder: () => ipcRenderer.invoke('backup:choose-folder'),
 });
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -874,6 +874,21 @@
                 <span>Error Logs</span>
               </div>
             </div>
+            <div class="settings-nav-item settings-nav-parent" data-section="backup-restore">
+              <i class="bi bi-shield-check"></i>
+              <span>Backup &amp; Restore</span>
+              <i class="bi bi-chevron-right settings-nav-chevron"></i>
+            </div>
+            <div class="settings-nav-sub" id="sub-backup-restore">
+              <div class="settings-nav-subitem" data-section="backup">
+                <i class="bi bi-cloud-arrow-up"></i>
+                <span>Backup</span>
+              </div>
+              <div class="settings-nav-subitem" data-section="restore">
+                <i class="bi bi-cloud-arrow-down"></i>
+                <span>Restore</span>
+              </div>
+            </div>
             <div class="settings-nav-item" data-section="about">
               <i class="bi bi-info-circle"></i>
               <span>About</span>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -79,6 +79,66 @@
         <!-- Week Range & Employee Info -->
         <div class="card glass-card mb-4 position-sticky" style="top: 85px;">
           <div class="card-body">
+
+            <!-- 1. WEEKLY SUMMARY -->
+            <h5 class="section-label mb-3"><i class="bi bi-bar-chart-line me-2"></i>Weekly Summary</h5>
+            <div class="d-flex flex-column gap-3 mb-4">
+              <div class="total-chip w-100 mt-0 text-center" id="total-hours-chip">
+                <div class="week-progress-fill" id="week-progress-fill"></div>
+                <span class="total-chip-label">Total Hours</span>
+                <span class="total-chip-value" id="total-hours">00:00</span>
+              </div>
+              <div class="d-flex gap-3">
+                <div class="total-chip flex-fill text-center px-2">
+                  <span class="total-chip-label" style="font-size:0.65rem">Work Days</span>
+                  <span class="total-chip-value fs-4" id="total-days">0</span>
+                </div>
+                <div class="total-chip flex-fill text-center px-2">
+                  <span class="total-chip-label" style="font-size:0.65rem">Entries</span>
+                  <span class="total-chip-value fs-4" id="total-entries">0</span>
+                </div>
+              </div>
+              <!-- Logged / Unlogged breakdown -->
+              <div class="logged-breakdown" id="logged-breakdown">
+                <div class="lb-row">
+                  <span class="lb-dot lb-dot-logged"></span>
+                  <span class="lb-label">Logged</span>
+                  <span class="lb-hours" id="lb-logged-hours">0:00</span>
+                  <span class="lb-entries" id="lb-logged-entries">0 entries</span>
+                </div>
+                <div class="lb-row">
+                  <span class="lb-dot lb-dot-unlogged"></span>
+                  <span class="lb-label">Unlogged</span>
+                  <span class="lb-hours" id="lb-unlogged-hours">0:00</span>
+                  <span class="lb-entries" id="lb-unlogged-entries">0 entries</span>
+                </div>
+              </div>
+            </div>
+
+            <hr class="border-secondary my-3 opacity-25">
+
+            <!-- 2. WEEK SWITCHER -->
+            <div class="mb-3">
+              <label class="form-label label-text">Timesheet Week</label>
+              <div class="d-flex align-items-stretch gap-2 mb-2">
+                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-prev-week" title="Previous Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
+                  <i class="bi bi-chevron-left"></i>
+                </button>
+                <input type="week" id="week-picker" class="form-control dark-input m-0 flex-grow-1" />
+                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-next-week" title="Next Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
+                  <i class="bi bi-chevron-right"></i>
+                </button>
+              </div>
+              <div class="form-text text-muted mt-1" id="week-display-label">Select a week</div>
+            </div>
+
+            <button class="btn btn-outline-accent w-100 mb-4" id="btn-autofill-week">
+              <i class="bi bi-calendar-week me-1"></i> Use Current Week
+            </button>
+
+            <hr class="border-secondary my-3 opacity-25">
+
+            <!-- 3. SHEET DETAILS -->
             <div class="d-flex align-items-center justify-content-between mb-3">
               <h5 class="section-label mb-0"><i class="bi bi-person-badge me-2"></i>Sheet Details</h5>
               <button class="btn btn-sm btn-outline-accent px-2 py-1" id="btn-edit-sheet-details" title="Edit in Settings">
@@ -96,50 +156,11 @@
               <div class="sheet-detail-value" id="display-emp-name">—</div>
             </div>
 
-            <div class="mb-3">
-              <label class="form-label label-text">Timesheet Week</label>
-              <div class="d-flex align-items-stretch gap-2 mb-2">
-                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-prev-week" title="Previous Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
-                  <i class="bi bi-chevron-left"></i>
-                </button>
-                <input type="week" id="week-picker" class="form-control dark-input m-0 flex-grow-1" />
-                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-next-week" title="Next Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
-                  <i class="bi bi-chevron-right"></i>
-                </button>
-              </div>
-              <div class="form-text text-muted mt-1" id="week-display-label">Select a week</div>
-            </div>
-
-            <button class="btn btn-outline-accent w-100" id="btn-autofill-week">
-              <i class="bi bi-calendar-week me-1"></i> Use Current Week
-            </button>
-
-            <div class="mb-3 mt-3">
+            <div class="mb-1">
               <div class="label-text">Daily Target</div>
               <div class="sheet-detail-value" id="display-daily-target">—</div>
             </div>
 
-            <hr class="border-secondary my-4 opacity-25">
-
-            <!-- Totals Area inside the sidebar -->
-            <h5 class="section-label mb-3"><i class="bi bi-bar-chart-line me-2"></i>Weekly Summary</h5>
-            <div class="d-flex flex-column gap-3">
-              <div class="total-chip w-100 mt-0 text-center" id="total-hours-chip">
-                <div class="week-progress-fill" id="week-progress-fill"></div>
-                <span class="total-chip-label">Total Hours</span>
-                <span class="total-chip-value" id="total-hours">00:00</span>
-              </div>
-              <div class="d-flex gap-3">
-                <div class="total-chip flex-fill text-center px-2">
-                  <span class="total-chip-label" style="font-size:0.65rem">Work Days</span>
-                  <span class="total-chip-value fs-4" id="total-days">0</span>
-                </div>
-                <div class="total-chip flex-fill text-center px-2">
-                  <span class="total-chip-label" style="font-size:0.65rem">Entries</span>
-                  <span class="total-chip-value fs-4" id="total-entries">0</span>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
       </div> <!-- /LEFT COLUMN -->

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -249,15 +249,11 @@
                 placeholder="e.g. JIRA-123 or #123" />
               <div class="form-text text-muted">Use # prefix for Service Desk tickets</div>
             </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Hours (HH)</label>
-              <input type="number" id="modal-hh" class="form-control dark-input text-center" min="0" max="23"
-                placeholder="00" />
-            </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Minutes (MM)</label>
-              <input type="number" id="modal-mm" class="form-control dark-input text-center" min="0" max="59" step="1"
-                placeholder="00">
+            <div class="col-12 col-md-6 col-lg-4">
+              <label class="form-label label-text">Time</label>
+              <input type="text" id="modal-time" class="form-control dark-input"
+                placeholder="e.g. 2:30, 90m, 1.5h" autocomplete="off" />
+              <div class="invalid-feedback" id="modal-time-error"></div>
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
@@ -357,13 +353,11 @@
               <label class="form-label label-text">Ticket / Reference ID</label>
               <input type="text" id="recurring-ticket" class="form-control dark-input" placeholder="e.g. JIRA-123 or #123" />
             </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Hours (HH)</label>
-              <input type="number" id="recurring-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="00" />
-            </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Minutes (MM)</label>
-              <input type="number" id="recurring-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" />
+            <div class="col-12 col-md-6 col-lg-4">
+              <label class="form-label label-text">Time</label>
+              <input type="text" id="recurring-time" class="form-control dark-input"
+                placeholder="e.g. 2:30, 90m, 1.5h" autocomplete="off" />
+              <div class="invalid-feedback" id="recurring-time-error"></div>
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
@@ -484,13 +478,11 @@
               <label class="form-label label-text">Ticket / Reference ID</label>
               <input type="text" id="scheduled-form-ticket" class="form-control dark-input" placeholder="e.g. JIRA-123 or #123" />
             </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Hours (HH)</label>
-              <input type="number" id="scheduled-form-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="00" />
-            </div>
-            <div class="col-6 col-md-3 col-lg-2">
-              <label class="form-label label-text">Minutes (MM)</label>
-              <input type="number" id="scheduled-form-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" />
+            <div class="col-12 col-md-6 col-lg-4">
+              <label class="form-label label-text">Time</label>
+              <input type="text" id="scheduled-form-time" class="form-control dark-input"
+                placeholder="e.g. 2:30, 90m, 1.5h" autocomplete="off" />
+              <div class="invalid-feedback" id="scheduled-form-time-error"></div>
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
@@ -801,12 +793,9 @@
           <!-- Daily Target -->
           <div class="mb-4">
             <label class="form-label label-text">Daily Target</label>
-            <div class="d-flex align-items-center gap-2">
-              <input type="number" id="onb-target-hh" class="form-control dark-input text-center" min="0" max="23" placeholder="08" style="max-width:64px" />
-              <span class="label-text">hrs</span>
-              <input type="number" id="onb-target-mm" class="form-control dark-input text-center" min="0" max="59" placeholder="00" style="max-width:64px" />
-              <span class="label-text">min</span>
-            </div>
+            <input type="text" id="onb-target-time" class="form-control dark-input"
+              placeholder="e.g. 8h, 7:30, 450m" autocomplete="off" />
+            <div class="invalid-feedback" id="onb-target-time-error"></div>
           </div>
 
           <button class="btn btn-gradient w-100 btn-ripple" id="btn-onb-submit" disabled>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -625,6 +625,7 @@
           <div class="cheatsheet-group">
             <div class="cheatsheet-group-label">Entries</div>
             <div class="cheatsheet-row"><kbd>N</kbd> <span>Add new entry to expanded day</span></div>
+            <div class="cheatsheet-row"><kbd>Ctrl</kbd><kbd>V</kbd> <span>Open entry modal pre-filled with clipboard ticket</span></div>
             <div class="cheatsheet-row"><kbd>T</kbd> <span>Open notes for expanded day</span></div>
             <div class="cheatsheet-row"><kbd>Enter</kbd> <span>Save entry (inside entry modal)</span></div>
             <div class="cheatsheet-row"><kbd>Alt</kbd><kbd>N</kbd> <span>Open entry modal with no-ticket toggled on</span></div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -919,6 +919,28 @@
     </div>
   </div>
 
+  <!-- RESTORE CONFLICT MODAL -->
+  <div class="modal fade" id="restoreConflictModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+      <div class="modal-content rc-modal-content">
+        <div class="modal-header rc-modal-header">
+          <div>
+            <h5 class="modal-title rc-modal-title" id="rc-modal-title">Restore — Review Conflicts</h5>
+            <p class="rc-modal-subtitle" id="rc-modal-subtitle"></p>
+          </div>
+          <button type="button" class="btn-close btn-close-white" id="btn-rc-close" aria-label="Close"></button>
+        </div>
+        <div class="modal-body rc-modal-body" id="rc-modal-body"></div>
+        <div class="modal-footer rc-modal-footer">
+          <button class="btn btn-outline-light btn-sm px-3" id="btn-rc-cancel">Cancel</button>
+          <button class="btn btn-outline-light btn-sm px-3" id="btn-rc-back" style="display:none">Back</button>
+          <button class="btn btn-gradient px-4" id="btn-rc-preview">Preview Merge</button>
+          <button class="btn btn-gradient px-4" id="btn-rc-confirm" style="display:none">Confirm Restore</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="main.js"></script>
 </body>

--- a/src/renderer/modules/context-menu.js
+++ b/src/renderer/modules/context-menu.js
@@ -170,13 +170,30 @@ export function showEntryQuickView(dayIdx, entryIdx, btnEl) {
 
     const typeLabel = getTypeLabel(entry.type);
     const hhmm = `${String(entry.hh || 0).padStart(2,'0')}:${String(entry.mm || 0).padStart(2,'0')}`;
+    const statusRow = entry.loggedUpdated
+        ? `<div class="qv-row qv-status-row"><span class="qv-label">Status</span><span class="qv-updated-badge"><i class="bi bi-pencil-fill"></i> (updated)</span></div>`
+        : entry.logged
+            ? `<div class="qv-row qv-status-row"><span class="qv-label">Status</span><span class="qv-logged-badge"><i class="bi bi-journal-check"></i> Logged</span></div>`
+            : '';
 
     qv.innerHTML = `
+        <div class="qv-header">
+          <span class="qv-title">Entry</span>
+          <button class="qv-copy-btn" title="Copy to clipboard"><i class="bi bi-clipboard"></i></button>
+        </div>
         <div class="qv-row"><span class="qv-label">Ticket</span><span class="qv-value">${escHtml(entry.ticket || '—')}</span></div>
         <div class="qv-row"><span class="qv-label">Type</span><span class="qv-value">${escHtml(typeLabel)}</span></div>
         <div class="qv-row"><span class="qv-label">Time</span><span class="qv-value">${hhmm}</span></div>
-        <div class="qv-row"><span class="qv-label">Desc</span><span class="qv-desc">${escHtml(entry.desc || '—')}</span></div>`;
+        <div class="qv-row"><span class="qv-label">Desc</span><span class="qv-desc">${escHtml(entry.desc || '—')}</span></div>
+        ${statusRow}`;
     qv.dataset.for = `${dayIdx}-${entryIdx}`;
+
+    qv.querySelector('.qv-copy-btn').addEventListener('click', () => {
+        const text = `${entry.ticket || '—'} | ${hhmm} | ${typeLabel}\n${entry.desc || ''}`;
+        window.nativeClipboard?.writeText
+            ? window.nativeClipboard.writeText(text).then(() => showToast('Copied to clipboard.', 'success'))
+            : navigator.clipboard.writeText(text).then(() => showToast('Copied to clipboard.', 'success'));
+    });
 
     const rect = btnEl.getBoundingClientRect();
     qv.style.display = 'block';

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -1,8 +1,9 @@
-import { state, WEEK_DAYS } from './state.js';
+import { state, WEEK_DAYS, MAX_DAY_MINS } from './state.js';
 import { saveState } from './store.js';
 import { showToast, showConfirm } from './toast.js';
 import { updateSummary } from './summary.js';
 import { populateTypeSelect } from './ticket-types.js';
+import { parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 // Circular — resolved at call time
 import { rerenderDayCard, renderAll } from './render.js';
 import { updateNoTicketBanner } from './no-ticket-reminder.js';
@@ -17,6 +18,14 @@ export function initEntryModal() {
     document.getElementById('modal-no-ticket').addEventListener('change', function () {
         document.getElementById('modal-ticket-wrap').style.display = this.checked ? 'none' : '';
         if (!this.checked) document.getElementById('modal-ticket').value = '';
+    });
+
+    // Validate time field on blur — no rewrite, preserve what user typed
+    document.getElementById('modal-time').addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value) : null;
+        this.classList.toggle('is-invalid', !!err);
+        document.getElementById('modal-time-error').textContent = err || '';
+        updateEntryDayTotal();
     });
 }
 
@@ -81,8 +90,7 @@ export function openEntryModal(dayIdx, entryIdx) {
         noTicketToggle.checked = !!e.noTicket;
         document.getElementById('modal-ticket-wrap').style.display = e.noTicket ? 'none' : '';
         document.getElementById('modal-ticket').value = e.noTicket ? '' : (e.ticket || '');
-        document.getElementById('modal-hh').value = e.hh ?? 0;
-        document.getElementById('modal-mm').value = String(e.mm ?? 0).padStart(2, '0');
+        document.getElementById('modal-time').value = e.timeRaw || fmtTimeInput(e.hh ?? 0, e.mm ?? 0);
         populateTypeSelect(document.getElementById('modal-type'), e.type || state.ticketTypes[0]?.id || 'jira');
         document.getElementById('modal-desc').value = e.desc || '';
         document.getElementById('modal-group-id').value = e.groupId || '';
@@ -117,9 +125,8 @@ export function updateEntryDayTotal() {
         return sum + (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0);
     }, 0);
 
-    const addHH = parseInt(document.getElementById('modal-hh').value) || 0;
-    const addMM = parseInt(document.getElementById('modal-mm').value) || 0;
-    const addMins = addHH * 60 + addMM;
+    const timeParsed = parseTimeInput(document.getElementById('modal-time').value);
+    const addMins = timeParsed ? timeParsed.hh * 60 + timeParsed.mm : 0;
     const newTotalMins = baseMins + addMins;
 
     const fmt = (mins) => `${String(Math.floor(mins / 60)).padStart(2, '0')}:${String(mins % 60).padStart(2, '0')}`;
@@ -171,8 +178,8 @@ export function clearEntryModal() {
     document.getElementById('modal-logged').checked = false;
     document.getElementById('modal-ticket-wrap').style.display = '';
     document.getElementById('modal-ticket').value = '';
-    document.getElementById('modal-hh').value = '';
-    document.getElementById('modal-mm').value = '00';
+    document.getElementById('modal-time').value = '';
+    document.getElementById('modal-time').classList.remove('is-invalid');
     populateTypeSelect(document.getElementById('modal-type'), state.ticketTypes[0]?.id || 'jira');
     document.getElementById('modal-desc').value = '';
     document.getElementById('modal-group-id').value = '';
@@ -182,45 +189,32 @@ export function clearEntryModal() {
 export function saveEntryInternal() {
     const dayIdx = parseInt(document.getElementById('modal-day-index').value);
     const entryIdx = parseInt(document.getElementById('modal-entry-index').value);
-    const hhInput = document.getElementById('modal-hh');
-    const mmInput = document.getElementById('modal-mm');
+    const timeInput = document.getElementById('modal-time');
     const ticketInput = document.getElementById('modal-ticket');
     const descInput = document.getElementById('modal-desc');
 
-    const hh = parseInt(hhInput.value) || 0;
-    const mm = parseInt(mmInput.value) || 0;
+    const timeParsed = parseTimeInput(timeInput.value);
+    const hh = timeParsed ? timeParsed.hh : 0;
+    const mm = timeParsed ? timeParsed.mm : 0;
     const tkt = ticketInput.value.trim();
     const desc = descInput.value.trim();
 
     const isNoTicket = document.getElementById('modal-no-ticket').checked;
     let hasError = false;
 
-    [ticketInput, descInput, hhInput, mmInput].forEach(el => el.classList.remove('is-invalid'));
+    [ticketInput, descInput, timeInput].forEach(el => el.classList.remove('is-invalid'));
 
     if (!isNoTicket && !tkt) { ticketInput.classList.add('is-invalid'); hasError = true; }
     if (!desc) { descInput.classList.add('is-invalid'); hasError = true; }
-    if (hh === 0 && mm === 0) {
-        hhInput.classList.add('is-invalid');
-        mmInput.classList.add('is-invalid');
+    if (!timeParsed || (hh === 0 && mm === 0)) {
+        timeInput.classList.add('is-invalid');
         hasError = true;
     }
 
     if (hasError) {
         showToast('Please fill in all required fields (Ticket, Description, Time).', 'danger');
+        return false;
     }
-
-    if (hh > 24) {
-        hhInput.classList.add('is-invalid');
-        showToast('Hours cannot exceed 24.', 'danger');
-        hasError = true;
-    }
-    if (mm > 59) {
-        mmInput.classList.add('is-invalid');
-        showToast('Minutes cannot exceed 59.', 'danger');
-        hasError = true;
-    }
-
-    if (hasError) return false;
 
     let totalMinsForDay = (hh * 60) + mm;
     const day = state.days[dayIdx];
@@ -231,6 +225,14 @@ export function saveEntryInternal() {
                 totalMinsForDay += (parseInt(existingEntry.hh) || 0) * 60 + (parseInt(existingEntry.mm) || 0);
             }
         });
+    }
+
+    if (totalMinsForDay > MAX_DAY_MINS) {
+        const maxH = Math.floor(MAX_DAY_MINS / 60);
+        const totalH = Math.floor(totalMinsForDay / 60);
+        const totalM = totalMinsForDay % 60;
+        showToast(`Cannot log more than ${maxH}h in a single day. Total would be ${totalH}h ${totalM}m.`, 'danger');
+        return false;
     }
 
     if (totalMinsForDay > state.dailyTargetMins) {
@@ -255,13 +257,15 @@ export function commitEntry(dayIdx, entryIdx) {
     const groupType = document.getElementById('modal-group-type-ref').value;
     const isNoTicket = document.getElementById('modal-no-ticket').checked;
     const tkt = isNoTicket ? 'NO-TICKET' : document.getElementById('modal-ticket').value.trim();
-    const hh = parseInt(document.getElementById('modal-hh').value) || 0;
-    const mm = parseInt(document.getElementById('modal-mm').value) || 0;
+    const timeRaw = document.getElementById('modal-time').value.trim();
+    const timeParsed = parseTimeInput(timeRaw);
+    const hh = timeParsed ? timeParsed.hh : 0;
+    const mm = timeParsed ? timeParsed.mm : 0;
     const type = document.getElementById('modal-type').value;
     const desc = document.getElementById('modal-desc').value.trim();
 
     const isLogged = document.getElementById('modal-logged').checked;
-    const entry = { ticket: tkt, hh, mm, type, desc };
+    const entry = { ticket: tkt, hh, mm, timeRaw, type, desc };
     if (isNoTicket) entry.noTicket = true;
     if (isLogged) entry.logged = true;
     if (groupId) { entry.groupId = groupId; entry.groupType = groupType; }

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -276,6 +276,8 @@ export function commitEntry(dayIdx, entryIdx) {
         const existing = state.days[dayIdx].entries[entryIdx];
         if (existing && existing.recurringId) entry.recurringId = existing.recurringId;
         if (existing && existing.isScheduled) entry.isScheduled = existing.isScheduled;
+        // If it was logged before but not re-marked logged now, flag it as updated
+        if (existing && existing.logged && !isLogged) entry.loggedUpdated = true;
         // logged is NOT carried over from existing — modal already pre-unchecked it (auto-unmark on edit)
         state.days[dayIdx].entries[entryIdx] = entry;
     }

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -20,6 +20,33 @@ export function initEntryModal() {
     });
 }
 
+/* ── CLIPBOARD TICKET DETECTION ─────────────────────────── */
+export async function readClipboardTicket() {
+    try {
+        const text = await window.nativeClipboard.readText();
+        if (!text) return null;
+
+        const types = state.ticketTypes || [];
+
+        // Try each type's configured ticketPattern first
+        for (const type of types) {
+            if (!type.ticketPattern) continue;
+            try {
+                const m = new RegExp(type.ticketPattern).exec(text);
+                if (m) return { ticket: m[0], typeId: type.id };
+            } catch (_) { /* skip invalid stored pattern */ }
+        }
+
+        // Generic fallback: Jira-style KEY-123
+        const generic = /\b([A-Z][A-Z0-9]+-\d+)\b/.exec(text);
+        if (generic) return { ticket: generic[1], typeId: null };
+
+        return null;
+    } catch (_) {
+        return null;
+    }
+}
+
 export function openEntryModal(dayIdx, entryIdx) {
     document.getElementById('modal-day-index').value = dayIdx;
     document.getElementById('modal-entry-index').value = entryIdx;
@@ -35,6 +62,19 @@ export function openEntryModal(dayIdx, entryIdx) {
         copyToBtn.style.display = 'none';
         makeRegularBtn.style.display = 'none';
         title.innerHTML = `<i class="bi bi-plus-circle me-2"></i>Add Entry — ${WEEK_DAYS[dayIdx]}`;
+
+        // Auto-fill ticket from clipboard
+        readClipboardTicket().then(result => {
+            if (!result) return;
+            const ticketEl = document.getElementById('modal-ticket');
+            const typeEl   = document.getElementById('modal-type');
+            if (ticketEl && !ticketEl.value) {
+                ticketEl.value = result.ticket;
+            }
+            if (result.typeId && typeEl) {
+                typeEl.value = result.typeId;
+            }
+        });
     } else {
         const e = state.days[dayIdx].entries[entryIdx];
         const noTicketToggle = document.getElementById('modal-no-ticket');

--- a/src/renderer/modules/header.js
+++ b/src/renderer/modules/header.js
@@ -68,17 +68,5 @@ export function bindHeaderEvents() {
     document.getElementById('btn-delete-entry').addEventListener('click', deleteEntry);
     document.getElementById('btn-make-regular').addEventListener('click', makeRegularEntry);
 
-    [
-        ['modal-hh',          'modal-mm'],
-        ['recurring-hh',      'recurring-mm'],
-        ['scheduled-form-hh', 'scheduled-form-mm'],
-    ].forEach(([hhId, mmId]) => {
-        document.getElementById(hhId).addEventListener('input', function () {
-            if (this.value.length >= 2) document.getElementById(mmId).focus();
-        });
-    });
-
-    ['modal-hh', 'modal-mm'].forEach(id => {
-        document.getElementById(id).addEventListener('input', updateEntryDayTotal);
-    });
+    document.getElementById('modal-time').addEventListener('input', updateEntryDayTotal);
 }

--- a/src/renderer/modules/onboarding.js
+++ b/src/renderer/modules/onboarding.js
@@ -2,9 +2,10 @@
    ONBOARDING — first-run setup modal
    ============================================================= */
 
-import { state } from './state.js';
+import { state, MAX_TARGET_MINS } from './state.js';
 import { saveState } from './store.js';
 import { updateSheetDetailsDisplay } from './settings.js';
+import { parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 
 let _modalInst = null;
 
@@ -15,15 +16,16 @@ export function needsOnboarding() {
 export function initOnboarding() {
     const nameInput  = document.getElementById('onb-name');
     const submitBtn  = document.getElementById('btn-onb-submit');
-    const hhInput    = document.getElementById('onb-target-hh');
-    const mmInput    = document.getElementById('onb-target-mm');
+    const timeInput  = document.getElementById('onb-target-time');
 
     nameInput.addEventListener('input', () => {
         submitBtn.disabled = nameInput.value.trim() === '';
     });
 
-    hhInput.addEventListener('input', function () {
-        if (this.value.length >= 2) mmInput.focus();
+    timeInput.addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value, MAX_TARGET_MINS) : null;
+        this.classList.toggle('is-invalid', !!err);
+        document.getElementById('onb-target-time-error').textContent = err || '';
     });
 
     submitBtn.addEventListener('click', async () => {
@@ -31,8 +33,9 @@ export function initOnboarding() {
         if (!name) return;
 
         const title = document.getElementById('onb-report-title').value.trim();
-        const hh    = parseInt(hhInput.value) || 8;
-        const mm    = parseInt(mmInput.value) || 0;
+        const timeParsed = parseTimeInput(timeInput.value);
+        const hh    = timeParsed ? timeParsed.hh : 8;
+        const mm    = timeParsed ? timeParsed.mm : 0;
         const mins  = hh * 60 + mm;
 
         state.employeeName    = name;
@@ -53,8 +56,7 @@ export function showOnboarding() {
         // Pre-fill defaults
         document.getElementById('onb-report-title').value = state.reportTitle || 'Booked hours in Jira and Service Desk';
         const tgt = state.dailyTargetMins || 480;
-        document.getElementById('onb-target-hh').value = Math.floor(tgt / 60);
-        document.getElementById('onb-target-mm').value = tgt % 60;
+        document.getElementById('onb-target-time').value = fmtTimeInput(Math.floor(tgt / 60), tgt % 60);
         document.getElementById('onb-name').value = '';
         document.getElementById('btn-onb-submit').disabled = true;
 

--- a/src/renderer/modules/recurring.js
+++ b/src/renderer/modules/recurring.js
@@ -1,7 +1,7 @@
 import { state, RECURRING_DAY_NAMES, DAY_IDX_TO_NAME } from './state.js';
 import { saveState } from './store.js';
 import { showToast } from './toast.js';
-import { escHtml, fmtDate } from './utils.js';
+import { escHtml, fmtDate, parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 import { getTypeById, populateTypeSelect } from './ticket-types.js';
 import { getDateFromWeek, getWeekStrFromDate } from './week.js';
 // Circular — resolved at call time
@@ -110,6 +110,12 @@ export function initRecurring() {
 
     document.getElementById('btn-save-recurring').addEventListener('click', saveRecurringRule);
 
+    document.getElementById('recurring-time').addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value) : null;
+        this.classList.toggle('is-invalid', !!err);
+        document.getElementById('recurring-time-error').textContent = err || '';
+    });
+
     document.querySelectorAll('.recurring-day-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             btn.classList.toggle('selected');
@@ -180,8 +186,9 @@ function renderRecurringList() {
 function openRecurringForm(rule) {
     document.getElementById('recurring-form-id').value = rule ? rule.id : '';
     document.getElementById('recurring-ticket').value = rule ? rule.ticket : '';
-    document.getElementById('recurring-hh').value = rule ? rule.hh : '';
-    document.getElementById('recurring-mm').value = rule ? String(rule.mm || 0).padStart(2, '0') : '00';
+    const timeEl = document.getElementById('recurring-time');
+    timeEl.value = rule ? (rule.timeRaw || fmtTimeInput(rule.hh, rule.mm)) : '';
+    timeEl.classList.remove('is-invalid');
     populateTypeSelect(document.getElementById('recurring-type'), rule ? rule.type : (state.ticketTypes[0]?.id || 'jira'));
     document.getElementById('recurring-desc').value = rule ? rule.desc : '';
     document.getElementById('recurringFormTitle').innerHTML =
@@ -193,7 +200,7 @@ function openRecurringForm(rule) {
     syncAllDaysCheckbox();
 
     [document.getElementById('recurring-ticket'), document.getElementById('recurring-desc'),
-     document.getElementById('recurring-hh'), document.getElementById('recurring-mm')]
+     document.getElementById('recurring-time')]
         .forEach(el => el.classList.remove('is-invalid'));
 
     recurringFormModal.show();
@@ -201,22 +208,23 @@ function openRecurringForm(rule) {
 
 function saveRecurringRule() {
     const ticket = document.getElementById('recurring-ticket').value.trim();
-    const hh = parseInt(document.getElementById('recurring-hh').value) || 0;
-    const mm = parseInt(document.getElementById('recurring-mm').value) || 0;
+    const timeRaw = document.getElementById('recurring-time').value.trim();
+    const timeParsed = parseTimeInput(timeRaw);
+    const hh = timeParsed ? timeParsed.hh : 0;
+    const mm = timeParsed ? timeParsed.mm : 0;
     const type = document.getElementById('recurring-type').value;
     const desc = document.getElementById('recurring-desc').value.trim();
     const selectedDays = [...document.querySelectorAll('.recurring-day-btn.selected')].map(b => b.dataset.day);
 
     let hasError = false;
     [document.getElementById('recurring-ticket'), document.getElementById('recurring-desc'),
-     document.getElementById('recurring-hh'), document.getElementById('recurring-mm')]
+     document.getElementById('recurring-time')]
         .forEach(el => el.classList.remove('is-invalid'));
 
     if (!ticket) { document.getElementById('recurring-ticket').classList.add('is-invalid'); hasError = true; }
     if (!desc) { document.getElementById('recurring-desc').classList.add('is-invalid'); hasError = true; }
-    if (hh === 0 && mm === 0) {
-        document.getElementById('recurring-hh').classList.add('is-invalid');
-        document.getElementById('recurring-mm').classList.add('is-invalid');
+    if (!timeParsed || (hh === 0 && mm === 0)) {
+        document.getElementById('recurring-time').classList.add('is-invalid');
         hasError = true;
     }
     if (selectedDays.length === 0) { showToast('Select at least one day.', 'danger'); hasError = true; }
@@ -226,11 +234,11 @@ function saveRecurringRule() {
     if (existingId) {
         const rule = state.recurringTasks.find(r => r.id === existingId);
         if (rule) {
-            Object.assign(rule, { ticket, hh, mm, type, desc, days: selectedDays });
+            Object.assign(rule, { ticket, hh, mm, timeRaw, type, desc, days: selectedDays });
             updateRecurringEntriesFromToday(rule);
         }
     } else {
-        const rule = { id: 'rec_' + Date.now(), ticket, hh, mm, type, desc, days: selectedDays };
+        const rule = { id: 'rec_' + Date.now(), ticket, hh, mm, timeRaw, type, desc, days: selectedDays };
         state.recurringTasks.push(rule);
         populateRecurringForWeek(getDateFromWeek(state.weekValue || getWeekStrFromDate(new Date())));
     }

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -180,7 +180,7 @@ export function buildEntriesHTML(entries, dayIdx) {
 
             const rowI = rowIndex++;
             return `
-    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}${e.noTicket ? ' entry-no-ticket' : ''}${e.logged ? ' entry-logged' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
+    <div class="entry-row${e.isScheduled ? ' entry-scheduled' : ''}${e.noTicket ? ' entry-no-ticket' : ''}${e.logged ? ' entry-logged' : ''}${e.loggedUpdated ? ' entry-logged-updated' : ''}" style="--i:${rowI}" data-day="${dayIdx}" data-entry="${actualOriginalIndex}" data-group-idx="${gi}" data-item-idx="${itemIdx}" data-group-type="${group.type}">
       <span class="drag-handle" title="Drag to reorder"><i class="bi bi-grip-vertical"></i></span>
       <span class="entry-num entry-num-roman">${rStr}</span>
       ${ticketHtml}
@@ -193,6 +193,7 @@ export function buildEntriesHTML(entries, dayIdx) {
         <button class="entry-btn-logged ${loggedClass}" title="${loggedTitle}"><i class="bi ${loggedIcon}"></i></button>
         <button class="entry-btn-star ${starClass}" title="${e.starred ? 'Unstar' : 'Star'}"><i class="bi ${starIcon}"></i></button>
       </div>
+      ${e.loggedUpdated ? '<span class="entry-updated-label">edited</span>' : ''}
     </div>`;
         }).join('');
 

--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -79,7 +79,9 @@ export function generateDayTxt(day, useHHMM = false) {
                     }
 
                     const showDesc = !(group.type === 'desc_group' && !isLast);
-                    const loggedMark = (!useHHMM && e.logged) ? '  (✓ logged)' : '';
+                    const loggedMark = !useHHMM
+                        ? e.loggedUpdated ? '  (updated)' : e.logged ? '  (✓ logged)' : ''
+                        : '';
 
                     if (!showDesc) {
                         lines.push(`${indent}${rStr}${ticket} ${timeStr}${loggedMark}`);

--- a/src/renderer/modules/restore.js
+++ b/src/renderer/modules/restore.js
@@ -1,0 +1,419 @@
+/* =============================================================
+   RESTORE — JSON backup restore with conflict resolution
+   ============================================================= */
+
+import { state } from './state.js';
+import { saveState } from './store.js';
+import { showToast, showConfirm } from './toast.js';
+import { escHtml } from './utils.js';
+import { renderAll } from './render.js';
+import { updateSummary } from './summary.js';
+
+let _modalInst  = null;
+let _cleanDays  = {};
+let _resolutions = [];  // [{ date, currentDay, incomingDay, same[], conflicts[], mineOnly[], theirsOnly[] }]
+
+/* ── PUBLIC ENTRY POINT ─────────────────────────────────────── */
+export async function openRestoreFromJson() {
+    let parsed;
+    try {
+        parsed = await window.backup.openJsonFile();
+    } catch (e) {
+        showToast('Could not read file. Is this a valid backup?', 'danger');
+        return;
+    }
+    if (!parsed) return; // user cancelled
+
+    if (!parsed.data || typeof parsed.data !== 'object') {
+        showToast('Invalid backup file — missing data field.', 'danger');
+        return;
+    }
+
+    const incoming = parsed.data.allDaysByDate || {};
+    if (Object.keys(incoming).length === 0) {
+        showToast('Backup file contains no timesheet data.', 'danger');
+        return;
+    }
+
+    const { cleanDays, conflictDays } = _diffBackup(incoming);
+    const totalDays = Object.keys(cleanDays).length + conflictDays.length;
+
+    if (conflictDays.length === 0) {
+        showConfirm(
+            `Restore ${totalDays} day(s) from backup with no conflicts. Existing entries for these days will be overwritten. Proceed?`,
+            () => _applyRestore(cleanDays)
+        );
+        return;
+    }
+
+    _cleanDays   = cleanDays;
+    _resolutions = conflictDays.map(({ date, current, incoming: inc }) =>
+        _buildResolution(date, current, inc));
+    _showModal();
+}
+
+/* ── DIFF ───────────────────────────────────────────────────── */
+function _diffBackup(incoming) {
+    const current     = state.allDaysByDate;
+    const cleanDays   = {};
+    const conflictDays = [];
+
+    for (const [date, incomingDay] of Object.entries(incoming)) {
+        if (!incomingDay) continue;
+        const currentDay        = current[date];
+        const hasCurrentEntries = currentDay && (currentDay.entries || []).length > 0;
+
+        if (!hasCurrentEntries) {
+            cleanDays[date] = incomingDay;
+            continue;
+        }
+
+        if (_daysIdentical(currentDay, incomingDay)) {
+            cleanDays[date] = incomingDay;
+        } else {
+            conflictDays.push({ date, current: currentDay, incoming: incomingDay });
+        }
+    }
+
+    conflictDays.sort((a, b) => a.date < b.date ? -1 : 1);
+    return { cleanDays, conflictDays };
+}
+
+function _daysIdentical(a, b) {
+    const sort = arr => [...(arr || [])].sort((x, y) =>
+        JSON.stringify(x) < JSON.stringify(y) ? -1 : 1);
+    return JSON.stringify(sort(a.entries)) === JSON.stringify(sort(b.entries)) &&
+           !!a.isHoliday === !!b.isHoliday &&
+           (a.holidayLabel || '') === (b.holidayLabel || '');
+}
+
+function _entryKey(e) {
+    return `${(e.ticket || '').toLowerCase()}|${e.type || ''}`;
+}
+
+function _entriesIdentical(a, b) {
+    return a.ticket === b.ticket && a.hh === b.hh && a.mm === b.mm &&
+           a.type  === b.type   && (a.desc || '') === (b.desc || '');
+}
+
+function _buildResolution(date, currentDay, incomingDay) {
+    const currentEntries  = currentDay.entries  || [];
+    const incomingEntries = incomingDay.entries || [];
+
+    const same       = [];
+    const conflicts  = [];
+    const mineOnly   = [];
+    const theirsOnly = [];
+
+    const usedCurrentIdx  = new Set();
+    const usedIncomingIdx = new Set();
+
+    // Pass 1: exact matches → same (auto-kept)
+    incomingEntries.forEach((theirs, i) => {
+        const j = currentEntries.findIndex((mine, idx) =>
+            !usedCurrentIdx.has(idx) && _entriesIdentical(mine, theirs));
+        if (j >= 0) {
+            same.push(theirs);
+            usedCurrentIdx.add(j);
+            usedIncomingIdx.add(i);
+        }
+    });
+
+    // Pass 2: same ticket+type but different values → conflict
+    incomingEntries.forEach((theirs, i) => {
+        if (usedIncomingIdx.has(i)) return;
+        const key = _entryKey(theirs);
+        const j   = currentEntries.findIndex((mine, idx) =>
+            !usedCurrentIdx.has(idx) && _entryKey(mine) === key);
+        if (j >= 0) {
+            conflicts.push({ mine: currentEntries[j], theirs, choice: 'theirs' });
+            usedCurrentIdx.add(j);
+            usedIncomingIdx.add(i);
+        }
+    });
+
+    // Pass 3: remaining incoming → theirs-only (new in backup)
+    incomingEntries.forEach((entry, i) => {
+        if (!usedIncomingIdx.has(i)) theirsOnly.push({ entry, keep: true });
+    });
+
+    // Pass 4: remaining current → mine-only (removed in backup)
+    currentEntries.forEach((entry, j) => {
+        if (!usedCurrentIdx.has(j)) mineOnly.push({ entry, keep: false });
+    });
+
+    return { date, currentDay, incomingDay, same, conflicts, mineOnly, theirsOnly };
+}
+
+/* ── MODAL LIFECYCLE ────────────────────────────────────────── */
+function _showModal() {
+    const modalEl = document.getElementById('restoreConflictModal');
+    if (!_modalInst) {
+        _modalInst = new bootstrap.Modal(modalEl, { backdrop: 'static', keyboard: false });
+        document.getElementById('btn-rc-close').addEventListener('click',   () => _modalInst.hide());
+        document.getElementById('btn-rc-cancel').addEventListener('click',  () => _modalInst.hide());
+        document.getElementById('btn-rc-back').addEventListener('click',    _showConflictView);
+        document.getElementById('btn-rc-preview').addEventListener('click', _showPreviewView);
+        document.getElementById('btn-rc-confirm').addEventListener('click', _confirmRestore);
+    }
+    _showConflictView();
+    _modalInst.show();
+}
+
+function _showConflictView() {
+    const cleanCount    = Object.keys(_cleanDays).length;
+    const conflictCount = _resolutions.length;
+    document.getElementById('rc-modal-title').textContent    = 'Restore — Review Conflicts';
+    document.getElementById('rc-modal-subtitle').textContent =
+        `${conflictCount} day(s) need review · ${cleanCount} day(s) will merge automatically`;
+    document.getElementById('btn-rc-preview').style.display = '';
+    document.getElementById('btn-rc-confirm').style.display = 'none';
+    document.getElementById('btn-rc-back').style.display    = 'none';
+    _renderConflictBody();
+}
+
+function _showPreviewView() {
+    document.getElementById('rc-modal-title').textContent    = 'Restore — Preview';
+    document.getElementById('rc-modal-subtitle').textContent = 'Review the final result before applying.';
+    document.getElementById('btn-rc-preview').style.display = 'none';
+    document.getElementById('btn-rc-confirm').style.display = '';
+    document.getElementById('btn-rc-back').style.display    = '';
+    _renderPreviewBody();
+}
+
+/* ── CONFLICT BODY ──────────────────────────────────────────── */
+function _renderConflictBody() {
+    const body = document.getElementById('rc-modal-body');
+    const cleanCount = Object.keys(_cleanDays).length;
+
+    const daysHtml = _resolutions.map((res, dayIdx) => {
+        const hasChoices = res.conflicts.length > 0 || res.mineOnly.length > 0 || res.theirsOnly.length > 0;
+        return `
+        <div class="rc-day-block">
+            <div class="rc-day-header">
+                <span class="rc-day-label">${escHtml(_fmtDate(res.date))}</span>
+                ${hasChoices ? `
+                <div class="rc-day-shortcuts">
+                    <button class="btn btn-sm btn-outline-light rc-use-mine" data-day="${dayIdx}">Use all mine</button>
+                    <button class="btn btn-sm btn-outline-light rc-use-theirs" data-day="${dayIdx}">Use all theirs</button>
+                </div>` : ''}
+            </div>
+            <div class="rc-entries">
+                ${_renderSameEntries(res.same)}
+                ${res.conflicts.map((c, ci) => _renderConflictEntry(dayIdx, ci, c)).join('')}
+                ${res.mineOnly.map((m, mi) => _renderMineOnlyEntry(dayIdx, mi, m)).join('')}
+                ${res.theirsOnly.map((t, ti) => _renderTheirsOnlyEntry(dayIdx, ti, t)).join('')}
+            </div>
+        </div>`;
+    }).join('');
+
+    const cleanNote = cleanCount > 0 ? `
+        <div class="rc-clean-note">
+            <i class="bi bi-check-circle-fill me-2" style="color:var(--success)"></i>
+            ${cleanCount} additional day(s) will be merged automatically with no conflicts.
+        </div>` : '';
+
+    body.innerHTML = daysHtml + cleanNote;
+    _bindConflictEvents(body);
+}
+
+function _renderSameEntries(entries) {
+    return entries.map(e => `
+        <div class="rc-entry rc-entry-same">
+            <i class="bi bi-check2 rc-entry-icon" style="color:var(--success)"></i>
+            <span class="rc-entry-ticket">${escHtml(e.ticket || '—')}</span>
+            <span class="rc-entry-time">${escHtml(e.hh || '0')}h ${escHtml(e.mm || '00')}m</span>
+            <span class="rc-entry-type">${escHtml(e.type || '')}</span>
+            <span class="rc-entry-desc">${escHtml(e.desc || '')}</span>
+            <span class="rc-entry-badge rc-badge-same">Unchanged</span>
+        </div>`).join('');
+}
+
+function _renderConflictEntry(dayIdx, ci, { mine, theirs, choice }) {
+    return `
+    <div class="rc-entry-conflict">
+        <div class="rc-conflict-label">
+            <i class="bi bi-exclamation-triangle-fill me-1" style="color:var(--warning)"></i>
+            Conflict — ${escHtml(theirs.ticket || mine.ticket || '—')}
+        </div>
+        <div class="rc-conflict-sides">
+            <div class="rc-conflict-side ${choice === 'mine' || choice === 'both' ? 'rc-side-selected' : 'rc-side-dim'}">
+                <div class="rc-side-header">Current (mine)</div>
+                <div class="rc-side-entry">
+                    <span class="rc-entry-time">${escHtml(mine.hh || '0')}h ${escHtml(mine.mm || '00')}m</span>
+                    <span class="rc-entry-type">${escHtml(mine.type || '')}</span>
+                    <span class="rc-entry-desc">${escHtml(mine.desc || '')}</span>
+                </div>
+            </div>
+            <div class="rc-conflict-side ${choice === 'theirs' || choice === 'both' ? 'rc-side-selected' : 'rc-side-dim'}">
+                <div class="rc-side-header">Backup (theirs)</div>
+                <div class="rc-side-entry">
+                    <span class="rc-entry-time">${escHtml(theirs.hh || '0')}h ${escHtml(theirs.mm || '00')}m</span>
+                    <span class="rc-entry-type">${escHtml(theirs.type || '')}</span>
+                    <span class="rc-entry-desc">${escHtml(theirs.desc || '')}</span>
+                </div>
+            </div>
+        </div>
+        <div class="rc-conflict-actions">
+            <button class="btn btn-sm rc-choice-btn ${choice === 'mine'   ? 'active' : ''}" data-day="${dayIdx}" data-ci="${ci}" data-choice="mine">Keep Mine</button>
+            <button class="btn btn-sm rc-choice-btn ${choice === 'theirs' ? 'active' : ''}" data-day="${dayIdx}" data-ci="${ci}" data-choice="theirs">Keep Theirs</button>
+            <button class="btn btn-sm rc-choice-btn ${choice === 'both'   ? 'active' : ''}" data-day="${dayIdx}" data-ci="${ci}" data-choice="both">Keep Both</button>
+        </div>
+    </div>`;
+}
+
+function _renderMineOnlyEntry(dayIdx, mi, { entry, keep }) {
+    return `
+    <div class="rc-entry ${keep ? 'rc-entry-kept' : 'rc-entry-discarded'}">
+        <i class="bi bi-dash-circle rc-entry-icon" style="color:var(--text-muted)"></i>
+        <span class="rc-entry-ticket">${escHtml(entry.ticket || '—')}</span>
+        <span class="rc-entry-time">${escHtml(entry.hh || '0')}h ${escHtml(entry.mm || '00')}m</span>
+        <span class="rc-entry-type">${escHtml(entry.type || '')}</span>
+        <span class="rc-entry-desc">${escHtml(entry.desc || '')}</span>
+        <span class="rc-entry-badge rc-badge-mine">Mine only</span>
+        <button class="btn btn-sm rc-toggle-mine ${keep ? 'active' : ''}" data-day="${dayIdx}" data-mi="${mi}">
+            ${keep ? 'Keep' : 'Discard'}
+        </button>
+    </div>`;
+}
+
+function _renderTheirsOnlyEntry(dayIdx, ti, { entry, keep }) {
+    return `
+    <div class="rc-entry ${keep ? 'rc-entry-kept' : 'rc-entry-discarded'}">
+        <i class="bi bi-plus-circle rc-entry-icon" style="color:var(--accent-light)"></i>
+        <span class="rc-entry-ticket">${escHtml(entry.ticket || '—')}</span>
+        <span class="rc-entry-time">${escHtml(entry.hh || '0')}h ${escHtml(entry.mm || '00')}m</span>
+        <span class="rc-entry-type">${escHtml(entry.type || '')}</span>
+        <span class="rc-entry-desc">${escHtml(entry.desc || '')}</span>
+        <span class="rc-entry-badge rc-badge-theirs">New in backup</span>
+        <button class="btn btn-sm rc-toggle-theirs ${keep ? 'active' : ''}" data-day="${dayIdx}" data-ti="${ti}">
+            ${keep ? 'Include' : 'Skip'}
+        </button>
+    </div>`;
+}
+
+function _bindConflictEvents(body) {
+    body.querySelectorAll('.rc-use-mine').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const res = _resolutions[+btn.dataset.day];
+            res.conflicts.forEach(c  => { c.choice = 'mine'; });
+            res.mineOnly.forEach(m   => { m.keep   = true;   });
+            res.theirsOnly.forEach(t => { t.keep   = false;  });
+            _renderConflictBody();
+        });
+    });
+
+    body.querySelectorAll('.rc-use-theirs').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const res = _resolutions[+btn.dataset.day];
+            res.conflicts.forEach(c  => { c.choice = 'theirs'; });
+            res.mineOnly.forEach(m   => { m.keep   = false;    });
+            res.theirsOnly.forEach(t => { t.keep   = true;     });
+            _renderConflictBody();
+        });
+    });
+
+    body.querySelectorAll('.rc-choice-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            _resolutions[+btn.dataset.day].conflicts[+btn.dataset.ci].choice = btn.dataset.choice;
+            _renderConflictBody();
+        });
+    });
+
+    body.querySelectorAll('.rc-toggle-mine').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const m = _resolutions[+btn.dataset.day].mineOnly[+btn.dataset.mi];
+            m.keep = !m.keep;
+            _renderConflictBody();
+        });
+    });
+
+    body.querySelectorAll('.rc-toggle-theirs').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const t = _resolutions[+btn.dataset.day].theirsOnly[+btn.dataset.ti];
+            t.keep = !t.keep;
+            _renderConflictBody();
+        });
+    });
+}
+
+/* ── PREVIEW BODY ───────────────────────────────────────────── */
+function _renderPreviewBody() {
+    const body       = document.getElementById('rc-modal-body');
+    const merged     = _buildMergedDays();
+    const cleanCount = Object.keys(_cleanDays).length;
+
+    const resolvedHtml = _resolutions.map(res => {
+        const entries = merged[res.date]?.entries || [];
+        return `
+        <div class="rc-preview-day">
+            <div class="rc-preview-day-header">${escHtml(_fmtDate(res.date))}</div>
+            ${entries.length === 0
+                ? '<div class="rc-preview-entry rc-preview-empty">No entries</div>'
+                : entries.map(e => `
+                    <div class="rc-preview-entry">
+                        <span class="rc-entry-ticket">${escHtml(e.ticket || '—')}</span>
+                        <span class="rc-entry-time">${escHtml(e.hh || '0')}h ${escHtml(e.mm || '00')}m</span>
+                        <span class="rc-entry-type">${escHtml(e.type || '')}</span>
+                        <span class="rc-entry-desc">${escHtml(e.desc || '')}</span>
+                    </div>`).join('')}
+        </div>`;
+    }).join('');
+
+    body.innerHTML = `
+        <div class="rc-preview-summary">
+            <i class="bi bi-check2-all me-2" style="color:var(--success)"></i>
+            <strong>${_resolutions.length}</strong> conflict day(s) resolved &nbsp;·&nbsp;
+            <strong>${cleanCount}</strong> day(s) auto-merged &nbsp;·&nbsp;
+            <strong>${_resolutions.length + cleanCount}</strong> total days ready to restore
+        </div>
+        <p class="rc-preview-section-title">Resolved days — final entries</p>
+        ${resolvedHtml}
+        ${cleanCount > 0 ? `<div class="rc-clean-note mt-3"><i class="bi bi-check-circle-fill me-2" style="color:var(--success)"></i>${cleanCount} additional day(s) merged automatically.</div>` : ''}`;
+}
+
+/* ── MERGE & APPLY ──────────────────────────────────────────── */
+function _buildMergedDays() {
+    const merged = { ..._cleanDays };
+
+    for (const res of _resolutions) {
+        const entries = [
+            ...res.same,
+            ...res.conflicts.flatMap(c => {
+                if (c.choice === 'mine')   return [c.mine];
+                if (c.choice === 'theirs') return [c.theirs];
+                return [c.mine, c.theirs]; // both
+            }),
+            ...res.mineOnly.filter(m  => m.keep).map(m  => m.entry),
+            ...res.theirsOnly.filter(t => t.keep).map(t => t.entry),
+        ];
+        merged[res.date] = { ...res.incomingDay, entries };
+    }
+
+    return merged;
+}
+
+async function _confirmRestore() {
+    _modalInst.hide();
+    await _applyRestore(_buildMergedDays());
+}
+
+async function _applyRestore(mergedDays) {
+    try {
+        state.allDaysByDate = { ...state.allDaysByDate, ...mergedDays };
+        await saveState();
+        renderAll();
+        updateSummary();
+        showToast('Restore complete.', 'success');
+    } catch (e) {
+        showToast('Restore failed. Check error logs.', 'danger');
+    }
+}
+
+/* ── UTILS ──────────────────────────────────────────────────── */
+function _fmtDate(dateStr) {
+    try {
+        return new Date(dateStr + 'T00:00:00')
+            .toLocaleDateString(undefined, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+    } catch (_) { return dateStr; }
+}

--- a/src/renderer/modules/restore.js
+++ b/src/renderer/modules/restore.js
@@ -8,12 +8,51 @@ import { showToast, showConfirm } from './toast.js';
 import { escHtml } from './utils.js';
 import { renderAll } from './render.js';
 import { updateSummary } from './summary.js';
+import { buildWeekDays, getDateFromWeek } from './week.js';
 
 let _modalInst  = null;
 let _cleanDays  = {};
 let _resolutions = [];  // [{ date, currentDay, incomingDay, same[], conflicts[], mineOnly[], theirsOnly[] }]
 
-/* ── PUBLIC ENTRY POINT ─────────────────────────────────────── */
+/* ── PUBLIC ENTRY POINTS ────────────────────────────────────── */
+export async function openRestoreFromTxt() {
+    let parsed;
+    try {
+        parsed = await window.backup.openTxtFile();
+    } catch (e) {
+        showToast('Could not read file. Is this a Timesheet Manager report?', 'danger');
+        return;
+    }
+    if (!parsed) return; // user cancelled
+
+    if (parsed.error) {
+        showToast(`${parsed.error} Is this a Timesheet Manager report?`, 'danger');
+        return;
+    }
+
+    const incoming = parsed;
+    if (typeof incoming !== 'object' || Object.keys(incoming).length === 0) {
+        showToast('No timesheet data found in this file. Is this a Timesheet Manager report?', 'danger');
+        return;
+    }
+
+    const { cleanDays, conflictDays } = _diffBackup(incoming);
+    const totalDays = Object.keys(cleanDays).length + conflictDays.length;
+
+    if (conflictDays.length === 0) {
+        showConfirm(
+            `Restore ${totalDays} day(s) from TXT report with no conflicts. Existing entries for these days will be overwritten. Proceed?`,
+            () => _applyRestore(cleanDays)
+        );
+        return;
+    }
+
+    _cleanDays   = cleanDays;
+    _resolutions = conflictDays.map(({ date, current, incoming: inc }) =>
+        _buildResolution(date, current, inc));
+    _showModal();
+}
+
 export async function openRestoreFromJson() {
     let parsed;
     try {
@@ -401,6 +440,12 @@ async function _confirmRestore() {
 async function _applyRestore(mergedDays) {
     try {
         state.allDaysByDate = { ...state.allDaysByDate, ...mergedDays };
+        // Rebuild state.days so renderAll picks up the restored day objects
+        // for the currently displayed week (spread creates new objects, old
+        // references in state.days would otherwise still point to stale data).
+        if (state.weekValue) {
+            state.days = buildWeekDays(getDateFromWeek(state.weekValue));
+        }
         await saveState();
         renderAll();
         updateSummary();

--- a/src/renderer/modules/scheduled.js
+++ b/src/renderer/modules/scheduled.js
@@ -1,7 +1,7 @@
 import { state } from './state.js';
 import { saveState } from './store.js';
 import { showToast } from './toast.js';
-import { escHtml, fmtDate } from './utils.js';
+import { escHtml, fmtDate, parseTimeInput, timeInputError } from './utils.js';
 import { getTypeById, populateTypeSelect } from './ticket-types.js';
 // Circular — resolved at call time
 import { rerenderDayCard } from './render.js';
@@ -52,6 +52,12 @@ export function initScheduledTasks() {
     });
 
     document.getElementById('btn-save-scheduled').addEventListener('click', saveScheduledTask);
+
+    document.getElementById('scheduled-form-time').addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value) : null;
+        this.classList.toggle('is-invalid', !!err);
+        document.getElementById('scheduled-form-time-error').textContent = err || '';
+    });
 
     const closeForm = () => {
         scheduledFormModal.hide();
@@ -176,8 +182,9 @@ function openScheduledForm() {
     dateInput.classList.remove('is-invalid');
     document.getElementById('scheduled-form-ticket').value = '';
     document.getElementById('scheduled-form-ticket').classList.remove('is-invalid');
-    document.getElementById('scheduled-form-hh').value = '';
-    document.getElementById('scheduled-form-mm').value = '00';
+    const timeEl = document.getElementById('scheduled-form-time');
+    timeEl.value = '';
+    timeEl.classList.remove('is-invalid');
     populateTypeSelect(document.getElementById('scheduled-form-type'), state.ticketTypes[0]?.id || 'jira');
     document.getElementById('scheduled-form-desc').value = '';
     document.getElementById('scheduled-form-desc').classList.remove('is-invalid');
@@ -191,17 +198,22 @@ function saveScheduledTask() {
     const scheduledDate = dateInput.value;
     const tkt = ticketInput.value.trim();
     const desc = descInput.value.trim();
-    const hh = parseInt(document.getElementById('scheduled-form-hh').value) || 0;
-    const mm = parseInt(document.getElementById('scheduled-form-mm').value) || 0;
+    const timeParsed = parseTimeInput(document.getElementById('scheduled-form-time').value);
+    const hh = timeParsed ? timeParsed.hh : 0;
+    const mm = timeParsed ? timeParsed.mm : 0;
     const type = document.getElementById('scheduled-form-type').value;
 
     let hasError = false;
-    [dateInput, ticketInput, descInput].forEach(el => el.classList.remove('is-invalid'));
+    [dateInput, ticketInput, descInput, document.getElementById('scheduled-form-time')]
+        .forEach(el => el.classList.remove('is-invalid'));
 
     if (!scheduledDate) { dateInput.classList.add('is-invalid'); hasError = true; }
     if (!tkt) { ticketInput.classList.add('is-invalid'); hasError = true; }
     if (!desc) { descInput.classList.add('is-invalid'); hasError = true; }
-    if (hh === 0 && mm === 0) { hasError = true; }
+    if (!timeParsed || (hh === 0 && mm === 0)) {
+        document.getElementById('scheduled-form-time').classList.add('is-invalid');
+        hasError = true;
+    }
 
     if (hasError) { showToast('Please fill in all required fields.', 'danger'); return; }
 

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -2,7 +2,7 @@
    SETTINGS — full-screen modal shell, nav routing, dirty state
    ============================================================= */
 
-import { state, APP_VERSION } from './state.js';
+import { state, APP_VERSION, MAX_TARGET_MINS } from './state.js';
 import { saveState } from './store.js';
 import { showToast } from './toast.js';
 import { updateSummary } from './summary.js';
@@ -13,6 +13,7 @@ import { renderTicketTypesSection } from './ticket-types.js';
 import { renderLeaveTypesSection } from './leave-types.js';
 import { renderErrorLogSection } from './error-log.js';
 import { openRestoreFromJson, openRestoreFromTxt } from './restore.js';
+import { parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -199,8 +200,6 @@ function renderSection(section) {
 
 function renderGeneral(el) {
     const tgt = state.dailyTargetMins || 480;
-    const hhVal = Math.floor(tgt / 60);
-    const mmVal = tgt % 60;
 
     el.innerHTML = `
         <div class="settings-section-header">
@@ -222,15 +221,11 @@ function renderGeneral(el) {
                         value="${escHtml(state.employeeName || '')}" />
                 </div>
                 <div class="settings-form-group">
-                    <label class="label-text">Daily Target</label>
-                    <div class="d-flex align-items-center gap-2">
-                        <input type="number" id="settings-target-hh" class="form-control dark-input text-center"
-                            min="0" max="23" placeholder="08" value="${hhVal}" style="max-width:64px" />
-                        <span class="label-text">hrs</span>
-                        <input type="number" id="settings-target-mm" class="form-control dark-input text-center"
-                            min="0" max="59" placeholder="00" value="${mmVal}" style="max-width:64px" />
-                        <span class="label-text">min</span>
-                    </div>
+                    <label class="label-text" for="settings-target-time">Daily Target</label>
+                    <input type="text" id="settings-target-time" class="form-control dark-input"
+                        placeholder="e.g. 8h, 7:30, 450m"
+                        value="${escHtml(fmtTimeInput(Math.floor(tgt / 60), tgt % 60))}" style="max-width:160px" />
+                    <div class="invalid-feedback" id="settings-target-time-error"></div>
                 </div>
                 <div class="settings-form-actions">
                     <button class="btn btn-gradient px-4" id="btn-save-general">
@@ -244,21 +239,30 @@ function renderGeneral(el) {
     const markGeneralDirty = () => markDirty('general');
     el.querySelector('#settings-report-title').addEventListener('input', markGeneralDirty);
     el.querySelector('#settings-emp-name').addEventListener('input', markGeneralDirty);
-    el.querySelector('#settings-target-hh').addEventListener('input', markGeneralDirty);
-    el.querySelector('#settings-target-mm').addEventListener('input', markGeneralDirty);
+    el.querySelector('#settings-target-time').addEventListener('input', markGeneralDirty);
 
-    // HH auto-advance to MM
-    el.querySelector('#settings-target-hh').addEventListener('input', function () {
-        if (this.value.length >= 2) el.querySelector('#settings-target-mm').focus();
+    // Validate on blur — no rewrite
+    el.querySelector('#settings-target-time').addEventListener('blur', function () {
+        const err = this.value.trim() ? timeInputError(this.value, MAX_TARGET_MINS) : null;
+        this.classList.toggle('is-invalid', !!err);
+        el.querySelector('#settings-target-time-error').textContent = err || '';
     });
 
     // Save
     el.querySelector('#btn-save-general').addEventListener('click', () => {
         const title = el.querySelector('#settings-report-title').value.trim();
         const name  = el.querySelector('#settings-emp-name').value.trim();
-        const hh    = parseInt(el.querySelector('#settings-target-hh').value) || 0;
-        const mm    = parseInt(el.querySelector('#settings-target-mm').value) || 0;
-        const mins  = hh * 60 + mm;
+        const timeEl = el.querySelector('#settings-target-time');
+        const timeParsed = parseTimeInput(timeEl.value);
+        const mins  = timeParsed ? timeParsed.hh * 60 + timeParsed.mm : 0;
+        const timeErr = timeEl.value.trim() ? timeInputError(timeEl.value, MAX_TARGET_MINS) : null;
+
+        if (timeErr) {
+            timeEl.classList.add('is-invalid');
+            el.querySelector('#settings-target-time-error').textContent = timeErr;
+            showToast(timeErr, 'danger');
+            return;
+        }
 
         state.reportTitle    = title;
         state.employeeName   = name;

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -12,7 +12,7 @@ import { applyTheme } from './theme.js';
 import { renderTicketTypesSection } from './ticket-types.js';
 import { renderLeaveTypesSection } from './leave-types.js';
 import { renderErrorLogSection } from './error-log.js';
-import { openRestoreFromJson } from './restore.js';
+import { openRestoreFromJson, openRestoreFromTxt } from './restore.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -665,7 +665,7 @@ function renderRestore(el) {
                         Import a <code>.txt</code> timesheet report downloaded from this app.
                         Conflicting weeks will go through the same merge review as a JSON restore.
                     </p>
-                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-txt" disabled>
+                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-txt">
                         <i class="bi bi-file-earmark-text me-1"></i> Choose Report File (.txt)
                     </button>
                 </div>
@@ -673,6 +673,7 @@ function renderRestore(el) {
         </div>`;
 
     el.querySelector('#btn-restore-json').addEventListener('click', () => openRestoreFromJson());
+    el.querySelector('#btn-restore-txt').addEventListener('click', () => openRestoreFromTxt());
 }
 
 function _renderMarkdown(md) {

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -503,10 +503,10 @@ async function renderBackup(el) {
             <div class="settings-form">
                 <div class="settings-form-group">
                     <label class="label-text">Manual Backup</label>
-                    <button class="btn btn-gradient px-4" id="btn-backup-now" disabled>
+                    <button class="btn btn-gradient px-4" id="btn-backup-now">
                         <i class="bi bi-cloud-arrow-up me-1"></i> Backup Now
                     </button>
-                    <p class="form-text mt-1" style="color:var(--text-secondary)">
+                    <p class="form-text mt-1" id="backup-last-info" style="color:var(--text-secondary)">
                         ${lastBackupAt
                             ? `Last backup: ${new Date(lastBackupAt).toLocaleString()}`
                             : 'No backups created yet.'}
@@ -563,7 +563,7 @@ async function renderBackup(el) {
                                 <span id="backup-folder-display" style="color:var(--text-secondary);font-size:0.82rem;word-break:break-all">
                                     ${folder || 'Default: Documents/TimesheetBackups'}
                                 </span>
-                                <button class="btn btn-sm btn-outline-light" id="btn-backup-folder" disabled>
+                                <button class="btn btn-sm btn-outline-light" id="btn-backup-folder">
                                     <i class="bi bi-folder me-1"></i> Change
                                 </button>
                             </div>
@@ -596,6 +596,29 @@ async function renderBackup(el) {
 
     el.querySelector('#backup-time').addEventListener('change', () => markDirty('backup'));
     el.querySelector('#backup-retention').addEventListener('input', () => markDirty('backup'));
+
+    el.querySelector('#btn-backup-now').addEventListener('click', async () => {
+        const btn = el.querySelector('#btn-backup-now');
+        btn.disabled = true;
+        try {
+            const result = await window.backup.export();
+            el.querySelector('#backup-last-info').textContent =
+                `Last backup: ${new Date(result.exportedAt).toLocaleString()}`;
+            showToast(`Backup saved to ${result.filePath}`, 'success');
+        } catch (e) {
+            showToast('Backup failed. Check error logs.', 'error');
+        } finally {
+            btn.disabled = false;
+        }
+    });
+
+    el.querySelector('#btn-backup-folder').addEventListener('click', async () => {
+        const chosen = await window.backup.chooseFolder();
+        if (!chosen) return;
+        const current = await window.electronStore.get(BACKUP_SETTINGS_KEY) || {};
+        await window.electronStore.set(BACKUP_SETTINGS_KEY, { ...current, folder: chosen });
+        el.querySelector('#backup-folder-display').textContent = chosen;
+    });
 
     el.querySelector('#btn-save-backup').addEventListener('click', async () => {
         const [hh, mm]   = (el.querySelector('#backup-time').value || '09:00').split(':').map(Number);

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -15,18 +15,22 @@ import { renderErrorLogSection } from './error-log.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
-    'general':       { parent: null,         label: 'General',       isParent: false },
-    'appearance':    { parent: null,         label: 'Appearance',    isParent: false },
-    'notifications': { parent: null,         label: 'Notifications', isParent: false },
-    'management':    { parent: null,         label: 'Management',    isParent: true  },
-    'ticket-types':  { parent: 'management', label: 'Ticket Types',  isParent: false },
-    'leave-types':   { parent: 'management', label: 'Leave Types',   isParent: false },
-    'developer':     { parent: null,         label: 'Developer',     isParent: true  },
-    'error-logs':    { parent: 'developer',  label: 'Error Logs',    isParent: false },
-    'about':         { parent: null,         label: 'About',         isParent: false },
+    'general':        { parent: null,             label: 'General',           isParent: false },
+    'appearance':     { parent: null,             label: 'Appearance',        isParent: false },
+    'notifications':  { parent: null,             label: 'Notifications',     isParent: false },
+    'management':     { parent: null,             label: 'Management',        isParent: true  },
+    'ticket-types':   { parent: 'management',     label: 'Ticket Types',      isParent: false },
+    'leave-types':    { parent: 'management',     label: 'Leave Types',       isParent: false },
+    'developer':      { parent: null,             label: 'Developer',         isParent: true  },
+    'error-logs':     { parent: 'developer',      label: 'Error Logs',        isParent: false },
+    'backup-restore': { parent: null,             label: 'Backup & Restore',  isParent: true  },
+    'backup':         { parent: 'backup-restore', label: 'Backup',            isParent: false },
+    'restore':        { parent: 'backup-restore', label: 'Restore',           isParent: false },
+    'about':          { parent: null,             label: 'About',             isParent: false },
 };
 
-const NOTIFICATION_KEY = 'notificationSettings';
+const NOTIFICATION_KEY   = 'notificationSettings';
+const BACKUP_SETTINGS_KEY = 'backupSettings';
 
 /* ── STATE ──────────────────────────────────────────────── */
 let currentSection = 'general';
@@ -183,9 +187,12 @@ function renderSection(section) {
         case 'management':     return renderManagement(el);
         case 'ticket-types': return renderTicketTypes(el);
         case 'leave-types':  return renderLeaveTypes(el);
-        case 'developer':    return renderDeveloper(el);
-        case 'error-logs':   return renderErrorLogs(el);
-        case 'about':        return renderAbout(el);
+        case 'developer':      return renderDeveloper(el);
+        case 'error-logs':     return renderErrorLogs(el);
+        case 'backup-restore': return renderBackupRestore(el);
+        case 'backup':         return renderBackup(el);
+        case 'restore':        return renderRestore(el);
+        case 'about':          return renderAbout(el);
     }
 }
 
@@ -436,6 +443,210 @@ function renderDeveloper(el) {
 
 function renderErrorLogs(el) {
     renderErrorLogSection(el, navigateTo);
+}
+
+/* ── BACKUP & RESTORE ────────────────────────────────────── */
+
+function renderBackupRestore(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Backup &amp; Restore</h2>
+            <p class="settings-section-desc">Protect your data and recover from a backup when needed.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="settings-mgmt-cards">
+                <div class="settings-mgmt-card" data-nav="backup">
+                    <div class="settings-mgmt-card-icon">
+                        <i class="bi bi-cloud-arrow-up-fill"></i>
+                    </div>
+                    <div class="settings-mgmt-card-body">
+                        <div class="settings-mgmt-card-title">Backup</div>
+                        <div class="settings-mgmt-card-desc">Manually back up your data or configure automatic scheduled backups</div>
+                    </div>
+                    <i class="bi bi-chevron-right settings-mgmt-card-arrow"></i>
+                </div>
+                <div class="settings-mgmt-card" data-nav="restore">
+                    <div class="settings-mgmt-card-icon">
+                        <i class="bi bi-cloud-arrow-down-fill"></i>
+                    </div>
+                    <div class="settings-mgmt-card-body">
+                        <div class="settings-mgmt-card-title">Restore</div>
+                        <div class="settings-mgmt-card-desc">Restore timesheet data from a JSON backup or a downloaded TXT report</div>
+                    </div>
+                    <i class="bi bi-chevron-right settings-mgmt-card-arrow"></i>
+                </div>
+            </div>
+        </div>`;
+    el.querySelectorAll('.settings-mgmt-card[data-nav]').forEach(card => {
+        card.addEventListener('click', () => navigateTo(card.dataset.nav));
+    });
+}
+
+async function renderBackup(el) {
+    const saved          = await window.electronStore.get(BACKUP_SETTINGS_KEY) || {};
+    const enabled        = saved.enabled !== false;
+    const frequency      = saved.frequency || 'weekly';
+    const dayOfWeek      = saved.dayOfWeek ?? 1;
+    const hour           = saved.hour ?? 9;
+    const minute         = saved.minute ?? 0;
+    const retentionDays  = saved.retentionDays ?? 30;
+    const lastBackupAt   = saved.lastBackupAt || null;
+    const folder         = saved.folder || '';
+    const timeVal        = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Backup</h2>
+            <p class="settings-section-desc">Save a copy of all your timesheet data to a local file.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="settings-form">
+                <div class="settings-form-group">
+                    <label class="label-text">Manual Backup</label>
+                    <button class="btn btn-gradient px-4" id="btn-backup-now" disabled>
+                        <i class="bi bi-cloud-arrow-up me-1"></i> Backup Now
+                    </button>
+                    <p class="form-text mt-1" style="color:var(--text-secondary)">
+                        ${lastBackupAt
+                            ? `Last backup: ${new Date(lastBackupAt).toLocaleString()}`
+                            : 'No backups created yet.'}
+                    </p>
+                </div>
+                <hr class="settings-divider">
+                <div class="settings-form-group">
+                    <label class="label-text">Auto-backup</label>
+                    <div class="form-check form-switch mt-1">
+                        <input class="form-check-input" type="checkbox" id="backup-enabled" ${enabled ? 'checked' : ''} />
+                        <label class="form-check-label label-text" for="backup-enabled">
+                            Automatically back up on app launch
+                        </label>
+                    </div>
+                </div>
+                <div id="backup-auto-config" style="${enabled ? '' : 'opacity:0.4;pointer-events:none'}">
+                    <div class="settings-form d-flex flex-column gap-4">
+                        <div class="settings-form-group">
+                            <label class="label-text" for="backup-frequency">Frequency</label>
+                            <select id="backup-frequency" class="form-control dark-input" style="max-width:180px">
+                                <option value="daily"   ${frequency === 'daily'   ? 'selected' : ''}>Daily</option>
+                                <option value="weekly"  ${frequency === 'weekly'  ? 'selected' : ''}>Weekly</option>
+                                <option value="monthly" ${frequency === 'monthly' ? 'selected' : ''}>Monthly</option>
+                            </select>
+                        </div>
+                        <div class="settings-form-group" id="backup-dow-group" style="${frequency === 'weekly' ? '' : 'display:none'}">
+                            <label class="label-text" for="backup-dow">Day of Week</label>
+                            <select id="backup-dow" class="form-control dark-input" style="max-width:180px">
+                                <option value="1" ${dayOfWeek === 1 ? 'selected' : ''}>Monday</option>
+                                <option value="2" ${dayOfWeek === 2 ? 'selected' : ''}>Tuesday</option>
+                                <option value="3" ${dayOfWeek === 3 ? 'selected' : ''}>Wednesday</option>
+                                <option value="4" ${dayOfWeek === 4 ? 'selected' : ''}>Thursday</option>
+                                <option value="5" ${dayOfWeek === 5 ? 'selected' : ''}>Friday</option>
+                            </select>
+                        </div>
+                        <div class="settings-form-group">
+                            <label class="label-text" for="backup-time">Check Time (on app launch)</label>
+                            <input type="time" id="backup-time" class="form-control dark-input" value="${timeVal}" style="max-width:140px" />
+                            <p class="form-text" style="color:var(--text-secondary)">
+                                Auto-backup runs when the app is launched at or after this time on the scheduled day.
+                            </p>
+                        </div>
+                        <div class="settings-form-group">
+                            <label class="label-text" for="backup-retention">Retain backups for</label>
+                            <div class="d-flex align-items-center gap-2">
+                                <input type="number" id="backup-retention" class="form-control dark-input text-center"
+                                    min="1" max="30" value="${retentionDays}" style="max-width:72px" />
+                                <span class="label-text">days &nbsp;<span style="color:var(--text-muted);font-size:0.8rem">(max 30)</span></span>
+                            </div>
+                        </div>
+                        <div class="settings-form-group">
+                            <label class="label-text">Backup Folder</label>
+                            <div class="d-flex align-items-center gap-2 flex-wrap">
+                                <span id="backup-folder-display" style="color:var(--text-secondary);font-size:0.82rem;word-break:break-all">
+                                    ${folder || 'Default: Documents/TimesheetBackups'}
+                                </span>
+                                <button class="btn btn-sm btn-outline-light" id="btn-backup-folder" disabled>
+                                    <i class="bi bi-folder me-1"></i> Change
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="settings-form-actions">
+                    <button class="btn btn-gradient px-4" id="btn-save-backup">
+                        <i class="bi bi-check-lg me-1"></i> Save
+                    </button>
+                </div>
+            </div>
+        </div>`;
+
+    const enabledToggle = el.querySelector('#backup-enabled');
+    const autoConfig    = el.querySelector('#backup-auto-config');
+    const freqSelect    = el.querySelector('#backup-frequency');
+    const dowGroup      = el.querySelector('#backup-dow-group');
+
+    enabledToggle.addEventListener('change', () => {
+        autoConfig.style.opacity       = enabledToggle.checked ? '1' : '0.4';
+        autoConfig.style.pointerEvents = enabledToggle.checked ? '' : 'none';
+        markDirty('backup');
+    });
+
+    freqSelect.addEventListener('change', () => {
+        dowGroup.style.display = freqSelect.value === 'weekly' ? '' : 'none';
+        markDirty('backup');
+    });
+
+    el.querySelector('#backup-time').addEventListener('change', () => markDirty('backup'));
+    el.querySelector('#backup-retention').addEventListener('input', () => markDirty('backup'));
+
+    el.querySelector('#btn-save-backup').addEventListener('click', async () => {
+        const [hh, mm]   = (el.querySelector('#backup-time').value || '09:00').split(':').map(Number);
+        const retention  = Math.min(30, Math.max(1, parseInt(el.querySelector('#backup-retention').value) || 30));
+        const dowEl      = el.querySelector('#backup-dow');
+        const current    = await window.electronStore.get(BACKUP_SETTINGS_KEY) || {};
+        await window.electronStore.set(BACKUP_SETTINGS_KEY, {
+            ...current,
+            enabled:        el.querySelector('#backup-enabled').checked,
+            frequency:      freqSelect.value,
+            dayOfWeek:      dowEl ? parseInt(dowEl.value) : 1,
+            hour:           hh || 9,
+            minute:         mm || 0,
+            retentionDays:  retention,
+        });
+        clearDirty();
+        showToast('Backup settings saved.', 'success');
+    });
+}
+
+function renderRestore(el) {
+    el.innerHTML = `
+        <div class="settings-section-header">
+            <h2 class="settings-section-title">Restore</h2>
+            <p class="settings-section-desc">Restore your timesheet data from a previously exported file.</p>
+        </div>
+        <div class="settings-section-body">
+            <div class="settings-form">
+                <div class="settings-form-group">
+                    <label class="label-text">Restore from Backup File</label>
+                    <p class="form-text" style="color:var(--text-secondary)">
+                        Import a <code>.json</code> backup file exported by this app.
+                        If the backup contains weeks you already have data for, you'll be shown a side-by-side merge review before anything is applied.
+                    </p>
+                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-json" disabled>
+                        <i class="bi bi-file-earmark-code me-1"></i> Choose Backup File (.json)
+                    </button>
+                </div>
+                <hr class="settings-divider">
+                <div class="settings-form-group">
+                    <label class="label-text">Restore from TXT Report</label>
+                    <p class="form-text" style="color:var(--text-secondary)">
+                        Import a <code>.txt</code> timesheet report downloaded from this app.
+                        Conflicting weeks will go through the same merge review as a JSON restore.
+                    </p>
+                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-txt" disabled>
+                        <i class="bi bi-file-earmark-text me-1"></i> Choose Report File (.txt)
+                    </button>
+                </div>
+            </div>
+        </div>`;
 }
 
 function _renderMarkdown(md) {

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -12,6 +12,7 @@ import { applyTheme } from './theme.js';
 import { renderTicketTypesSection } from './ticket-types.js';
 import { renderLeaveTypesSection } from './leave-types.js';
 import { renderErrorLogSection } from './error-log.js';
+import { openRestoreFromJson } from './restore.js';
 
 /* ── SECTION METADATA ───────────────────────────────────── */
 const SECTION_META = {
@@ -653,7 +654,7 @@ function renderRestore(el) {
                         Import a <code>.json</code> backup file exported by this app.
                         If the backup contains weeks you already have data for, you'll be shown a side-by-side merge review before anything is applied.
                     </p>
-                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-json" disabled>
+                    <button class="btn btn-gradient px-4 mt-1" id="btn-restore-json">
                         <i class="bi bi-file-earmark-code me-1"></i> Choose Backup File (.json)
                     </button>
                 </div>
@@ -670,6 +671,8 @@ function renderRestore(el) {
                 </div>
             </div>
         </div>`;
+
+    el.querySelector('#btn-restore-json').addEventListener('click', () => openRestoreFromJson());
 }
 
 function _renderMarkdown(md) {

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -2,7 +2,7 @@ import { state } from './state.js';
 import { showToast } from './toast.js';
 import { escHtml } from './utils.js';
 import { renderStarredList } from './star.js';
-import { saveEntry, openEntryModal } from './entry-modal.js';
+import { saveEntry, openEntryModal, readClipboardTicket } from './entry-modal.js';
 import { toggleDay, renderAll, openDayNotesModal } from './render.js';
 import { openStatsModal } from './stats.js';
 import { changeWeekBy, setCurrentWeek } from './week.js';
@@ -277,6 +277,23 @@ export function initKeyboard() {
         if (e.ctrlKey && (e.key === 'p' || e.key === 'P')) {
             e.preventDefault();
             doPrint();
+        }
+
+        if (e.ctrlKey && (e.key === 'v' || e.key === 'V')) {
+            const expandedIdx = state.days.findIndex(d => d.expanded);
+            if (expandedIdx === -1) return;
+            readClipboardTicket().then(result => {
+                if (!result) return;
+                e.preventDefault();
+                openEntryModal(expandedIdx, -1);
+                // Wait for modal to render before setting values
+                document.getElementById('entryModal').addEventListener('shown.bs.modal', () => {
+                    const ticketEl = document.getElementById('modal-ticket');
+                    const typeEl   = document.getElementById('modal-type');
+                    if (ticketEl) ticketEl.value = result.ticket;
+                    if (result.typeId && typeEl) typeEl.value = result.typeId;
+                }, { once: true });
+            });
         }
     });
 }

--- a/src/renderer/modules/star.js
+++ b/src/renderer/modules/star.js
@@ -26,6 +26,7 @@ export function toggleEntryLogged(dayIdx, entryIdx, btnEl) {
     const entry = state.days[dayIdx]?.entries[entryIdx];
     if (!entry) return;
     entry.logged = !entry.logged;
+    if (entry.logged) delete entry.loggedUpdated; // re-marking clears the updated flag
     btnEl.classList.toggle('logged', entry.logged);
     btnEl.querySelector('i').className = entry.logged ? 'bi bi-journal-check' : 'bi bi-journal';
     btnEl.title = entry.logged ? 'Logged to timesheet — click to unmark' : 'Mark as logged to timesheet';

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -8,6 +8,8 @@ export const LS_KEY = 'timesheetState_v1';
 export const RECURRING_DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 export const DAY_IDX_TO_NAME = { 1: 'Mon', 2: 'Tue', 3: 'Wed', 4: 'Thu', 5: 'Fri' };
 export const SEARCH_PAGE_SIZE = 10;
+export const MAX_DAY_MINS = 840;        // 14h hard cap per day
+export const MAX_TARGET_MINS = 840;     // 14h max for daily target setting
 
 export const DEFAULT_LEAVE_TYPES = [
     { id: 'offshore-holiday', label: 'Offshore Holiday', paid: false },

--- a/src/renderer/modules/state.js
+++ b/src/renderer/modules/state.js
@@ -1,4 +1,4 @@
-export const APP_VERSION = '2.2.0';
+export const APP_VERSION = '2.3.0';
 
 export const WEEK_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
 export const ROMAN = ['i', 'ii', 'iii', 'iv', 'v', 'vi', 'vii', 'viii', 'ix', 'x',

--- a/src/renderer/modules/summary.js
+++ b/src/renderer/modules/summary.js
@@ -11,6 +11,10 @@ export function updateSummary() {
     let workingDays = 0;
     let totalEntries = 0;
     let holidayCount = 0;
+    let loggedMins = 0;
+    let loggedCount = 0;
+    let unloggedMins = 0;
+    let unloggedCount = 0;
 
     state.days.forEach(day => {
         if (day.isHoliday) {
@@ -20,6 +24,11 @@ export function updateSummary() {
             if (m > 0) workingDays++;
             totalMins += m;
             totalEntries += (day.entries || []).length;
+            (day.entries || []).forEach(e => {
+                const mins = (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0);
+                if (e.logged) { loggedMins += mins; loggedCount++; }
+                else          { unloggedMins += mins; unloggedCount++; }
+            });
         }
     });
 
@@ -43,5 +52,16 @@ export function updateSummary() {
             fill.style.width = pct.toFixed(1) + '%';
             fill.classList.toggle('over', isOver);
         }
+    }
+
+    // Logged / unlogged breakdown
+    const fmt = (m) => `${Math.floor(m / 60)}:${String(m % 60).padStart(2, '0')}`;
+    const breakdown = document.getElementById('logged-breakdown');
+    if (breakdown) {
+        breakdown.style.display = totalEntries > 0 ? '' : 'none';
+        document.getElementById('lb-logged-hours').textContent   = fmt(loggedMins);
+        document.getElementById('lb-logged-entries').textContent = `${loggedCount} ${loggedCount === 1 ? 'entry' : 'entries'}`;
+        document.getElementById('lb-unlogged-hours').textContent   = fmt(unloggedMins);
+        document.getElementById('lb-unlogged-entries').textContent = `${unloggedCount} ${unloggedCount === 1 ? 'entry' : 'entries'}`;
     }
 }

--- a/src/renderer/modules/ticket-types.js
+++ b/src/renderer/modules/ticket-types.js
@@ -136,6 +136,23 @@ function _buildForm(editingType, formTypeId) {
                 <input type="text" id="tt-form-prefixtext" class="form-control dark-input"
                     placeholder="e.g. (Service desk) " value="${escHtml(t?.prefixText || '')}" maxlength="100" />
             </div>
+            <div class="settings-form-group">
+                <div class="d-flex align-items-center gap-2">
+                    <input type="checkbox" id="tt-form-haspattern" class="form-check-input" ${t?.ticketPattern ? 'checked' : ''} />
+                    <label class="label-text mb-0" for="tt-form-haspattern">Match clipboard ticket pattern</label>
+                </div>
+            </div>
+            <div class="settings-form-group" id="tt-form-pattern-row" style="${t?.ticketPattern ? '' : 'display:none'}">
+                <label class="label-text" for="tt-form-pattern">Pattern <span style="color:var(--text-secondary);font-weight:normal">(regex, e.g. <code>#\\d+</code> or <code>[A-Z]+-\\d+</code>)</span></label>
+                <input type="text" id="tt-form-pattern" class="form-control dark-input font-monospace"
+                    placeholder="e.g. #\\d+" value="${escHtml(t?.ticketPattern || '')}" maxlength="100" />
+                <div id="tt-form-pattern-error" class="tt-pattern-error" style="display:none"></div>
+                <div class="tt-pattern-preview" id="tt-form-pattern-preview" style="${t?.ticketPattern ? '' : 'display:none'}">
+                    <input type="text" id="tt-form-pattern-sample" class="form-control dark-input"
+                        placeholder="Test value, e.g. #1234" style="margin-top:6px" />
+                    <span id="tt-form-pattern-result" class="tt-pattern-result"></span>
+                </div>
+            </div>
             <div class="settings-form-actions d-flex gap-2">
                 <button class="btn btn-gradient px-4" id="tt-form-save">
                     <i class="bi bi-check-lg me-1"></i>${isNew ? 'Add' : 'Save'}
@@ -145,16 +162,84 @@ function _buildForm(editingType, formTypeId) {
         </div>`;
 }
 
+function _validatePattern(pattern) {
+    if (!pattern) return null; // empty = no pattern, valid
+    if (pattern.length > 100) return 'Pattern must be 100 characters or fewer.';
+
+    // 1. Syntax check
+    try { new RegExp(pattern); } catch (e) {
+        return `Invalid regex syntax: ${e.message}`;
+    }
+
+    // 2. ReDoS heuristic — nested quantifiers like (a+)+, (.+)+, (?:x+)+
+    if (/\([^)]*[+*?]\)[+*?]/.test(pattern)) {
+        return 'Pattern contains nested quantifiers that may freeze the app. Simplify it (e.g. use \\d+ instead of (\\d+)+).';
+    }
+
+    // 3. Execution timeout — run against adversarial string
+    const adversarial = 'a'.repeat(200) + 'b';
+    const start = Date.now();
+    try { new RegExp(pattern).test(adversarial); } catch (_) { /* already caught above */ }
+    if (Date.now() - start > 50) {
+        return 'Pattern is too slow — try simplifying it.';
+    }
+
+    return null; // valid
+}
+
 function _bindForm(formEl, editingType, el, navigate) {
-    const colorInput  = formEl.querySelector('#tt-form-color');
-    const colorVal    = formEl.querySelector('#tt-form-color-val');
-    const hasPrefixCb = formEl.querySelector('#tt-form-hasprefix');
-    const prefixRow   = formEl.querySelector('#tt-form-prefix-row');
+    const colorInput    = formEl.querySelector('#tt-form-color');
+    const colorVal      = formEl.querySelector('#tt-form-color-val');
+    const hasPrefixCb   = formEl.querySelector('#tt-form-hasprefix');
+    const prefixRow     = formEl.querySelector('#tt-form-prefix-row');
+    const hasPatternCb  = formEl.querySelector('#tt-form-haspattern');
+    const patternRow    = formEl.querySelector('#tt-form-pattern-row');
+    const patternInput  = formEl.querySelector('#tt-form-pattern');
+    const patternError  = formEl.querySelector('#tt-form-pattern-error');
+    const patternPreview = formEl.querySelector('#tt-form-pattern-preview');
+    const sampleInput   = formEl.querySelector('#tt-form-pattern-sample');
+    const patternResult = formEl.querySelector('#tt-form-pattern-result');
 
     colorInput.addEventListener('input', () => { colorVal.textContent = colorInput.value; });
+
     hasPrefixCb.addEventListener('change', () => {
         prefixRow.style.display = hasPrefixCb.checked ? '' : 'none';
     });
+
+    hasPatternCb.addEventListener('change', () => {
+        patternRow.style.display    = hasPatternCb.checked ? '' : 'none';
+        patternPreview.style.display = hasPatternCb.checked ? '' : 'none';
+        if (!hasPatternCb.checked) {
+            patternInput.value = '';
+            patternError.style.display = 'none';
+            patternResult.textContent = '';
+        }
+    });
+
+    const updatePreview = () => {
+        const pattern = patternInput.value.trim();
+        const sample  = sampleInput?.value || '';
+        if (!pattern || !sample) { patternResult.textContent = ''; return; }
+        try {
+            const match = new RegExp(pattern).exec(sample);
+            if (match) {
+                patternResult.textContent = `✓ Matched: "${match[0]}"`;
+                patternResult.style.color = 'var(--success)';
+            } else {
+                patternResult.textContent = '✗ No match';
+                patternResult.style.color = 'var(--danger, #f87171)';
+            }
+        } catch (_) {
+            patternResult.textContent = '';
+        }
+    };
+
+    patternInput?.addEventListener('input', () => {
+        patternError.style.display = 'none';
+        patternPreview.style.display = patternInput.value.trim() ? '' : 'none';
+        updatePreview();
+    });
+    sampleInput?.addEventListener('input', updatePreview);
 
     formEl.querySelector('#tt-form-save').addEventListener('click', () => {
         const labelInput = formEl.querySelector('#tt-form-label');
@@ -162,16 +247,29 @@ function _bindForm(formEl, editingType, el, navigate) {
         if (!label) { labelInput.classList.add('is-invalid'); return; }
         labelInput.classList.remove('is-invalid');
 
-        const color      = colorInput.value;
-        const hasPrefix  = hasPrefixCb.checked;
-        const prefixText = hasPrefix ? (formEl.querySelector('#tt-form-prefixtext').value) : '';
+        const color         = colorInput.value;
+        const hasPrefix     = hasPrefixCb.checked;
+        const prefixText    = hasPrefix ? (formEl.querySelector('#tt-form-prefixtext').value) : '';
+        const ticketPattern = hasPatternCb.checked ? patternInput.value.trim() : '';
+
+        // Validate pattern before saving
+        if (ticketPattern) {
+            const err = _validatePattern(ticketPattern);
+            if (err) {
+                patternError.textContent = err;
+                patternError.style.display = '';
+                patternInput.focus();
+                return;
+            }
+        }
+        patternError.style.display = 'none';
 
         if (editingType) {
             const type = state.ticketTypes.find(t => t.id === editingType.id);
-            if (type) { type.label = label; type.color = color; type.hasPrefix = hasPrefix; type.prefixText = prefixText; }
+            if (type) { type.label = label; type.color = color; type.hasPrefix = hasPrefix; type.prefixText = prefixText; type.ticketPattern = ticketPattern; }
         } else {
             const id = 'type_' + Date.now();
-            state.ticketTypes.push({ id, label, color, hasPrefix, prefixText });
+            state.ticketTypes.push({ id, label, color, hasPrefix, prefixText, ticketPattern });
         }
 
         saveState();

--- a/src/renderer/modules/utils.js
+++ b/src/renderer/modules/utils.js
@@ -37,6 +37,102 @@ export function fmtSearchDate(dateStr) {
     return `${days[d.getDay()]} ${d.getDate()} ${months[d.getMonth()]}`;
 }
 
+// Parse a freeform time string → { hh, mm } or null
+// Supported: "2:30", "2h 30m", "2h30m", "90m", "1.5h", "2h", "30m", "30", "2"
+// Maximum: 24:00 (1440 minutes total)
+export function parseTimeInput(str) {
+    if (!str) return null;
+    const s = str.trim();
+    if (!s) return null;
+
+    let m;
+    const cap = (hh, mm) => (hh * 60 + mm <= 1440) ? { hh, mm } : null;
+
+    // H:MM or HH:MM
+    m = s.match(/^(\d{1,3}):(\d{2})$/);
+    if (m) {
+        const hh = parseInt(m[1], 10);
+        const mm = parseInt(m[2], 10);
+        if (mm > 59) return null;
+        return cap(hh, mm);
+    }
+
+    // XhYm or Xh Ym (e.g. 2h30m, 2h 30m)
+    m = s.match(/^(\d+)\s*h\s*(\d+)\s*m$/i);
+    if (m) {
+        const hh = parseInt(m[1], 10);
+        const mm = parseInt(m[2], 10);
+        if (mm > 59) return null;
+        return cap(hh, mm);
+    }
+
+    // X.Yh decimal hours — must come before plain Xh (e.g. 1.5h)
+    m = s.match(/^(\d+\.\d+)\s*h$/i);
+    if (m) {
+        const totalMins = Math.round(parseFloat(m[1]) * 60);
+        return cap(Math.floor(totalMins / 60), totalMins % 60);
+    }
+
+    // Xh (e.g. 2h)
+    m = s.match(/^(\d+)\s*h$/i);
+    if (m) return cap(parseInt(m[1], 10), 0);
+
+    // Xm — total minutes (e.g. 90m → 1h 30m)
+    m = s.match(/^(\d+)\s*m$/i);
+    if (m) {
+        const totalMins = parseInt(m[1], 10);
+        return cap(Math.floor(totalMins / 60), totalMins % 60);
+    }
+
+    // Bare integer: < 24 → treat as hours, >= 24 → treat as total minutes
+    m = s.match(/^(\d+)$/);
+    if (m) {
+        const n = parseInt(m[1], 10);
+        if (n < 24) return cap(n, 0);
+        return cap(Math.floor(n / 60), n % 60);
+    }
+
+    return null;
+}
+
+// Returns a human-readable error string for an invalid time input, or null if valid.
+// maxMins: optional upper bound (default 1440 = 24h). Pass 840 for daily-target fields.
+export function timeInputError(str, maxMins = 1440) {
+    if (!str || !str.trim()) return null; // empty is handled separately
+    const s = str.trim();
+    const parsed = parseTimeInput(s);
+
+    if (parsed) {
+        // Parsed OK against the 24h cap — now check the caller's cap
+        const total = parsed.hh * 60 + parsed.mm;
+        if (total > maxMins) {
+            const h = Math.floor(maxMins / 60);
+            const m = maxMins % 60;
+            return `Maximum is ${m ? `${h}h ${m}m` : `${h}h`} (e.g. 8h, 2:30, 90m)`;
+        }
+        return null;
+    }
+
+    // parseTimeInput returned null — either unrecognised format or > 24h
+    const looksLikeTime = /^(\d+):(\d{2})$/.test(s)
+        || /^(\d+)\s*h\s*(\d+)\s*m$/i.test(s)
+        || /^(\d+\.\d+)\s*h$/i.test(s)
+        || /^(\d+)\s*h$/i.test(s)
+        || /^(\d+)\s*m$/i.test(s)
+        || /^\d+$/.test(s);
+    if (looksLikeTime) {
+        const h = Math.floor(maxMins / 60);
+        const m = maxMins % 60;
+        return `Maximum is ${m ? `${h}h ${m}m` : `${h}h`} (e.g. 8h, 2:30, 90m)`;
+    }
+    return 'Use a format like 2:30, 2h 30m, 90m, or 1.5h';
+}
+
+// Format hh + mm → "H:MM" for display in the freeform time field
+export function fmtTimeInput(hh, mm) {
+    return `${parseInt(hh) || 0}:${String(parseInt(mm) || 0).padStart(2, '0')}`;
+}
+
 export function padTicket(ticket) {
     const target = 11;
     if (ticket.length < target) return ticket + ' '.repeat(target - ticket.length);

--- a/src/renderer/styles/context-menu.css
+++ b/src/renderer/styles/context-menu.css
@@ -119,6 +119,62 @@
   word-break: break-word;
 }
 
+.qv-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.qv-title {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.qv-copy-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  line-height: 1.4;
+  transition: background 0.15s, color 0.15s;
+}
+
+.qv-copy-btn:hover {
+  background: var(--bg-input);
+  color: var(--text-primary);
+}
+
+.qv-status-row {
+  margin-top: 4px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.qv-logged-badge {
+  font-size: 0.72rem;
+  color: #22d3a0;
+  font-weight: 600;
+}
+
+.qv-updated-badge {
+  font-size: 0.72rem;
+  color: #fb923c;
+  font-weight: 600;
+}
+
 /* ── CHEATSHEET ── */
 
 .cheatsheet-group {

--- a/src/renderer/styles/entries.css
+++ b/src/renderer/styles/entries.css
@@ -414,3 +414,14 @@
   color: var(--warning);
   opacity: 0.85;
 }
+
+.entry-updated-label {
+  position: absolute;
+  bottom: 3px;
+  right: 8px;
+  font-size: 0.62rem;
+  color: #9ca3af;
+  opacity: 0.85;
+  pointer-events: none;
+  line-height: 1;
+}

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -58,3 +58,51 @@
   color: #d4d4d4;
   line-height: 1.2;
 }
+
+/* ── LOGGED / UNLOGGED BREAKDOWN ── */
+
+.logged-breakdown {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lb-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.78rem;
+}
+
+.lb-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.lb-dot-logged   { background: #22d3a0; }
+.lb-dot-unlogged { background: #f87171; }
+
+.lb-label {
+  color: var(--text-secondary);
+  min-width: 58px;
+}
+
+.lb-hours {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  color: #d4d4d4;
+  min-width: 38px;
+}
+
+.lb-entries {
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+[data-theme="light"] .lb-hours { color: #1a1a2e; }

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -20,3 +20,4 @@
 @import './animations.css';
 @import './settings.css';
 @import './stats.css';
+@import './restore.css';

--- a/src/renderer/styles/restore.css
+++ b/src/renderer/styles/restore.css
@@ -1,0 +1,349 @@
+/* ── RESTORE CONFLICT MODAL ── */
+
+.rc-modal-content {
+  background: var(--bg-base);
+  border: 1px solid var(--border-accent);
+}
+
+.rc-modal-header {
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 24px;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.rc-modal-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 2px;
+}
+
+.rc-modal-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.rc-modal-body {
+  padding: 20px 24px;
+  background: var(--bg-base);
+}
+
+.rc-modal-footer {
+  background: var(--bg-card);
+  border-top: 1px solid var(--border);
+  padding: 12px 24px;
+  gap: 8px;
+}
+
+/* ── DAY BLOCKS ── */
+
+.rc-day-block {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  margin-bottom: 16px;
+  background: var(--bg-card);
+}
+
+.rc-day-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: var(--bg-card-hover);
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.rc-day-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.rc-day-shortcuts {
+  display: flex;
+  gap: 6px;
+}
+
+.rc-day-shortcuts .btn {
+  font-size: 0.75rem;
+  padding: 2px 10px;
+  opacity: 0.8;
+}
+
+.rc-day-shortcuts .btn:hover {
+  opacity: 1;
+}
+
+/* ── ENTRY ROWS ── */
+
+.rc-entries {
+  display: flex;
+  flex-direction: column;
+}
+
+.rc-entry {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+  font-size: 0.83rem;
+}
+
+.rc-entry:last-child {
+  border-bottom: none;
+}
+
+.rc-entry-same {
+  opacity: 0.6;
+}
+
+.rc-entry-kept {
+  background: rgba(34, 211, 160, 0.04);
+}
+
+.rc-entry-discarded {
+  opacity: 0.4;
+  text-decoration: line-through;
+}
+
+.rc-entry-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.rc-entry-ticket {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  min-width: 80px;
+}
+
+.rc-entry-time {
+  color: var(--accent-light);
+  font-size: 0.8rem;
+  min-width: 60px;
+}
+
+.rc-entry-type {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  min-width: 70px;
+}
+
+.rc-entry-desc {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rc-entry-badge {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-radius: 4px;
+  padding: 1px 6px;
+  flex-shrink: 0;
+}
+
+.rc-badge-same {
+  background: rgba(100, 116, 139, 0.15);
+  color: var(--text-muted);
+}
+
+.rc-badge-mine {
+  background: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+}
+
+.rc-badge-theirs {
+  background: rgba(34, 211, 160, 0.12);
+  color: var(--success);
+}
+
+/* ── CONFLICT ENTRY ── */
+
+.rc-entry-conflict {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(251, 191, 36, 0.04);
+}
+
+.rc-entry-conflict:last-child {
+  border-bottom: none;
+}
+
+.rc-conflict-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--warning, #fbbf24);
+  margin-bottom: 8px;
+}
+
+.rc-conflict-sides {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.rc-conflict-side {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.rc-side-selected {
+  border-color: var(--success);
+  background: rgba(34, 211, 160, 0.06);
+}
+
+.rc-side-dim {
+  opacity: 0.45;
+}
+
+.rc-side-header {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.rc-side-entry {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 0.82rem;
+}
+
+.rc-conflict-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.rc-choice-btn {
+  font-size: 0.75rem;
+  padding: 3px 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 20px;
+  transition: all 0.15s;
+}
+
+.rc-choice-btn:hover {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.rc-choice-btn.active {
+  border-color: var(--success);
+  background: rgba(34, 211, 160, 0.12);
+  color: var(--success);
+  font-weight: 600;
+}
+
+/* ── MINE/THEIRS TOGGLE BUTTONS ── */
+
+.rc-toggle-mine,
+.rc-toggle-theirs {
+  font-size: 0.72rem;
+  padding: 2px 10px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 20px;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+
+.rc-toggle-mine.active,
+.rc-toggle-theirs.active {
+  border-color: var(--success);
+  color: var(--success);
+  background: rgba(34, 211, 160, 0.08);
+}
+
+/* ── CLEAN NOTE ── */
+
+.rc-clean-note {
+  font-size: 0.83rem;
+  color: var(--text-secondary);
+  padding: 10px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  margin-top: 4px;
+}
+
+/* ── PREVIEW ── */
+
+.rc-preview-summary {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  padding: 12px 16px;
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  margin-bottom: 20px;
+}
+
+.rc-preview-section-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 12px;
+}
+
+.rc-preview-day {
+  margin-bottom: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-card);
+}
+
+.rc-preview-day-header {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  padding: 8px 14px;
+  background: var(--bg-card-hover);
+  border-bottom: 1px solid var(--border);
+}
+
+.rc-preview-entry {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 7px 14px;
+  font-size: 0.82rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.rc-preview-entry:last-child {
+  border-bottom: none;
+}
+
+.rc-preview-empty {
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -422,6 +422,18 @@
   cursor: pointer;
 }
 
+.tt-pattern-error {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: var(--danger, #f87171);
+}
+
+.tt-pattern-result {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.8rem;
+}
+
 /* ── ERROR LOGS ── */
 
 .el-toolbar {

--- a/src/renderer/styles/settings.css
+++ b/src/renderer/styles/settings.css
@@ -493,6 +493,14 @@
   padding: 6px 8px;
 }
 
+/* ── BACKUP & RESTORE ── */
+
+.settings-divider {
+  border-color: var(--border);
+  opacity: 1;
+  margin: 4px 0;
+}
+
 /* ── ABOUT ── */
 
 .about-app-card {


### PR DESCRIPTION
## Release v2.3.0

### What's new

- **Restore from TXT report** — parse downloaded `.txt` timesheet reports and restore entries with conflict resolution (#135)
- **Clipboard ticket detection** — auto-fill ticket field on modal open; Ctrl+V shortcut; configurable regex pattern per ticket type (#140)
- **Freeform time input** — single text field replacing HH/MM split inputs; accepts `2:30`, `2h 30m`, `90m`, `1.5h`; 14h daily cap (#142)
- **Logged/unlogged breakdown** — weekly summary sidebar shows logged vs unlogged hours and entry counts (#144)
- **Quick-view copy button** — copy entry details to clipboard from the popover (#145)
- **Edited indicator** — entries modified after logging show "edited" label and "(updated)" in day preview (#146)

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)