### PR TITLE
feat(tm-151): week switcher modal, panel cleanup, and header polish

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -18,7 +18,7 @@
   <header class="app-header">
     <div class="container-fluid px-4">
       <div class="d-flex align-items-center justify-content-between gap-3">
-        <div class="d-flex align-items-center gap-3 flex-shrink-0">
+        <div class="header-side d-flex align-items-center gap-3">
           <div class="header-logo">
             <img src="favicon.png" alt="App Icon" style="width: 100%; height: 100%; border-radius: 10px;" />
           </div>
@@ -38,13 +38,11 @@
           </div>
           <div class="search-dropdown" id="search-dropdown" style="display:none"></div>
         </div>
-        <div class="d-flex gap-2 flex-shrink-0">
-          <button class="btn btn-outline-light btn-sm px-3" id="btn-preview">
-            <i class="bi bi-eye me-1"></i> Preview
-          </button>
-          <button class="btn btn-gradient btn-sm px-3" id="btn-print">
-            <i class="bi bi-printer me-1"></i> Print
-          </button>
+        <div class="header-side header-side--right gap-2">
+          <div class="header-user-chip" id="header-user-chip">
+            <i class="bi bi-person-circle"></i>
+            <span id="header-emp-name"></span>
+          </div>
           <button class="btn btn-outline-light btn-sm px-2" id="btn-menu-toggle" type="button" data-bs-toggle="offcanvas"
             data-bs-target="#appSidebar" aria-controls="appSidebar" title="Menu">
             <i class="bi bi-list fs-5"></i>
@@ -81,6 +79,12 @@
           <button class="summary-toggle-btn" id="btn-expand-summary" title="Show Summary panel">
             <i class="bi bi-bar-chart-line"></i>
           </button>
+          <button class="summary-toggle-btn" id="btn-collapsed-preview" title="Preview">
+            <i class="bi bi-eye"></i>
+          </button>
+          <button class="summary-toggle-btn" id="btn-collapsed-print" title="Print">
+            <i class="bi bi-printer"></i>
+          </button>
         </div>
 
         <!-- Week Range & Employee Info -->
@@ -88,12 +92,15 @@
           <div class="card-body">
 
             <!-- 1. WEEKLY SUMMARY -->
-            <div class="d-flex align-items-center justify-content-between mb-3">
+            <div class="d-flex align-items-center justify-content-between mb-1">
               <h5 class="section-label mb-0"><i class="bi bi-bar-chart-line me-2"></i>Weekly Summary</h5>
               <button class="btn-collapse-panel" id="btn-collapse-summary" title="Hide Summary panel">
                 <i class="bi bi-x-lg"></i>
               </button>
             </div>
+            <button class="panel-week-label btn-ripple" id="panel-week-label" title="Switch week (Ctrl+G)">
+              <i class="bi bi-calendar3 me-1"></i><span id="panel-week-text">—</span>
+            </button>
             <div class="d-flex flex-column gap-3 mb-4">
               <div class="total-chip w-100 mt-0 text-center" id="total-hours-chip">
                 <div class="week-progress-fill" id="week-progress-fill"></div>
@@ -127,51 +134,15 @@
               </div>
             </div>
 
-            <hr class="border-secondary my-3 opacity-25">
-
-            <!-- 2. WEEK SWITCHER -->
-            <div class="mb-3">
-              <label class="form-label label-text">Timesheet Week</label>
-              <div class="d-flex align-items-stretch gap-2 mb-2">
-                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-prev-week" title="Previous Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
-                  <i class="bi bi-chevron-left"></i>
-                </button>
-                <input type="week" id="week-picker" class="form-control dark-input m-0 flex-grow-1" />
-                <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="btn-next-week" title="Next Week" style="width: 42px; border-radius: var(--radius-sm) !important;">
-                  <i class="bi bi-chevron-right"></i>
-                </button>
-              </div>
-              <div class="form-text text-muted mt-1" id="week-display-label">Select a week</div>
-            </div>
-
-            <button class="btn btn-outline-accent w-100 mb-4" id="btn-autofill-week">
-              <i class="bi bi-calendar-week me-1"></i> Use Current Week
-            </button>
-
-            <hr class="border-secondary my-3 opacity-25">
-
-            <!-- 3. SHEET DETAILS -->
-            <div class="d-flex align-items-center justify-content-between mb-3">
-              <h5 class="section-label mb-0"><i class="bi bi-person-badge me-2"></i>Sheet Details</h5>
-              <button class="btn btn-sm btn-outline-accent px-2 py-1" id="btn-edit-sheet-details" title="Edit in Settings">
-                <i class="bi bi-pencil" style="font-size:0.8rem"></i>
+            <div class="d-flex gap-2 mt-3">
+              <button class="btn btn-outline-accent btn-sm flex-fill" id="btn-preview">
+                <i class="bi bi-eye me-1"></i> Preview
+              </button>
+              <button class="btn btn-gradient btn-sm flex-fill" id="btn-print">
+                <i class="bi bi-printer me-1"></i> Print
               </button>
             </div>
 
-            <div class="mb-3">
-              <div class="label-text">Report Title</div>
-              <div class="sheet-detail-value" id="display-report-title">—</div>
-            </div>
-
-            <div class="mb-3">
-              <div class="label-text">Employee Name</div>
-              <div class="sheet-detail-value" id="display-emp-name">—</div>
-            </div>
-
-            <div class="mb-1">
-              <div class="label-text">Daily Target</div>
-              <div class="sheet-detail-value" id="display-daily-target">—</div>
-            </div>
 
           </div>
         </div>
@@ -185,6 +156,49 @@
     </div> <!-- /row -->
   </main>
 
+  <!-- Hidden week-picker elements (referenced by existing JS) -->
+  <div style="display:none" aria-hidden="true">
+    <button id="btn-prev-week"></button>
+    <input type="week" id="week-picker" />
+    <button id="btn-next-week"></button>
+    <div id="week-display-label"></div>
+    <button id="btn-autofill-week"></button>
+  </div>
+
+  <!-- WEEK SWITCHER MODAL -->
+  <div class="modal fade" id="weekSwitcherModal" tabindex="-1" aria-labelledby="weekSwitcherModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm modal-dialog-centered">
+      <div class="modal-content modal-dark">
+        <div class="modal-header">
+          <h5 class="modal-title" id="weekSwitcherModalLabel"><i class="bi bi-calendar-week me-2"></i>Switch Week</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <button class="btn btn-outline-accent w-100 mb-3" id="modal-btn-current-week">
+            <i class="bi bi-calendar-check me-1"></i> Go to Current Week
+          </button>
+          <label class="form-label label-text mb-2">Select Week</label>
+          <div class="d-flex align-items-stretch gap-2 mb-2">
+            <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="modal-btn-prev-week" style="width:42px;border-radius:var(--radius-sm)!important">
+              <i class="bi bi-chevron-left"></i>
+            </button>
+            <input type="week" id="modal-week-picker" class="form-control dark-input m-0 flex-grow-1" />
+            <button class="btn btn-outline-accent btn-ripple d-flex align-items-center justify-content-center p-0" id="modal-btn-next-week" style="width:42px;border-radius:var(--radius-sm)!important">
+              <i class="bi bi-chevron-right"></i>
+            </button>
+          </div>
+          <div class="form-text text-muted mt-1" id="modal-week-display-label"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-gradient" id="modal-btn-switch-week">
+            <i class="bi bi-arrow-right-circle me-1"></i> Switch
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- PREVIEW MODAL -->
   <div class="modal fade" id="previewModal" tabindex="-1" aria-labelledby="previewModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-xl modal-dialog-scrollable">
@@ -197,6 +211,9 @@
           <pre id="txt-preview" class="txt-output"></pre>
         </div>
         <div class="modal-footer">
+          <button class="btn btn-sm btn-outline-accent me-auto" id="btn-edit-sheet-details">
+            <i class="bi bi-pencil me-1"></i> Edit Sheet Details
+          </button>
           <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Close</button>
           <button type="button" class="btn btn-gradient" id="btn-copy-txt">
             <i class="bi bi-clipboard me-1"></i> Copy to Clipboard
@@ -646,6 +663,7 @@
             <div class="cheatsheet-row"><kbd>↑</kbd><kbd>↓</kbd> <span>Switch expanded day up / down</span></div>
             <div class="cheatsheet-row"><kbd>←</kbd><kbd>→</kbd> <span>Switch to previous / next week</span></div>
             <div class="cheatsheet-row"><kbd>G</kbd> <span>Jump to current week and expand today</span></div>
+            <div class="cheatsheet-row"><kbd>Ctrl</kbd><kbd>G</kbd> <span>Open week switcher</span></div>
           </div>
           <div class="cheatsheet-group">
             <div class="cheatsheet-group-label">Entries</div>

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -14,7 +14,7 @@ import { initRecurring } from './modules/recurring.js';
 import { initEntryModal } from './modules/entry-modal.js';
 import { initCopyTo } from './modules/copy-to.js';
 import { initReport } from './modules/report.js';
-import { bindHeaderEvents } from './modules/header.js';
+import { bindHeaderEvents, openWeekSwitcherModal } from './modules/header.js';
 import { initSettings, updateSheetDetailsDisplay, loadChangelog } from './modules/settings.js';
 import { loadErrorLog } from './modules/error-log.js';
 import { renderAll } from './modules/render.js';
@@ -79,6 +79,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     updateSummary();
+    document.getElementById('panel-week-label')?.addEventListener('click', openWeekSwitcherModal);
     initKeyboard();
     updateNoTicketBanner();
     updateUnderloggedBanner();

--- a/src/renderer/modules/header.js
+++ b/src/renderer/modules/header.js
@@ -70,3 +70,70 @@ export function bindHeaderEvents() {
 
     document.getElementById('modal-time').addEventListener('input', updateEntryDayTotal);
 }
+
+export function openWeekSwitcherModal() {
+    const modalEl = document.getElementById('weekSwitcherModal');
+    if (!modalEl) return;
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+
+    const modalPicker = document.getElementById('modal-week-picker');
+    const modalLabel = document.getElementById('modal-week-display-label');
+    const maxWeek = getWeekStrFromDate(new Date());
+
+    function fmt(d) {
+        return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+    }
+
+    function syncLabel(weekStr) {
+        const mon = getDateFromWeek(weekStr);
+        const fri = new Date(mon);
+        fri.setDate(mon.getDate() + 4);
+        modalLabel.textContent = `${fmt(mon)} to ${fmt(fri)}`;
+        document.getElementById('modal-btn-next-week').disabled = weekStr >= maxWeek;
+    }
+
+    modalPicker.max = maxWeek;
+    modalPicker.value = state.weekValue || maxWeek;
+    syncLabel(modalPicker.value);
+
+    modalPicker.onchange = () => syncLabel(modalPicker.value);
+
+    document.getElementById('modal-btn-prev-week').onclick = () => {
+        const mon = getDateFromWeek(modalPicker.value);
+        mon.setDate(mon.getDate() - 7);
+        const w = getWeekStrFromDate(mon);
+        modalPicker.value = w;
+        syncLabel(w);
+    };
+
+    document.getElementById('modal-btn-next-week').onclick = () => {
+        const mon = getDateFromWeek(modalPicker.value);
+        mon.setDate(mon.getDate() + 7);
+        const w = getWeekStrFromDate(mon);
+        if (w > maxWeek) return;
+        modalPicker.value = w;
+        syncLabel(w);
+    };
+
+    document.getElementById('modal-btn-current-week').onclick = () => {
+        modal.hide();
+        const prevWeek = state.weekValue;
+        setCurrentWeek();
+        saveState();
+        setWeekTransitionDir(prevWeek ? (state.weekValue > prevWeek ? 'left' : state.weekValue < prevWeek ? 'right' : null) : null);
+        renderAll();
+        setWeekTransitionDir(null);
+        updateSummary();
+    };
+
+    document.getElementById('modal-btn-switch-week').onclick = () => {
+        const selected = modalPicker.value;
+        if (!selected) return;
+        modal.hide();
+        const picker = document.getElementById('week-picker');
+        picker.value = selected;
+        picker.dispatchEvent(new Event('change'));
+    };
+
+    modal.show();
+}

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -285,6 +285,12 @@ export function updateSheetDetailsDisplay() {
 
     if (titleEl)  titleEl.textContent  = state.reportTitle  || '—';
     if (nameEl)   nameEl.textContent   = state.employeeName || '—';
+
+    const headerEmp = document.getElementById('header-emp-name');
+    const headerChip = document.getElementById('header-user-chip');
+    if (headerEmp) headerEmp.textContent = state.employeeName || '';
+    if (headerChip) headerChip.style.display = state.employeeName ? '' : 'none';
+
     if (targetEl) {
         const hh = Math.floor(state.dailyTargetMins / 60);
         const mm = state.dailyTargetMins % 60;

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -9,6 +9,7 @@ import { changeWeekBy, setCurrentWeek } from './week.js';
 import { updateSummary } from './summary.js';
 import { openPreview, openDayQuickView, doPrint } from './report.js';
 import { openSettings, addChangelogEntry } from './settings.js';
+import { openWeekSwitcherModal } from './header.js';
 import { logError } from './error-log.js';
 
 /* ── SUMMARY PANEL COLLAPSE ─────────────────────────────── */
@@ -30,6 +31,16 @@ export function initSummaryPanel() {
     btnExpand?.addEventListener('click', () => {
         mainRow.classList.remove('summary-collapsed');
         localStorage.setItem(STORAGE_KEY, '0');
+    });
+
+    document.getElementById('btn-collapsed-preview')?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openPreview();
+    });
+
+    document.getElementById('btn-collapsed-print')?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        doPrint();
     });
 }
 
@@ -212,6 +223,12 @@ export function initKeyboard() {
         if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
 
         const modalOpen = document.querySelector('.modal.show');
+
+        if (e.ctrlKey && (e.key === 'g' || e.key === 'G')) {
+            e.preventDefault();
+            openWeekSwitcherModal();
+            return;
+        }
 
         if (modalOpen) {
             if (e.key === 'Enter' && modalOpen.id === 'entryModal') {

--- a/src/renderer/modules/week.js
+++ b/src/renderer/modules/week.js
@@ -72,6 +72,10 @@ export function updateWeekDisplay() {
 
     const display = `${fmtDisplayDate(fmtDate(mon))} to ${fmtDisplayDate(fmtDate(fri))}`;
     document.getElementById('week-display-label').textContent = display;
+
+    const [year, weekNum] = state.weekValue.split('-W');
+    const panelText = document.getElementById('panel-week-text');
+    if (panelText) panelText.textContent = `Week ${parseInt(weekNum)}, ${year}`;
 }
 
 export function enforceExpandedState() {

--- a/src/renderer/styles/header.css
+++ b/src/renderer/styles/header.css
@@ -40,3 +40,45 @@
   color: var(--text-muted);
   margin: 0;
 }
+
+.header-side {
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.header-side--right {
+  justify-content: flex-end;
+}
+
+.header-user-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 500;
+  white-space: nowrap;
+  max-width: 180px;
+  overflow: hidden;
+}
+
+.header-user-chip i {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+#header-emp-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.header-user-chip:empty,
+.header-user-chip:has(#header-emp-name:empty) {
+  display: none;
+}

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -107,9 +107,33 @@
 
 [data-theme="light"] .lb-hours { color: #1a1a2e; }
 
+/* ── PANEL WEEK LABEL ── */
+
+.panel-week-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  padding: 2px 0;
+  margin-bottom: 14px;
+  cursor: pointer;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  transition: color 0.2s ease;
+}
+
+.panel-week-label:hover {
+  color: var(--text-secondary);
+}
+
 /* ── SUMMARY PANEL COLLAPSE ── */
 
 #summary-col {
+  align-self: flex-start;
   overflow: hidden;
   transition: flex-basis 0.32s cubic-bezier(0.4, 0, 0.2, 1),
               max-width  0.32s cubic-bezier(0.4, 0, 0.2, 1),
@@ -122,7 +146,9 @@
 
 .summary-panel-toggle {
   display: none;
-  justify-content: flex-start;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
   opacity: 0;
   transition: opacity 0.2s ease 0.18s;
 }


### PR DESCRIPTION
## Summary
- Week switcher moved out of the panel into a **Ctrl+G modal** (prev/next nav, current-week jump, Switch button)
- Compact week label added to summary panel — clickable to open modal
- **Preview & Print** buttons moved into the panel; icon-only variants shown when panel is collapsed
- **Sheet Details** section removed from panel; edit button moved to preview modal footer (left side, with label)
- **Employee name chip** added to header nav (pill with person icon, hidden when empty)
- Header search bar re-centred with balanced flex sides
- Keyboard shortcuts cheatsheet updated with Ctrl+G

Closes #151

## Test plan
- [ ] Ctrl+G opens week switcher modal
- [ ] Modal prev/next navigates without changing active week; Switch applies it
- [ ] Go to Current Week closes modal and jumps correctly
- [ ] Panel week label shows current week and opens modal on click
- [ ] Preview / Print work from panel buttons and from collapsed icon strip
- [ ] Edit Sheet Details button in preview modal footer opens settings
- [ ] Employee name chip shows/hides correctly; updates when name is changed in settings
- [ ] Search bar is horizontally centred in the header
- [ ] ← / → week shortcuts still work without opening modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)