### PR TITLE
feat(tm-153): notification centre with bell icon and banner-to-list collapse

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -43,6 +43,10 @@
             <i class="bi bi-person-circle"></i>
             <span id="header-emp-name"></span>
           </div>
+          <button class="btn btn-outline-light btn-sm px-2 notif-btn" id="btn-notifications" title="Notifications">
+            <i class="bi bi-bell"></i>
+            <span class="notif-badge" id="notif-badge" style="display:none">0</span>
+          </button>
           <button class="btn btn-outline-light btn-sm px-2" id="btn-menu-toggle" type="button" data-bs-toggle="offcanvas"
             data-bs-target="#appSidebar" aria-controls="appSidebar" title="Menu">
             <i class="bi bi-list fs-5"></i>
@@ -979,6 +983,19 @@
           <button class="btn btn-gradient px-4" id="btn-rc-confirm" style="display:none">Confirm Restore</button>
         </div>
       </div>
+    </div>
+  </div>
+
+  <!-- NOTIFICATION DROPDOWN -->
+  <div class="notif-dropdown" id="notif-dropdown" style="display:none">
+    <div class="notif-dropdown-header">
+      <span class="notif-dropdown-title"><i class="bi bi-bell me-2"></i>Notifications</span>
+      <button class="notif-clear-all" id="btn-notif-clear-all">Clear all</button>
+    </div>
+    <div class="notif-list" id="notif-list"></div>
+    <div class="notif-empty" id="notif-empty">
+      <i class="bi bi-bell-slash"></i>
+      <span>No notifications</span>
     </div>
   </div>
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -24,6 +24,7 @@ import { updateSummary } from './modules/summary.js';
 import { initOnboarding, needsOnboarding, showOnboarding } from './modules/onboarding.js';
 import { initNoTicketBanner, updateNoTicketBanner } from './modules/no-ticket-reminder.js';
 import { initUnderloggedBanner, updateUnderloggedBanner } from './modules/underlogged-reminder.js';
+import { initNotifications } from './modules/notifications.js';
 import { initStats } from './modules/stats.js';
 import { setCurrentWeek } from './modules/week.js';
 
@@ -33,6 +34,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initRipple();
     initSettings();
     initOnboarding();
+    initNotifications();
     initNoTicketBanner();
     initUnderloggedBanner();
     initSidebar();

--- a/src/renderer/modules/no-ticket-reminder.js
+++ b/src/renderer/modules/no-ticket-reminder.js
@@ -3,12 +3,15 @@
    ============================================================= */
 
 import { state } from './state.js';
+import { pushNotification } from './notifications.js';
 
 let _dismissed = false;
 
 export function initNoTicketBanner() {
     document.getElementById('btn-dismiss-no-ticket')
         .addEventListener('click', () => {
+            const msg = document.getElementById('no-ticket-banner-msg').textContent;
+            pushNotification('no-ticket', msg);
             document.getElementById('no-ticket-banner').style.display = 'none';
             _dismissed = true;
         });

--- a/src/renderer/modules/notifications.js
+++ b/src/renderer/modules/notifications.js
@@ -1,0 +1,178 @@
+/* =============================================================
+   NOTIFICATION CENTRE
+   ============================================================= */
+
+const STORAGE_KEY = 'tm_notifications';
+
+let notifications = [];
+let dropdownOpen = false;
+
+const TYPE_META = {
+    'no-ticket':   { icon: 'bi-exclamation-triangle-fill', color: 'var(--danger)' },
+    'underlogged': { icon: 'bi-clock-history',             color: 'var(--warning)' },
+};
+
+/* ── persistence ── */
+
+function load() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        notifications = raw ? JSON.parse(raw) : [];
+    } catch { notifications = []; }
+}
+
+function save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(notifications.slice(0, 50)));
+}
+
+/* ── public API ── */
+
+export function pushNotification(type, message) {
+    load();
+    const existing = notifications.find(n => n.type === type && !n.dismissed);
+    if (existing) {
+        if (existing.message !== message) {
+            existing.message = message;
+            existing.timestamp = new Date().toISOString();
+            existing.read = false;
+            save();
+            renderBadge();
+        }
+        return;
+    }
+    notifications.unshift({
+        id: 'n-' + Date.now(),
+        type,
+        message,
+        timestamp: new Date().toISOString(),
+        read: false,
+        dismissed: false,
+    });
+    save();
+    renderBadge();
+}
+
+/* ── init ── */
+
+export function initNotifications() {
+    load();
+    renderBadge();
+
+    const btn = document.getElementById('btn-notifications');
+    btn?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        toggleDropdown();
+    });
+
+    document.addEventListener('click', (e) => {
+        if (dropdownOpen && !document.getElementById('notif-dropdown')?.contains(e.target)) {
+            closeDropdown();
+        }
+    });
+
+    document.getElementById('btn-notif-clear-all')?.addEventListener('click', () => {
+        notifications = [];
+        save();
+        renderBadge();
+        renderList();
+    });
+}
+
+/* ── badge ── */
+
+function renderBadge() {
+    const unread = notifications.filter(n => !n.read && !n.dismissed).length;
+    const badge = document.getElementById('notif-badge');
+    const btn   = document.getElementById('btn-notifications');
+    if (badge) {
+        badge.textContent = unread > 9 ? '9+' : String(unread);
+        badge.style.display = unread > 0 ? '' : 'none';
+    }
+    if (btn) btn.classList.toggle('notif-btn--active', unread > 0);
+}
+
+/* ── dropdown ── */
+
+function toggleDropdown() {
+    dropdownOpen ? closeDropdown() : openDropdown();
+}
+
+function openDropdown() {
+    const btn = document.getElementById('btn-notifications');
+    const dropdown = document.getElementById('notif-dropdown');
+    if (!btn || !dropdown) return;
+
+    const rect = btn.getBoundingClientRect();
+    dropdown.style.top   = (rect.bottom + 8) + 'px';
+    dropdown.style.right = (window.innerWidth - rect.right) + 'px';
+    dropdown.style.display = 'flex';
+    dropdownOpen = true;
+
+    // mark all as read
+    notifications.forEach(n => { n.read = true; });
+    save();
+    renderBadge();
+    renderList();
+}
+
+function closeDropdown() {
+    const dropdown = document.getElementById('notif-dropdown');
+    if (dropdown) dropdown.style.display = 'none';
+    dropdownOpen = false;
+}
+
+/* ── list ── */
+
+function renderList() {
+    const list  = document.getElementById('notif-list');
+    const empty = document.getElementById('notif-empty');
+    if (!list) return;
+
+    const active = notifications.filter(n => !n.dismissed);
+    empty.style.display = active.length === 0 ? '' : 'none';
+    list.innerHTML = '';
+
+    active.forEach(n => {
+        const meta = TYPE_META[n.type] || { icon: 'bi-bell', color: 'var(--text-muted)' };
+        const time = formatTime(n.timestamp);
+        const item = document.createElement('div');
+        item.className = 'notif-item';
+        item.innerHTML = `
+            <i class="bi ${meta.icon} notif-item-icon" style="color:${meta.color}"></i>
+            <div class="notif-item-body">
+                <p class="notif-item-msg">${escHtml(n.message)}</p>
+                <span class="notif-item-time">${time}</span>
+            </div>
+            <button class="notif-item-dismiss" data-id="${n.id}" title="Dismiss">
+                <i class="bi bi-x"></i>
+            </button>`;
+        item.querySelector('.notif-item-dismiss').addEventListener('click', (e) => {
+            e.stopPropagation();
+            dismissOne(n.id);
+        });
+        list.appendChild(item);
+    });
+}
+
+function dismissOne(id) {
+    const n = notifications.find(n => n.id === id);
+    if (n) { n.dismissed = true; save(); renderBadge(); renderList(); }
+}
+
+/* ── helpers ── */
+
+function formatTime(iso) {
+    const d = new Date(iso);
+    const now = new Date();
+    const diffMs = now - d;
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 1)  return 'Just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHrs = Math.floor(diffMins / 60);
+    if (diffHrs < 24)  return `${diffHrs}h ago`;
+    return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' });
+}
+
+function escHtml(str) {
+    return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}

--- a/src/renderer/modules/underlogged-reminder.js
+++ b/src/renderer/modules/underlogged-reminder.js
@@ -4,12 +4,15 @@
 
 import { state, WEEK_DAYS } from './state.js';
 import { fmtDate } from './utils.js';
+import { pushNotification } from './notifications.js';
 
 let _dismissed = false;
 
 export function initUnderloggedBanner() {
     document.getElementById('btn-dismiss-underlogged')
         .addEventListener('click', () => {
+            const msg = document.getElementById('underlogged-banner-msg').textContent;
+            pushNotification('underlogged', msg);
             document.getElementById('underlogged-banner').style.display = 'none';
             _dismissed = true;
         });

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -21,3 +21,4 @@
 @import './settings.css';
 @import './stats.css';
 @import './restore.css';
+@import './notifications.css';

--- a/src/renderer/styles/notifications.css
+++ b/src/renderer/styles/notifications.css
@@ -1,0 +1,161 @@
+/* ── NOTIFICATION BELL ── */
+
+.notif-btn {
+  position: relative;
+}
+
+.notif-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 3px;
+  background: var(--danger);
+  color: #fff;
+  font-size: 0.58rem;
+  font-weight: 700;
+  border-radius: 8px;
+  border: 1.5px solid var(--bg-base);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.notif-btn--active {
+  border-color: var(--danger) !important;
+  color: var(--danger) !important;
+}
+
+/* ── NOTIFICATION DROPDOWN ── */
+
+.notif-dropdown {
+  position: fixed;
+  z-index: 9999;
+  width: 340px;
+  max-height: 420px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.notif-dropdown-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.notif-dropdown-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.notif-clear-all {
+  background: transparent;
+  border: none;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.notif-clear-all:hover {
+  color: var(--text-primary);
+  background: var(--bg-input);
+}
+
+.notif-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.notif-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.15s ease;
+}
+
+.notif-item:last-child {
+  border-bottom: none;
+}
+
+.notif-item:hover {
+  background: var(--bg-card-hover);
+}
+
+.notif-item-icon {
+  font-size: 0.9rem;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.notif-item-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.notif-item-msg {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  margin: 0 0 4px;
+  line-height: 1.4;
+}
+
+.notif-item-time {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+
+.notif-item-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease;
+  line-height: 1;
+}
+
+.notif-item:hover .notif-item-dismiss {
+  opacity: 1;
+}
+
+.notif-item-dismiss:hover {
+  color: var(--text-primary);
+}
+
+.notif-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 32px 16px;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.notif-empty i {
+  font-size: 1.6rem;
+  opacity: 0.4;
+}
+
+[data-theme="light"] .notif-dropdown {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}


### PR DESCRIPTION
## Summary
- Clicking X on a banner now pushes it to the notification centre instead of discarding it
- Bell icon added to header with a red corner badge showing unread count
- Clicking bell opens a dropdown listing all notifications with type icon, message, and timestamp
- No duplicates — same alert type won't add a second entry if one already exists unread
- Banners naturally reappear next app launch if the issue is still unresolved (existing behaviour)
- Individual dismiss (×) and "Clear all" supported
- Notifications persisted via localStorage

Closes #153

## Test plan
- [ ] Dismiss a banner → appears in notification list, badge count increments
- [ ] Badge sits at top-right corner of bell without covering the icon
- [ ] Bell dropdown opens/closes on click; closes on outside click
- [ ] Dismissing same banner type again doesn't duplicate the notification
- [ ] Individual × removes item; Clear all empties the list
- [ ] Notifications survive app restart
- [ ] Banners reappear on next launch if issue unresolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)