### PR TITLE
feat(tm-161): add smart suggestions — ticket autocomplete, desc chips, time hint, AI improve

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -206,10 +206,10 @@ async function callGemini(settings, prompt, context) {
   return data.candidates?.[0]?.content?.parts?.[0]?.text || null;
 }
 
-async function dispatchAI(prompt, context) {
+async function dispatchAI(prompt, context, settingsOverride) {
   try {
     const saved    = store.get(AI_SETTINGS_KEY) || {};
-    const settings = { ...DEFAULT_AI_SETTINGS, ...saved };
+    const settings = settingsOverride ?? { ...DEFAULT_AI_SETTINGS, ...saved };
     if (!settings.enabled) return null;
 
     if (settings.provider === 'local') return await callOllama(settings, prompt, context);
@@ -559,6 +559,25 @@ ipcMain.handle('clipboard:write', (_, text) => clipboard.writeText(text));
 
 // ── IPC: AI ──────────────────────────────────────────────
 ipcMain.handle('ai:ask', async (_, prompt, context) => dispatchAI(prompt, context));
+
+ipcMain.handle('ai:ask-with-model', async (_, prompt, context, preferredModel) => {
+  const saved    = store.get(AI_SETTINGS_KEY) || {};
+  const settings = { ...DEFAULT_AI_SETTINGS, ...saved };
+  if (!settings.enabled) return null;
+
+  // Only attempt preferred model on local (Ollama) provider
+  if (preferredModel && settings.provider === 'local') {
+    try {
+      const tagsData = await httpRequest(settings.ollamaUrl + '/api/tags', { method: 'GET' }, null);
+      const available = (tagsData?.models || []).map(m => m.name);
+      if (available.includes(preferredModel)) {
+        return dispatchAI(prompt, context, { ...settings, ollamaModel: preferredModel });
+      }
+    } catch (_) { /* preferred model unavailable — fall through to default */ }
+  }
+
+  return dispatchAI(prompt, context, settings);
+});
 
 ipcMain.handle('ai:get-settings', () => {
   const saved    = store.get(AI_SETTINGS_KEY) || {};

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -29,7 +29,8 @@ contextBridge.exposeInMainWorld('backup', {
 });
 
 contextBridge.exposeInMainWorld('ai', {
-    ask:            (prompt, context) => ipcRenderer.invoke('ai:ask', prompt, context),
+    ask:            (prompt, context)        => ipcRenderer.invoke('ai:ask', prompt, context),
+    askWithModel:   (prompt, context, model) => ipcRenderer.invoke('ai:ask-with-model', prompt, context, model),
     getSettings:    ()               => ipcRenderer.invoke('ai:get-settings'),
     setSettings:    (patch)          => ipcRenderer.invoke('ai:set-settings', patch),
     getMemory:      ()               => ipcRenderer.invoke('ai:get-memory'),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -316,10 +316,11 @@
                 <label class="form-check-label" for="modal-logged" style="font-size:0.82rem;color:var(--text-secondary);cursor:pointer"><i class="bi bi-journal-check me-1"></i>Already logged to timesheet</label>
               </div>
             </div>
-            <div id="modal-ticket-wrap" class="col-12 col-lg-5">
+            <div id="modal-ticket-wrap" class="col-12 col-lg-5" style="position:relative">
               <label class="form-label label-text">Ticket / Reference ID</label>
               <input type="text" id="modal-ticket" class="form-control dark-input"
-                placeholder="e.g. JIRA-123 or #123" />
+                placeholder="e.g. JIRA-123 or #123" autocomplete="off" />
+              <div id="ticket-suggestions" class="suggestion-dropdown"></div>
               <div class="form-text text-muted">Use # prefix for Service Desk tickets</div>
             </div>
             <div class="col-12 col-md-6 col-lg-4">
@@ -327,6 +328,7 @@
               <input type="text" id="modal-time" class="form-control dark-input"
                 placeholder="e.g. 2:30, 90m, 1.5h" autocomplete="off" />
               <div class="invalid-feedback" id="modal-time-error"></div>
+              <div id="time-hint" class="time-hint-text"></div>
             </div>
             <div class="col-12 col-md-6 col-lg-3">
               <label class="form-label label-text">Type</label>
@@ -336,6 +338,13 @@
               <label class="form-label label-text">Description</label>
               <textarea id="modal-desc" class="form-control dark-input" rows="3"
                 placeholder="Brief description of work done..."></textarea>
+              <div class="d-flex align-items-center gap-2 mt-1 flex-wrap">
+                <div id="desc-suggestions" class="desc-suggestions" style="flex:1"></div>
+                <button type="button" id="btn-improve-desc" class="btn btn-outline-light btn-sm flex-shrink-0"
+                  style="display:none;font-size:0.78rem">
+                  <i class="bi bi-stars me-1"></i>Improve
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/renderer/modules/ai.js
+++ b/src/renderer/modules/ai.js
@@ -38,6 +38,15 @@ export async function ask(prompt, context) {
     }
 }
 
+export async function askWithModel(prompt, context, model) {
+    if (!isEnabled()) return null;
+    try {
+        return await window.ai.askWithModel(prompt, context ?? null, model || null);
+    } catch (e) {
+        return null;
+    }
+}
+
 export async function getMemory() {
     try {
         return await window.ai.getMemory();

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -8,7 +8,7 @@ import { parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 import { rerenderDayCard, renderAll } from './render.js';
 import { updateNoTicketBanner } from './no-ticket-reminder.js';
 import { updateUnderloggedBanner } from './underlogged-reminder.js';
-import { isFeatureEnabled, ask } from './ai.js';
+import { isFeatureEnabled, ask, askWithModel, getProvider } from './ai.js';
 
 let entryModal;
 export let lastDeleted = null;
@@ -151,6 +151,171 @@ function applyParsedEntry(parsed) {
     updateEntryDayTotal();
 }
 
+/* ── SMART SUGGESTIONS ──────────────────────────────────── */
+
+let _history = {};   // rebuilt each time the modal opens
+
+function buildEntryHistory() {
+    const byTicket = {};
+    for (const day of Object.values(state.allDaysByDate || {})) {
+        for (const entry of (day.entries || [])) {
+            const t = (entry.ticket || '').trim().toUpperCase();
+            if (!t) continue;
+            if (!byTicket[t]) byTicket[t] = { count: 0, lastDate: '', descs: {}, totalMins: 0, timeSamples: 0 };
+            const r = byTicket[t];
+            r.count++;
+            if ((day.date || '') > r.lastDate) r.lastDate = day.date || '';
+            const d = (entry.desc || '').trim();
+            if (d) {
+                r.descs[d] = (r.descs[d] || 0) + 1;
+                const mins = (parseInt(entry.hh) || 0) * 60 + (parseInt(entry.mm) || 0);
+                if (mins > 0) { r.totalMins += mins; r.timeSamples++; }
+            }
+        }
+    }
+    return byTicket;
+}
+
+function refreshDescSuggestions(ticket) {
+    const container = document.getElementById('desc-suggestions');
+    container.innerHTML = '';
+    const rec = _history[(ticket || '').toUpperCase()];
+    if (!rec) return;
+    const top3 = Object.entries(rec.descs)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([d]) => d);
+    for (const d of top3) {
+        const chip = document.createElement('button');
+        chip.type = 'button';
+        chip.className = 'suggestion-chip';
+        chip.textContent = d;
+        chip.addEventListener('click', () => {
+            document.getElementById('modal-desc').value = d;
+            container.innerHTML = '';
+        });
+        container.appendChild(chip);
+    }
+}
+
+function refreshTimeHint(ticket) {
+    const hint = document.getElementById('time-hint');
+    const rec = _history[(ticket || '').toUpperCase()];
+    if (rec && rec.timeSamples >= 1) {
+        const avgMins = Math.round(rec.totalMins / rec.timeSamples);
+        const hh = Math.floor(avgMins / 60);
+        const mm = avgMins % 60;
+        hint.textContent = `avg ${fmtTimeInput(hh, mm)} for this ticket`;
+        hint.classList.add('show');
+    } else {
+        hint.classList.remove('show');
+    }
+}
+
+function stripAiPreamble(text) {
+    // Remove common local-model preamble lines ("Sure, here is...", "Here is...", etc.)
+    const lines = text.trim().split('\n');
+    const preambleRe = /^(sure[,.]|here is|here's|certainly|of course|below is|the improved|improved version)/i;
+    const cleaned = lines.filter(l => !preambleRe.test(l.trim()) && l.trim() !== '');
+    return cleaned.join(' ').trim();
+}
+
+function initTicketAutocomplete() {
+    const input = document.getElementById('modal-ticket');
+    const dropdown = document.getElementById('ticket-suggestions');
+    let debounceTimer = null;
+    let activeIdx = -1;
+
+    function getItems() { return dropdown.querySelectorAll('.suggestion-item'); }
+
+    function setActive(idx) {
+        const items = getItems();
+        items.forEach((el, i) => el.classList.toggle('active', i === idx));
+        activeIdx = idx;
+    }
+
+    function closeDropdown() {
+        dropdown.classList.remove('open');
+        dropdown.innerHTML = '';
+        activeIdx = -1;
+    }
+
+    function acceptItem(value) {
+        input.value = value;
+        closeDropdown();
+        refreshDescSuggestions(value);
+        refreshTimeHint(value);
+    }
+
+    function renderDropdown(query) {
+        const q = query.toUpperCase();
+        if (!q) { closeDropdown(); return; }
+
+        const today = new Date().toISOString().slice(0, 10);
+        const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+        const matches = Object.entries(_history)
+            .filter(([t]) => t.startsWith(q))
+            .map(([t, r]) => {
+                const recency = r.lastDate >= today.slice(0, 7) ? 2 : r.lastDate >= oneMonthAgo ? 1 : 0;
+                return { ticket: t, score: r.count + recency * 5 };
+            })
+            .sort((a, b) => b.score - a.score)
+            .slice(0, 8);
+
+        if (!matches.length) { closeDropdown(); return; }
+
+        dropdown.innerHTML = '';
+        for (const { ticket } of matches) {
+            const item = document.createElement('div');
+            item.className = 'suggestion-item';
+            item.textContent = ticket;
+            item.addEventListener('mousedown', (e) => {
+                e.preventDefault();   // prevent input blur before click fires
+                acceptItem(ticket);
+            });
+            dropdown.appendChild(item);
+        }
+        dropdown.classList.add('open');
+        activeIdx = -1;
+    }
+
+    input.addEventListener('input', () => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => renderDropdown(input.value.trim()), 300);
+    });
+
+    input.addEventListener('keydown', (e) => {
+        const items = getItems();
+        if (!dropdown.classList.contains('open')) return;
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setActive(Math.min(activeIdx + 1, items.length - 1));
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setActive(Math.max(activeIdx - 1, 0));
+        } else if (e.key === 'Enter' || e.key === 'Tab') {
+            if (activeIdx >= 0 && items[activeIdx]) {
+                e.preventDefault();
+                acceptItem(items[activeIdx].textContent);
+            } else {
+                closeDropdown();
+            }
+        } else if (e.key === 'Escape') {
+            closeDropdown();
+        }
+    });
+
+    input.addEventListener('blur', () => {
+        // Small delay so mousedown on a suggestion item fires first
+        setTimeout(() => {
+            closeDropdown();
+            refreshDescSuggestions(input.value.trim());
+            refreshTimeHint(input.value.trim());
+        }, 150);
+    });
+}
+
 export function initEntryModal() {
     entryModal = new bootstrap.Modal(document.getElementById('entryModal'));
 
@@ -185,6 +350,44 @@ export function initEntryModal() {
 
     nlBtn.addEventListener('click', runNlParse);
     nlInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); runNlParse(); } });
+
+    // Description improve button
+    const descEl = document.getElementById('modal-desc');
+    const improveBtn = document.getElementById('btn-improve-desc');
+
+    function updateImproveBtnVisibility() {
+        improveBtn.style.display =
+            isFeatureEnabled('suggestions') && descEl.value.trim() ? '' : 'none';
+    }
+
+    descEl.addEventListener('input', updateImproveBtnVisibility);
+
+    improveBtn.addEventListener('click', async () => {
+        const current = descEl.value.trim();
+        if (!current) return;
+        const icon = improveBtn.querySelector('i');
+        improveBtn.disabled = true;
+        icon.className = 'bi bi-hourglass-split me-1';
+
+        const improvePrompt =
+            `Improve the grammar and wording of this timesheet description. ` +
+            `Rules: keep ALL activities mentioned, keep all names exactly as written, do not add or remove any work items, do not summarise. ` +
+            `Output the improved text ONLY — no introduction, no explanation, no "Here is", no quotes.\n\n` +
+            `Input: ${current}\nOutput:`;
+
+        // Local provider: prefer qwen2.5:0.5b (small, fast); falls back to configured model if unavailable.
+        // Cloud provider: use the configured cloud provider directly.
+        const raw = getProvider() === 'local'
+            ? await askWithModel(improvePrompt, null, 'qwen2.5:0.5b')
+            : await ask(improvePrompt, null);
+
+        const improved = raw ? stripAiPreamble(raw) : null;
+        if (improved) descEl.value = improved;
+        icon.className = 'bi bi-stars me-1';
+        improveBtn.disabled = false;
+    });
+
+    initTicketAutocomplete();
 }
 
 /* ── CLIPBOARD TICKET DETECTION ─────────────────────────── */
@@ -219,8 +422,20 @@ export function openEntryModal(dayIdx, entryIdx) {
     document.getElementById('modal-entry-index').value = entryIdx;
 
     const nlBar = document.getElementById('modal-nl-bar');
-    nlBar.style.display = isFeatureEnabled('suggestions') ? '' : 'none';
+    const suggestionsOn = isFeatureEnabled('suggestions');
+    nlBar.style.display = suggestionsOn ? '' : 'none';
     document.getElementById('modal-nl-input').value = '';
+
+    // Rebuild history and reset suggestion UIs on each open
+    if (suggestionsOn) {
+        _history = buildEntryHistory();
+    } else {
+        _history = {};
+    }
+    document.getElementById('ticket-suggestions').innerHTML = '';
+    document.getElementById('desc-suggestions').innerHTML = '';
+    document.getElementById('time-hint').classList.remove('show');
+    document.getElementById('btn-improve-desc').style.display = 'none';
 
     const deleteBtn = document.getElementById('btn-delete-entry');
     const copyToBtn = document.getElementById('btn-copy-to-entry');

--- a/src/renderer/styles/modals.css
+++ b/src/renderer/styles/modals.css
@@ -87,3 +87,31 @@
   font-weight: 500;
   padding: 1px 6px;
 }
+
+/* ── Smart suggestions ── */
+.suggestion-dropdown {
+  position: absolute; top: 100%; left: 0; right: 0; z-index: 1060;
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: 6px; max-height: 180px; overflow-y: auto; display: none;
+  margin-top: 2px;
+}
+.suggestion-dropdown.open { display: block; }
+.suggestion-item {
+  padding: 7px 12px; cursor: pointer; font-size: 0.83rem;
+  color: var(--text-primary);
+}
+.suggestion-item:hover, .suggestion-item.active { background: var(--bg-card-hover); }
+
+.desc-suggestions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.suggestion-chip {
+  display: inline-flex; align-items: center; padding: 3px 10px;
+  border-radius: 20px; font-size: 0.78rem; background: var(--bg-input);
+  border: 1px solid var(--border); color: var(--text-secondary);
+  cursor: pointer; transition: background 0.15s, color 0.15s; white-space: nowrap;
+}
+.suggestion-chip:hover { background: var(--bg-card-hover); color: var(--text-primary); }
+
+.time-hint-text {
+  font-size: 0.78rem; color: var(--text-secondary); margin-top: 4px; display: none;
+}
+.time-hint-text.show { display: block; }


### PR DESCRIPTION
## Summary
- **Ticket autocomplete**: debounced dropdown (300ms) while typing, ranked by frequency + recency, keyboard nav (Arrow/Enter/Tab/Escape)
- **Description suggestions**: top-3 clickable chips below the desc field, populated from historical entries for the entered ticket
- **Time hint**: shows historical average time below the time field when a known ticket is entered
- **AI Improve button**: appears when desc has text; uses `qwen2.5:0.5b` on local Ollama if available, falls back to configured model; cloud provider users go straight to their configured cloud AI

## Changes
- `src/main/index.js` — `dispatchAI` accepts optional settings override; new `ai:ask-with-model` IPC handler checks `/api/tags` before routing to preferred model
- `src/preload/index.js` — expose `askWithModel` on `window.ai` bridge
- `src/renderer/modules/ai.js` — add `askWithModel` export
- `src/renderer/modules/entry-modal.js` — `buildEntryHistory`, `refreshDescSuggestions`, `refreshTimeHint`, `initTicketAutocomplete`, `stripAiPreamble`, improve button wiring
- `src/renderer/index.html` — add `#ticket-suggestions`, `#time-hint`, `#desc-suggestions`, `#btn-improve-desc`
- `src/renderer/styles/modals.css` — add suggestion dropdown, chip, and hint styles

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Ticket autocomplete appears when typing a known ticket prefix
- [ ] Desc chips appear after entering a known ticket
- [ ] Time hint shows correct average below time field
- [ ] Improve button appears only when desc has text and AI is enabled
- [ ] Improve uses qwen2.5:0.5b when available on Ollama
- [ ] Improve falls back to configured model when qwen2.5:0.5b not installed
- [ ] Cloud provider: Improve uses cloud AI directly
- [ ] All suggestions hidden when AI features disabled
- [ ] Dark mode verified
- [ ] No console errors

Closes #161

🤖 Generated with [Claude Code](https://claude.ai/claude-code)