### PR TITLE
feat(tm-155): add Ctrl+L bulk-log, Ctrl+N entry, Change Week button

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -89,6 +89,9 @@
           <button class="summary-toggle-btn" id="btn-collapsed-print" title="Print">
             <i class="bi bi-printer"></i>
           </button>
+          <button class="summary-toggle-btn" id="btn-collapsed-week-switch" title="Change Week">
+            <i class="bi bi-calendar-week"></i>
+          </button>
         </div>
 
         <!-- Week Range & Employee Info -->
@@ -146,6 +149,9 @@
                 <i class="bi bi-printer me-1"></i> Print
               </button>
             </div>
+            <button class="btn btn-outline-secondary btn-sm w-100 mt-2" id="btn-panel-week-switch">
+              <i class="bi bi-calendar-week me-1"></i> Change Week
+            </button>
 
 
           </div>
@@ -671,11 +677,12 @@
           </div>
           <div class="cheatsheet-group">
             <div class="cheatsheet-group-label">Entries</div>
-            <div class="cheatsheet-row"><kbd>N</kbd> <span>Add new entry to expanded day</span></div>
+            <div class="cheatsheet-row"><kbd>Ctrl</kbd><kbd>N</kbd> <span>Add new entry to expanded day</span></div>
             <div class="cheatsheet-row"><kbd>Ctrl</kbd><kbd>V</kbd> <span>Open entry modal pre-filled with clipboard ticket</span></div>
             <div class="cheatsheet-row"><kbd>T</kbd> <span>Open notes for expanded day</span></div>
             <div class="cheatsheet-row"><kbd>Enter</kbd> <span>Save entry (inside entry modal)</span></div>
             <div class="cheatsheet-row"><kbd>Alt</kbd><kbd>N</kbd> <span>Open entry modal with no-ticket toggled on</span></div>
+            <div class="cheatsheet-row"><kbd>Ctrl</kbd><kbd>L</kbd> <span>Mark all entries of expanded day as logged</span></div>
           </div>
           <div class="cheatsheet-group">
             <div class="cheatsheet-group-label">Views</div>

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -72,18 +72,6 @@ export function openEntryModal(dayIdx, entryIdx) {
         makeRegularBtn.style.display = 'none';
         title.innerHTML = `<i class="bi bi-plus-circle me-2"></i>Add Entry — ${WEEK_DAYS[dayIdx]}`;
 
-        // Auto-fill ticket from clipboard
-        readClipboardTicket().then(result => {
-            if (!result) return;
-            const ticketEl = document.getElementById('modal-ticket');
-            const typeEl   = document.getElementById('modal-type');
-            if (ticketEl && !ticketEl.value) {
-                ticketEl.value = result.ticket;
-            }
-            if (result.typeId && typeEl) {
-                typeEl.value = result.typeId;
-            }
-        });
     } else {
         const e = state.days[dayIdx].entries[entryIdx];
         const noTicketToggle = document.getElementById('modal-no-ticket');

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -1,7 +1,7 @@
 import { state } from './state.js';
 import { showToast } from './toast.js';
 import { escHtml } from './utils.js';
-import { renderStarredList } from './star.js';
+import { renderStarredList, markDayAllLogged } from './star.js';
 import { saveEntry, openEntryModal, readClipboardTicket } from './entry-modal.js';
 import { toggleDay, renderAll, openDayNotesModal } from './render.js';
 import { openStatsModal } from './stats.js';
@@ -41,6 +41,15 @@ export function initSummaryPanel() {
     document.getElementById('btn-collapsed-print')?.addEventListener('click', (e) => {
         e.stopPropagation();
         doPrint();
+    });
+
+    document.getElementById('btn-panel-week-switch')?.addEventListener('click', () => {
+        openWeekSwitcherModal();
+    });
+
+    document.getElementById('btn-collapsed-week-switch')?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openWeekSwitcherModal();
     });
 }
 
@@ -224,6 +233,14 @@ export function initKeyboard() {
 
         const modalOpen = document.querySelector('.modal.show');
 
+        if (e.ctrlKey && (e.key === 'n' || e.key === 'N')) {
+            e.preventDefault();
+            if (modalOpen) return;
+            const expandedIdx = state.days.findIndex(d => d.expanded);
+            if (expandedIdx !== -1) openEntryModal(expandedIdx, -1);
+            return;
+        }
+
         if (e.ctrlKey && (e.key === 'g' || e.key === 'G')) {
             e.preventDefault();
             openWeekSwitcherModal();
@@ -265,10 +282,6 @@ export function initKeyboard() {
                 updateSummary();
                 break;
 
-            case 'n':
-            case 'N':
-                if (!e.altKey && expandedIdx !== -1) openEntryModal(expandedIdx, -1);
-                break;
 
             case 't':
             case 'T':
@@ -333,6 +346,14 @@ export function initKeyboard() {
                     if (result.typeId && typeEl) typeEl.value = result.typeId;
                 }, { once: true });
             });
+        }
+
+        if (e.ctrlKey && (e.key === 'l' || e.key === 'L')) {
+            e.preventDefault();
+            if (modalOpen) return;
+            const expandedIdx = state.days.findIndex(d => d.expanded);
+            if (expandedIdx === -1) return;
+            markDayAllLogged(expandedIdx);
         }
     });
 }

--- a/src/renderer/modules/star.js
+++ b/src/renderer/modules/star.js
@@ -3,6 +3,8 @@ import { saveState } from './store.js';
 import { escHtml, fmtSearchDate, fmtHHMM } from './utils.js';
 import { getTypeLabel } from './ticket-types.js';
 import { navigateToResult } from './search.js';
+import { rerenderDayCard } from './render.js';
+import { showToast } from './toast.js';
 
 export function toggleEntryStarred(dayIdx, entryIdx, btnEl) {
     const entry = state.days[dayIdx]?.entries[entryIdx];
@@ -37,6 +39,87 @@ export function toggleEntryLogged(dayIdx, entryIdx, btnEl) {
         state.allDaysByDate[dateStr].entries[entryIdx] = entry;
     }
     saveState();
+}
+
+let _lastBulkLog = null;
+
+export function markDayAllLogged(dayIdx) {
+    const day = state.days[dayIdx];
+    if (!day?.entries?.length) return;
+
+    const unlogged = day.entries
+        .map((e, i) => ({ i, wasLoggedUpdated: !!e.loggedUpdated }))
+        .filter((_, idx) => !day.entries[idx].logged);
+
+    if (!unlogged.length) return;
+
+    // Snapshot for undo
+    _lastBulkLog = { dayIdx, snapshot: unlogged };
+
+    unlogged.forEach(({ i }) => {
+        const entry = day.entries[i];
+        entry.logged = true;
+        delete entry.loggedUpdated;
+    });
+
+    const dateStr = day.date;
+    if (state.allDaysByDate[dateStr]) {
+        state.allDaysByDate[dateStr].entries = day.entries;
+    }
+
+    saveState();
+    rerenderDayCard(dayIdx);
+    _showBulkLogUndoToast(unlogged.length);
+}
+
+function _undoBulkLog() {
+    if (!_lastBulkLog) return;
+    const { dayIdx, snapshot } = _lastBulkLog;
+    _lastBulkLog = null;
+    const day = state.days[dayIdx];
+    if (!day?.entries) return;
+
+    snapshot.forEach(({ i, wasLoggedUpdated }) => {
+        day.entries[i].logged = false;
+        if (wasLoggedUpdated) day.entries[i].loggedUpdated = true;
+    });
+
+    const dateStr = day.date;
+    if (state.allDaysByDate[dateStr]) {
+        state.allDaysByDate[dateStr].entries = day.entries;
+    }
+
+    saveState();
+    rerenderDayCard(dayIdx);
+    showToast('Bulk log undone.', 'success');
+}
+
+function _showBulkLogUndoToast(count) {
+    let container = document.querySelector('.toast-container');
+    if (!container) {
+        container = document.createElement('div');
+        container.className = 'toast-container';
+        document.body.appendChild(container);
+    }
+    const existing = document.getElementById('bulk-log-toast');
+    if (existing) existing.remove();
+
+    container.insertAdjacentHTML('beforeend', `
+    <div id="bulk-log-toast" class="toast toast-custom show align-items-center" role="alert" style="min-width:280px">
+      <div class="d-flex align-items-center gap-2 px-3 py-2">
+        <i class="bi bi-journal-check" style="color:#4ade80"></i>
+        <span style="font-size:0.85rem">${count} ${count === 1 ? 'entry' : 'entries'} marked as logged.</span>
+        <button type="button" class="btn btn-sm btn-outline-light ms-auto py-0 px-2" style="font-size:0.75rem" id="btn-undo-bulk-log">Undo</button>
+      </div>
+    </div>`);
+
+    const timerId = setTimeout(() => { document.getElementById('bulk-log-toast')?.remove(); }, 5000);
+
+    document.getElementById('btn-undo-bulk-log').addEventListener('click', () => {
+        clearTimeout(timerId);
+        document.getElementById('bulk-log-toast')?.remove();
+        _undoBulkLog();
+    });
 }
 
 export function renderStarredList() {

--- a/src/renderer/styles/header.css
+++ b/src/renderer/styles/header.css
@@ -82,3 +82,12 @@
 .header-user-chip:has(#header-emp-name:empty) {
   display: none;
 }
+
+#btn-menu-toggle {
+  width: 2.25rem;
+  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}

--- a/src/renderer/styles/notifications.css
+++ b/src/renderer/styles/notifications.css
@@ -2,6 +2,12 @@
 
 .notif-btn {
   position: relative;
+  width: 2.25rem;
+  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 !important;
 }
 
 .notif-badge {


### PR DESCRIPTION
## Summary
- Add **Ctrl+L** shortcut to mark all unlogged entries in the expanded day as logged, with a 5-second undo toast
- Replace bare **N** shortcut with **Ctrl+N** to open new entry modal
- Remove clipboard auto-prefill on new entry open (Ctrl+V already handles this explicitly)
- Add **Change Week** button to summary panel (below Preview/Print) and to the collapsed icon strip

## Changes
| File | What changed |
|------|-------------|
| `src/renderer/modules/star.js` | Added `markDayAllLogged()` with snapshot-based undo toast |
| `src/renderer/modules/sidebar.js` | Registered Ctrl+L and Ctrl+N shortcuts; wired Change Week buttons |
| `src/renderer/modules/entry-modal.js` | Removed clipboard auto-prefill on new entry open |
| `src/renderer/index.html` | Added Change Week buttons, updated cheatsheet for all new/changed shortcuts |
| `src/renderer/styles/notifications.css` | Pinned notification bell to 2.25rem square with flex centering |
| `src/renderer/styles/header.css` | Pinned menu toggle to 2.25rem square to match bell button |

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Ctrl+L marks all unlogged entries and undo restores them
- [ ] Ctrl+N opens new entry modal; bare N no longer triggers it
- [ ] Change Week button in panel and collapsed strip both open week switcher
- [ ] Bell and menu buttons are equal size in header
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #155

🤖 Generated with [Claude Code](https://claude.ai/claude-code)