### PR TITLE
feat(tm-149): collapsible summary panel with icon strip toggle

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -71,17 +71,29 @@
       <button id="btn-dismiss-underlogged" title="Dismiss"><i class="bi bi-x-lg"></i></button>
     </div>
 
-    <div class="row g-4">
+    <div class="row g-4" id="main-row">
 
       <!-- LEFT COLUMN: Details & Summary -->
-      <div class="col-lg-3 col-xl-3">
+      <div class="col-lg-3 col-xl-3" id="summary-col">
+
+        <!-- Collapsed toggle strip (visible only when panel is hidden) -->
+        <div class="summary-panel-toggle" id="summary-panel-toggle">
+          <button class="summary-toggle-btn" id="btn-expand-summary" title="Show Summary panel">
+            <i class="bi bi-bar-chart-line"></i>
+          </button>
+        </div>
 
         <!-- Week Range & Employee Info -->
-        <div class="card glass-card mb-4 position-sticky" style="top: 85px;">
+        <div class="card glass-card mb-4 position-sticky summary-panel-card" style="top: 85px;">
           <div class="card-body">
 
             <!-- 1. WEEKLY SUMMARY -->
-            <h5 class="section-label mb-3"><i class="bi bi-bar-chart-line me-2"></i>Weekly Summary</h5>
+            <div class="d-flex align-items-center justify-content-between mb-3">
+              <h5 class="section-label mb-0"><i class="bi bi-bar-chart-line me-2"></i>Weekly Summary</h5>
+              <button class="btn-collapse-panel" id="btn-collapse-summary" title="Hide Summary panel">
+                <i class="bi bi-x-lg"></i>
+              </button>
+            </div>
             <div class="d-flex flex-column gap-3 mb-4">
               <div class="total-chip w-100 mt-0 text-center" id="total-hours-chip">
                 <div class="week-progress-fill" id="week-progress-fill"></div>
@@ -166,7 +178,7 @@
       </div> <!-- /LEFT COLUMN -->
 
       <!-- RIGHT COLUMN: Days Grid -->
-      <div class="col-lg-9 col-xl-9">
+      <div class="col-lg-9 col-xl-9" id="main-col">
         <div id="days-container"></div>
       </div> <!-- /RIGHT COLUMN -->
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -6,7 +6,7 @@ import { APP_VERSION } from './modules/state.js';
 import { loadState } from './modules/store.js';
 import { initTheme } from './modules/theme.js';
 import { initRipple } from './modules/ripple.js';
-import { initSidebar, initUpdater, initKeyboard } from './modules/sidebar.js';
+import { initSidebar, initUpdater, initKeyboard, initSummaryPanel } from './modules/sidebar.js';
 import { initContextMenu } from './modules/context-menu.js';
 import { initSearch } from './modules/search.js';
 import { initScheduledTasks } from './modules/scheduled.js';
@@ -36,6 +36,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initNoTicketBanner();
     initUnderloggedBanner();
     initSidebar();
+    initSummaryPanel();
     initStats();
     initUpdater();
     initContextMenu();

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -11,6 +11,28 @@ import { openPreview, openDayQuickView, doPrint } from './report.js';
 import { openSettings, addChangelogEntry } from './settings.js';
 import { logError } from './error-log.js';
 
+/* ── SUMMARY PANEL COLLAPSE ─────────────────────────────── */
+export function initSummaryPanel() {
+    const mainRow = document.getElementById('main-row');
+    const btnCollapse = document.getElementById('btn-collapse-summary');
+    const btnExpand = document.getElementById('btn-expand-summary');
+    const STORAGE_KEY = 'summaryPanelCollapsed';
+
+    if (localStorage.getItem(STORAGE_KEY) === '1') {
+        mainRow.classList.add('summary-collapsed');
+    }
+
+    btnCollapse?.addEventListener('click', () => {
+        mainRow.classList.add('summary-collapsed');
+        localStorage.setItem(STORAGE_KEY, '1');
+    });
+
+    btnExpand?.addEventListener('click', () => {
+        mainRow.classList.remove('summary-collapsed');
+        localStorage.setItem(STORAGE_KEY, '0');
+    });
+}
+
 /* ── SIDEBAR & ABOUT ────────────────────────────────────── */
 export function initSidebar() {
     const sidebarEl = document.getElementById('appSidebar');

--- a/src/renderer/styles/cards.css
+++ b/src/renderer/styles/cards.css
@@ -12,7 +12,6 @@
 
 .glass-card:hover {
   border-color: var(--border-accent);
-  transform: translateY(-2px);
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.6);
 }
 

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -106,3 +106,99 @@
 }
 
 [data-theme="light"] .lb-hours { color: #1a1a2e; }
+
+/* ── SUMMARY PANEL COLLAPSE ── */
+
+#summary-col {
+  overflow: hidden;
+  transition: flex-basis 0.32s cubic-bezier(0.4, 0, 0.2, 1),
+              max-width  0.32s cubic-bezier(0.4, 0, 0.2, 1),
+              min-width  0.32s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.summary-panel-card {
+  transition: opacity 0.18s ease;
+}
+
+.summary-panel-toggle {
+  display: none;
+  justify-content: flex-start;
+  opacity: 0;
+  transition: opacity 0.2s ease 0.18s;
+}
+
+.summary-toggle-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  min-height: 40px;
+  max-width: 40px;
+  max-height: 40px;
+  padding: 0;
+  margin: 0;
+  line-height: 1;
+  box-sizing: border-box;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  flex-shrink: 0;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.summary-toggle-btn:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+  border-color: var(--border-accent);
+}
+
+.btn-collapse-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.72rem;
+  flex-shrink: 0;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.btn-collapse-panel:hover {
+  background: var(--bg-input);
+  border-color: var(--border);
+  color: var(--text-primary);
+}
+
+#main-row.summary-collapsed #summary-col {
+  flex: 0 0 52px !important;
+  max-width: 52px !important;
+  min-width: 52px !important;
+  padding-left: 6px !important;
+  padding-right: 6px !important;
+  overflow: visible;
+}
+
+#main-row.summary-collapsed #main-col {
+  flex: 1 1 0 !important;
+  max-width: calc(100% - 52px) !important;
+}
+
+#main-row.summary-collapsed .summary-panel-card {
+  display: none;
+}
+
+#main-row.summary-collapsed .summary-panel-toggle {
+  display: flex;
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- Adds an X button to the Weekly Summary header to collapse the left panel
- Collapsed state shrinks the column to a 44px icon strip; clicking the chart icon re-expands
- Removed `translateY(-2px)` float on `.glass-card:hover` that caused clipping at the top edge
- Collapse state persisted via `localStorage` across sessions

Closes #149

## Test plan
- [ ] Click X → panel collapses smoothly, days column expands
- [ ] Click chart icon → panel re-expands
- [ ] Reload app → collapse state is restored
- [ ] Hover over panel in expanded state → no upward float/clipping
- [ ] Works in both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)