### PR TITLE
feat(tm-163): add week summary generator with bullet, paragraph, standup formats

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -156,6 +156,17 @@
               <i class="bi bi-calendar-week me-1"></i> Change Week
             </button>
 
+            <!-- AI Week Summary -->
+            <div id="week-summary-section" style="display:none">
+              <div class="summary-format-row mt-3">
+                <div class="summary-format-chip active" data-format="bullet">Bullet</div>
+                <div class="summary-format-chip" data-format="paragraph">Paragraph</div>
+                <div class="summary-format-chip" data-format="standup">Standup</div>
+              </div>
+              <button class="btn btn-outline-accent btn-sm w-100" id="btn-generate-summary">
+                <i class="bi bi-stars me-1"></i> Generate Summary
+              </button>
+            </div>
 
           </div>
         </div>
@@ -1043,6 +1054,35 @@
     <div class="notif-empty" id="notif-empty">
       <i class="bi bi-bell-slash"></i>
       <span>No notifications</span>
+    </div>
+  </div>
+
+  <!-- WEEK SUMMARY MODAL -->
+  <div class="modal fade" id="weekSummaryModal" tabindex="-1" aria-labelledby="weekSummaryModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+      <div class="modal-content modal-dark">
+        <div class="modal-header border-secondary border-opacity-25">
+          <h5 class="modal-title" id="weekSummaryModalLabel">
+            <i class="bi bi-stars me-2 text-accent"></i>Week Summary
+            <span class="chat-experimental-badge ms-1">Experimental</span>
+          </h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="summary-output-wrap">
+            <pre id="week-summary-output"></pre>
+          </div>
+          <div class="summary-disclaimer">AI can make mistakes. Results may vary depending on the model used.</div>
+        </div>
+        <div class="modal-footer border-secondary border-opacity-25 gap-2">
+          <button type="button" class="btn btn-outline-secondary btn-sm" id="btn-regenerate-summary">
+            <i class="bi bi-arrow-clockwise me-1"></i> Regenerate
+          </button>
+          <button type="button" class="btn btn-gradient btn-sm" id="btn-copy-summary">
+            <i class="bi bi-clipboard me-1"></i> Copy
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -29,6 +29,7 @@ import { initStats } from './modules/stats.js';
 import { setCurrentWeek } from './modules/week.js';
 import { refreshSettings } from './modules/ai.js';
 import { initAiChat } from './modules/ai-chat.js';
+import { initWeekSummary } from './modules/week-summary.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
@@ -43,6 +44,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initSummaryPanel();
     initStats();
     initAiChat();
+    initWeekSummary();
     initUpdater();
     initContextMenu();
     initSearch();

--- a/src/renderer/modules/week-summary.js
+++ b/src/renderer/modules/week-summary.js
@@ -1,0 +1,215 @@
+import { state } from './state.js';
+import { isFeatureEnabled, ask, refreshSettings } from './ai.js';
+import { showToast } from './toast.js';
+
+/* ── DATA BUILDER ───────────────────────────────────────── */
+function buildWeekData() {
+    const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+    const todayStr = new Date().toISOString().slice(0, 10);
+    const targetMins = state.dailyTargetMins || 480;
+
+    let weekLabel = '';
+    const dayRows = [];
+    const ticketMap = {}; // ticket → { mins, descs[] }
+    let totalMins = 0;
+    let firstDate = '', lastDate = '';
+
+    for (let i = 0; i < (state.days || []).length; i++) {
+        const day = state.days[i];
+        if (!day) continue;
+        const dayName = DAYS[i] || `Day ${i + 1}`;
+        const date = day.date || '';
+
+        if (!firstDate) firstDate = date;
+        lastDate = date;
+
+        if (day.isHoliday) {
+            dayRows.push({ dayName, date, isHoliday: true, label: day.holidayLabel || 'Holiday', mins: 0, entries: [] });
+            continue;
+        }
+
+        const entries = day.entries || [];
+        const dayMins = entries.reduce((s, e) =>
+            s + (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0), 0);
+
+        if (date <= todayStr) totalMins += dayMins;
+
+        for (const e of entries) {
+            const ticket = (e.ticket || '').trim() || '(no ticket)';
+            const desc   = (e.desc   || '').trim();
+            const emins  = (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0);
+            if (!ticketMap[ticket]) ticketMap[ticket] = { mins: 0, descs: [] };
+            ticketMap[ticket].mins += emins;
+            if (desc && !ticketMap[ticket].descs.includes(desc)) ticketMap[ticket].descs.push(desc);
+        }
+
+        dayRows.push({ dayName, date, isHoliday: false, mins: dayMins, entries });
+    }
+
+    // Week label e.g. "Apr 21 – Apr 25"
+    if (firstDate && lastDate) {
+        const fmt = d => {
+            const [,m,dd] = d.split('-');
+            const mon = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][parseInt(m)-1];
+            return `${mon} ${parseInt(dd)}`;
+        };
+        weekLabel = `${fmt(firstDate)} – ${fmt(lastDate)}`;
+    }
+
+    const hh = Math.floor(totalMins / 60);
+    const mm = totalMins % 60;
+    const totalStr = mm > 0 ? `${hh}h ${mm}m` : `${hh}h`;
+
+    return { weekLabel, totalStr, totalMins, dayRows, ticketMap, todayStr, targetMins };
+}
+
+function fmtMins(mins) {
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    if (h > 0 && m > 0) return `${h}h ${m}m`;
+    if (h > 0) return `${h}h`;
+    return `${m}m`;
+}
+
+/* ── PROMPT BUILDER ─────────────────────────────────────── */
+function buildPrompt(format, data) {
+    const { weekLabel, totalStr, dayRows, ticketMap, todayStr, targetMins } = data;
+
+    // Compact per-day block
+    const DAYS_SHORT = ['Mon','Tue','Wed','Thu','Fri'];
+    const dayBlock = dayRows.map((d, i) => {
+        if (d.isHoliday) return `  ${DAYS_SHORT[i] || d.dayName} ${d.date}: [${d.label}]`;
+        const gap = targetMins - d.mins;
+        const status = d.date > todayStr ? '(future)' : gap > 0 ? `MISSING ${fmtMins(gap)}` : 'COMPLETE';
+        return `  ${DAYS_SHORT[i] || d.dayName} ${d.date}: logged ${fmtMins(d.mins)} | ${status}`;
+    }).join('\n');
+
+    // Per-ticket block
+    const ticketBlock = Object.entries(ticketMap)
+        .sort((a, b) => b[1].mins - a[1].mins)
+        .map(([ticket, { mins, descs }]) => {
+            const descStr = descs.slice(0, 3).join('; ');
+            return `  ${ticket}: ${fmtMins(mins)}${descStr ? ' — ' + descStr : ''}`;
+        }).join('\n');
+
+    const dataSection = [
+        `Week: ${weekLabel}`,
+        `Total logged: ${totalStr}`,
+        `Daily target: ${fmtMins(targetMins)}`,
+        ``,
+        `DAY BREAKDOWN:`,
+        dayBlock || '  (no days)',
+        ``,
+        `BY TICKET:`,
+        ticketBlock || '  (no entries)',
+    ].join('\n');
+
+    const formatInstructions = {
+        bullet: `Generate a bullet-list week summary. Start with "Week of ${weekLabel} (${totalStr} logged)" then one bullet per ticket/theme with hours and a short description of the work done. Keep each bullet to one line. Do not add extra sections.`,
+        paragraph: `Write a short 2–3 sentence paragraph summarising this week's work. Suitable for a status update email to a manager. Mention the main tickets and themes worked on and total time. Do not use bullet points.`,
+        standup: `Generate a standup-style summary with three sections: "Yesterday:" (most recent logged day's work), "Today:" (today's planned or logged work — if today has no entries, write "Continuing work on [main ticket]"), and "Blockers:" (write "None." unless you can infer one). Keep each section to 1–2 lines.`,
+    };
+
+    return [
+        `You are a timesheet assistant. Generate a work summary from the data below. Be concise and professional. Do not invent work that is not in the data.`,
+        ``,
+        `TIMESHEET DATA:`,
+        dataSection,
+        ``,
+        `INSTRUCTION: ${formatInstructions[format]}`,
+    ].join('\n');
+}
+
+/* ── MODAL LOGIC ────────────────────────────────────────── */
+let _modal = null;
+let _generating = false;
+let _currentFormat = 'bullet';
+
+function showGenerating() {
+    const out = document.getElementById('week-summary-output');
+    if (!out) return;
+    out.innerHTML = '';
+    const wrap = out.parentElement;
+    let spinner = wrap.querySelector('.summary-generating');
+    if (!spinner) {
+        spinner = document.createElement('div');
+        spinner.className = 'summary-generating';
+        spinner.innerHTML = `<div class="summary-generating-dot"></div><div class="summary-generating-dot"></div><div class="summary-generating-dot"></div><span>Generating…</span>`;
+        wrap.insertBefore(spinner, out);
+    }
+    spinner.style.display = 'flex';
+    out.style.display = 'none';
+}
+
+function showOutput(text) {
+    const out = document.getElementById('week-summary-output');
+    if (!out) return;
+    const wrap = out.parentElement;
+    const spinner = wrap.querySelector('.summary-generating');
+    if (spinner) spinner.style.display = 'none';
+    out.style.display = '';
+    out.textContent = text;
+}
+
+async function runGenerate() {
+    if (_generating) return;
+    _generating = true;
+
+    const genBtn  = document.getElementById('btn-generate-summary');
+    const regenBtn = document.getElementById('btn-regenerate-summary');
+    if (genBtn)  genBtn.disabled = true;
+    if (regenBtn) regenBtn.disabled = true;
+
+    if (!_modal) _modal = new bootstrap.Modal(document.getElementById('weekSummaryModal'));
+    _modal.show();
+    showGenerating();
+
+    const data   = buildWeekData();
+    const prompt = buildPrompt(_currentFormat, data);
+    const result = await ask(prompt, null);
+
+    if (!result) {
+        showOutput('Could not reach the AI. Please check your AI settings and try again.');
+    } else {
+        showOutput(result);
+    }
+
+    _generating = false;
+    if (genBtn)  genBtn.disabled = false;
+    if (regenBtn) regenBtn.disabled = false;
+}
+
+/* ── INIT ────────────────────────────────────────────────── */
+export function initWeekSummary() {
+    const section = document.getElementById('week-summary-section');
+    const genBtn  = document.getElementById('btn-generate-summary');
+
+    if (!section || !genBtn) return;
+
+    // Show section only when feature is enabled
+    refreshSettings().then(() => {
+        if (isFeatureEnabled('weeklySummary')) section.style.display = '';
+    });
+
+    // Format chip selection
+    section.querySelectorAll('.summary-format-chip').forEach(chip => {
+        chip.addEventListener('click', () => {
+            section.querySelectorAll('.summary-format-chip').forEach(c => c.classList.remove('active'));
+            chip.classList.add('active');
+            _currentFormat = chip.dataset.format;
+        });
+    });
+
+    // Generate button
+    genBtn.addEventListener('click', () => runGenerate());
+
+    // Regenerate button (inside modal)
+    document.getElementById('btn-regenerate-summary')?.addEventListener('click', () => runGenerate());
+
+    // Copy button
+    document.getElementById('btn-copy-summary')?.addEventListener('click', () => {
+        const text = document.getElementById('week-summary-output')?.textContent || '';
+        if (!text) return;
+        navigator.clipboard.writeText(text).then(() => showToast('Summary copied to clipboard.', 'success'));
+    });
+}

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -23,3 +23,4 @@
 @import './restore.css';
 @import './notifications.css';
 @import './ai-chat.css';
+@import './week-summary.css';

--- a/src/renderer/styles/week-summary.css
+++ b/src/renderer/styles/week-summary.css
@@ -1,0 +1,100 @@
+/* ── WEEK SUMMARY GENERATOR ── */
+
+/* ── Format picker chips ── */
+.summary-format-row {
+  display: flex;
+  gap: 5px;
+  margin-top: 10px;
+}
+
+.summary-format-chip {
+  flex: 1;
+  padding: 5px 4px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-align: center;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.13s, color 0.13s, border-color 0.13s;
+  user-select: none;
+}
+
+.summary-format-chip:hover {
+  color: var(--text-primary);
+  border-color: var(--border-accent);
+}
+
+.summary-format-chip.active {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+  border-color: var(--border-accent);
+}
+
+/* ── Generate button ── */
+#btn-generate-summary {
+  margin-top: 8px;
+}
+
+/* ── Modal output area ── */
+#weekSummaryModal .modal-body {
+  padding: 16px 18px;
+}
+
+.summary-output-wrap {
+  position: relative;
+  min-height: 80px;
+}
+
+#week-summary-output {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  min-height: 120px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.summary-generating {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  font-style: italic;
+  padding: 24px 0 8px;
+}
+
+.summary-generating-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  animation: sum-pulse 1.4s ease-in-out infinite;
+}
+
+.summary-generating-dot:nth-child(2) { animation-delay: 0.2s; }
+.summary-generating-dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes sum-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.3; transform: scale(0.7); }
+}
+
+.summary-disclaimer {
+  font-size: 0.68rem;
+  color: var(--text-secondary);
+  opacity: 0.5;
+  text-align: center;
+  margin-top: 8px;
+}


### PR DESCRIPTION
## Summary
- Adds a week summary generator to the left summary panel — three format options (Bullet, Paragraph, Standup) selected via chips, then a Generate button triggers an AI-written narrative of the week's activity
- Output appears in a modal with Copy and Regenerate controls
- Data is precomputed client-side (per-day totals, per-ticket breakdown) so the AI only formats text, not arithmetic
- Gated behind the existing `weeklySummary` feature flag in AI Settings — no schema changes needed

## Changes
- `src/renderer/modules/week-summary.js` — new module: `buildWeekData()`, `buildPrompt(format, data)` (3 format instructions), `runGenerate()`, `initWeekSummary()`
- `src/renderer/styles/week-summary.css` — new stylesheet: format chips, `<pre>` output area, animated generating dots, disclaimer
- `src/renderer/index.html` — format chips + `#btn-generate-summary` in summary panel; `#weekSummaryModal` with Copy + Regenerate
- `src/renderer/main.js` — import + call `initWeekSummary()`
- `src/renderer/styles/main.css` — `@import './week-summary.css'`

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Generate button hidden when weeklySummary feature disabled
- [ ] All three formats produce correct AI output
- [ ] Regenerate replaces previous output
- [ ] Copy button writes plain text to clipboard
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #163

🤖 Generated with [Claude Code](https://claude.ai/claude-code)