### PR TITLE
feat(tm-164): add anomaly and gap detection to notification centre

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -30,6 +30,7 @@ import { setCurrentWeek } from './modules/week.js';
 import { refreshSettings } from './modules/ai.js';
 import { initAiChat } from './modules/ai-chat.js';
 import { initWeekSummary } from './modules/week-summary.js';
+import { runAnomalyDetection } from './modules/anomaly-detection.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
@@ -91,6 +92,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initKeyboard();
     updateNoTicketBanner();
     updateUnderloggedBanner();
+    runAnomalyDetection();
 
     // Navigate to today when triggered from tray or notification click
     if (window.tray) {

--- a/src/renderer/modules/anomaly-detection.js
+++ b/src/renderer/modules/anomaly-detection.js
@@ -1,0 +1,300 @@
+/* =============================================================
+   ANOMALY DETECTION — passive logging pattern analysis
+   Runs on: app load, week change, after saving/deleting an entry.
+   All rule-based except duplicate detection which optionally uses AI.
+   ============================================================= */
+
+import { state } from './state.js';
+import { isFeatureEnabled, ask } from './ai.js';
+import { pushNotification } from './notifications.js';
+import { fmtDate } from './utils.js';
+
+/* ── helpers ── */
+
+function dayEntryMins(dayData) {
+    return (dayData?.entries || []).reduce(
+        (sum, e) => sum + (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0), 0
+    );
+}
+
+function isWorkday(dateStr) {
+    const d = new Date(dateStr + 'T12:00:00');
+    const dow = d.getDay();
+    return dow >= 1 && dow <= 5;
+}
+
+function pastWorkdaysInRange(fromDateStr, toDateStr) {
+    const days = [];
+    const cur = new Date(fromDateStr + 'T12:00:00');
+    const end = new Date(toDateStr + 'T12:00:00');
+    while (cur <= end) {
+        const dow = cur.getDay();
+        if (dow >= 1 && dow <= 5) days.push(fmtDate(cur));
+        cur.setDate(cur.getDate() + 1);
+    }
+    return days;
+}
+
+/* ── public entry point ── */
+
+export async function runAnomalyDetection() {
+    if (!isFeatureEnabled('anomalyDetection')) return;
+
+    detectUnloggedDays();
+    detectUnusualTicketHours();
+    detectUnderloggedWeek();
+    detectTicketGaps();
+    await detectDuplicateEntries();
+}
+
+/* ── 1. Unlogged workdays ── */
+
+function detectUnloggedDays() {
+    const today = fmtDate(new Date());
+
+    // Look back at the last 14 calendar days (excluding today)
+    const lookbackStart = new Date();
+    lookbackStart.setDate(lookbackStart.getDate() - 14);
+    const startStr = fmtDate(lookbackStart);
+
+    // Build yesterday's date string as upper bound
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = fmtDate(yesterday);
+
+    const workdays = pastWorkdaysInRange(startStr, yesterdayStr);
+
+    const unlogged = workdays.filter(dateStr => {
+        const day = state.allDaysByDate[dateStr];
+        if (!day) return true;                              // no record at all
+        if (day.isHoliday || day.leaveTypeId) return false; // holiday/leave — skip
+        return (day.entries || []).length === 0;
+    });
+
+    if (unlogged.length === 0) return;
+
+    const labels = unlogged.map(d => {
+        const dt = new Date(d + 'T12:00:00');
+        return dt.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+    });
+
+    const msg = unlogged.length === 1
+        ? `${labels[0]} has no entries — did you forget to log?`
+        : `${unlogged.length} days have no entries (${labels.join(', ')}) — did you forget to log?`;
+
+    pushNotification('unlogged-day', msg);
+}
+
+/* ── 2. Unusually high hours on a ticket (rule-based) ── */
+
+function detectUnusualTicketHours() {
+    const today = fmtDate(new Date());
+    const todayData = state.days.find(d => d.date === today) || state.allDaysByDate[today];
+    if (!todayData || (todayData.entries || []).length === 0) return;
+
+    // Build per-ticket daily totals from the last 28 days (excluding today)
+    const historyCutoff = new Date();
+    historyCutoff.setDate(historyCutoff.getDate() - 28);
+    const cutoffStr = fmtDate(historyCutoff);
+
+    const ticketHistory = {}; // ticket → [mins per day it appeared]
+    for (const [dateStr, day] of Object.entries(state.allDaysByDate)) {
+        if (dateStr >= today || dateStr < cutoffStr) continue;
+        const byTicket = {};
+        (day.entries || []).forEach(e => {
+            if (!e.ticket) return;
+            byTicket[e.ticket] = (byTicket[e.ticket] || 0) + (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0);
+        });
+        Object.entries(byTicket).forEach(([t, m]) => {
+            if (!ticketHistory[t]) ticketHistory[t] = [];
+            ticketHistory[t].push(m);
+        });
+    }
+
+    // Per-ticket total today
+    const todayByTicket = {};
+    todayData.entries.forEach(e => {
+        if (!e.ticket) return;
+        todayByTicket[e.ticket] = (todayByTicket[e.ticket] || 0) + (parseInt(e.hh) || 0) * 60 + (parseInt(e.mm) || 0);
+    });
+
+    // Need at least 3 historical days per ticket to compute a meaningful average
+    const MIN_HISTORY = 3;
+    let anomalous = null;
+    let worstRatio = 2; // threshold: 2× average
+
+    for (const [ticket, todayMins] of Object.entries(todayByTicket)) {
+        const hist = ticketHistory[ticket];
+        if (!hist || hist.length < MIN_HISTORY) continue;
+        const avg = hist.reduce((s, m) => s + m, 0) / hist.length;
+        if (avg < 30) continue; // ignore tickets with trivial average (< 30 min)
+        const ratio = todayMins / avg;
+        if (ratio > worstRatio) {
+            worstRatio = ratio;
+            anomalous = { ticket, todayMins, avg };
+        }
+    }
+
+    if (!anomalous) return;
+
+    const todayHrs = (anomalous.todayMins / 60).toFixed(1);
+    const avgHrs   = (anomalous.avg / 60).toFixed(1);
+    pushNotification('high-hours',
+        `${anomalous.ticket} has ${todayHrs}h today — your usual average is ${avgHrs}h`);
+}
+
+/* ── 3. Week under-logged vs usual pace ── */
+
+function detectUnderloggedWeek() {
+    const today = new Date();
+    const todayStr = fmtDate(today);
+    const dow = today.getDay(); // 1=Mon … 5=Fri (or 0/6 for weekend)
+
+    // Only run Mon–Fri
+    if (dow === 0 || dow === 6) return;
+
+    // Days elapsed this week (Mon = day 1, …, today = day N)
+    const daysElapsed = dow; // getDay() Mon=1 … Fri=5, which equals elapsed workdays Mon–today
+
+    // Remaining workdays after today (not counting today)
+    const daysRemaining = 5 - daysElapsed;
+    if (daysRemaining === 0) return; // Friday — no point warning with no days left
+
+    // Current week total (Mon–yesterday)
+    const monday = new Date(today);
+    monday.setDate(today.getDate() - (daysElapsed - 1));
+
+    let weekMins = 0;
+    for (let i = 0; i < daysElapsed; i++) {
+        const d = new Date(monday);
+        d.setDate(monday.getDate() + i);
+        const ds = fmtDate(d);
+        const day = state.days.find(x => x.date === ds) || state.allDaysByDate[ds];
+        if (day && !day.isHoliday && !day.leaveTypeId) weekMins += dayEntryMins(day);
+    }
+
+    // Historical weekly totals (last 4 complete weeks — need ≥ 3 to fire)
+    const weekTotals = [];
+    for (let w = 1; w <= 4; w++) {
+        const wMon = new Date(monday);
+        wMon.setDate(monday.getDate() - w * 7);
+        let wTotal = 0;
+        for (let i = 0; i < 5; i++) {
+            const d = new Date(wMon);
+            d.setDate(wMon.getDate() + i);
+            const ds = fmtDate(d);
+            const day = state.allDaysByDate[ds];
+            if (day && !day.isHoliday && !day.leaveTypeId) wTotal += dayEntryMins(day);
+        }
+        if (wTotal > 0) weekTotals.push(wTotal);
+    }
+
+    if (weekTotals.length < 3) return; // not enough history
+
+    const avgWeekMins = weekTotals.reduce((s, m) => s + m, 0) / weekTotals.length;
+
+    // Extrapolate: project current pace to end of week
+    const projectedMins = daysElapsed > 0 ? (weekMins / daysElapsed) * 5 : 0;
+    const shortfallRatio = (avgWeekMins - projectedMins) / avgWeekMins;
+
+    if (shortfallRatio < 0.15) return; // within 15% — no alert
+
+    const shortHrs = ((avgWeekMins - weekMins) / 60).toFixed(1);
+    pushNotification('underlogged-week',
+        `You're ${shortHrs}h below your usual weekly total with ${daysRemaining} day${daysRemaining > 1 ? 's' : ''} left`);
+}
+
+/* ── 4. Long streak without a specific ticket ── */
+
+function detectTicketGaps() {
+    const today = fmtDate(new Date());
+
+    // Build frequency + last-seen for tickets active in the last 30 days
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - 30);
+    const cutoffStr = fmtDate(cutoff);
+
+    const ticketInfo = {}; // ticket → { count, lastSeen }
+    for (const [dateStr, day] of Object.entries(state.allDaysByDate)) {
+        if (dateStr > today || dateStr < cutoffStr) continue;
+        (day.entries || []).forEach(e => {
+            if (!e.ticket) return;
+            if (!ticketInfo[e.ticket]) ticketInfo[e.ticket] = { count: 0, lastSeen: dateStr };
+            ticketInfo[e.ticket].count++;
+            if (dateStr > ticketInfo[e.ticket].lastSeen) ticketInfo[e.ticket].lastSeen = dateStr;
+        });
+    }
+
+    // Also scan current week's days (state.days) which may not be in allDaysByDate yet
+    state.days.forEach(day => {
+        const dateStr = day.date;
+        (day.entries || []).forEach(e => {
+            if (!e.ticket) return;
+            if (!ticketInfo[e.ticket]) ticketInfo[e.ticket] = { count: 0, lastSeen: dateStr };
+            ticketInfo[e.ticket].count++;
+            if (dateStr > ticketInfo[e.ticket].lastSeen) ticketInfo[e.ticket].lastSeen = dateStr;
+        });
+    });
+
+    const GAP_DAYS = 5;
+    const MIN_FREQUENCY = 5;
+    const MAX_ALERTS = 2;
+
+    // Compute days since last seen relative to today
+    const stale = Object.entries(ticketInfo)
+        .filter(([, info]) => {
+            if (info.count < MIN_FREQUENCY) return false;
+            const last = new Date(info.lastSeen + 'T12:00:00');
+            const todayDate = new Date(today + 'T12:00:00');
+            const diffDays = Math.round((todayDate - last) / 86400000);
+            return diffDays > GAP_DAYS;
+        })
+        .sort((a, b) => a[1].lastSeen.localeCompare(b[1].lastSeen)) // oldest first
+        .slice(0, MAX_ALERTS);
+
+    stale.forEach(([ticket, info]) => {
+        const last = new Date(info.lastSeen + 'T12:00:00');
+        const todayDate = new Date(today + 'T12:00:00');
+        const diffDays = Math.round((todayDate - last) / 86400000);
+        pushNotification(`ticket-gap-${ticket}`,
+            `${ticket} hasn't been logged in ${diffDays} days — still active?`);
+    });
+}
+
+/* ── 5. Duplicate-looking entries ── */
+
+async function detectDuplicateEntries() {
+    const today = fmtDate(new Date());
+    const todayData = state.days.find(d => d.date === today) || state.allDaysByDate[today];
+    if (!todayData || (todayData.entries || []).length < 2) return;
+
+    const entries = todayData.entries;
+
+    // Rule-based: same ticket + description normalises to the same string
+    const normalize = str => (str || '').toLowerCase().trim().replace(/\s+/g, ' ');
+
+    const seen = new Set();
+    let hasDupe = false;
+    for (const e of entries) {
+        const key = `${(e.ticket || '').toLowerCase()}|${normalize(e.desc)}`;
+        if (seen.has(key)) { hasDupe = true; break; }
+        seen.add(key);
+    }
+
+    if (!hasDupe) {
+        // AI fuzzy check — only if AI available and rule-based passed
+        const enabled = isFeatureEnabled('anomalyDetection');
+        if (!enabled) return;
+        try {
+            const snippets = entries.map((e, i) =>
+                `${i + 1}. [${e.ticket || 'no-ticket'}] ${e.desc || ''} (${e.hh || 0}h${e.mm || 0}m)`
+            ).join('\n');
+            const prompt = `These are today's timesheet entries:\n${snippets}\n\nAre any of these likely duplicates of each other? Reply with only "yes" or "no".`;
+            const reply = await ask(prompt, null);
+            if (!reply || reply.trim().toLowerCase() !== 'yes') return;
+        } catch { return; }
+    }
+
+    pushNotification('duplicate-entries',
+        `${entries.length} entries today look similar — possible duplicate?`);
+}

--- a/src/renderer/modules/entry-modal.js
+++ b/src/renderer/modules/entry-modal.js
@@ -8,6 +8,7 @@ import { parseTimeInput, fmtTimeInput, timeInputError } from './utils.js';
 import { rerenderDayCard, renderAll } from './render.js';
 import { updateNoTicketBanner } from './no-ticket-reminder.js';
 import { updateUnderloggedBanner } from './underlogged-reminder.js';
+import { runAnomalyDetection } from './anomaly-detection.js';
 import { isFeatureEnabled, ask, askWithModel, getProvider } from './ai.js';
 
 let entryModal;
@@ -652,6 +653,7 @@ export function commitEntry(dayIdx, entryIdx) {
     saveState();
     updateNoTicketBanner();
     updateUnderloggedBanner();
+    runAnomalyDetection();
     entryModal.hide();
 }
 
@@ -700,6 +702,7 @@ export function finishDeleteEntry(dayIdx, entryIdx, deletedEntry) {
     updateSummary();
     updateNoTicketBanner();
     updateUnderloggedBanner();
+    runAnomalyDetection();
 
     const timerId = setTimeout(() => {
         lastDeleted = null;

--- a/src/renderer/modules/header.js
+++ b/src/renderer/modules/header.js
@@ -6,6 +6,7 @@ import { renderAll, renderDays, setWeekTransitionDir } from './render.js';
 import { openPreview, doPrint, copyTxt, downloadTxt } from './report.js';
 import { saveEntry, deleteEntry, makeRegularEntry, updateEntryDayTotal } from './entry-modal.js';
 import { openSettings } from './settings.js';
+import { runAnomalyDetection } from './anomaly-detection.js';
 
 export function bindHeaderEvents() {
     const weekPicker = document.getElementById('week-picker');
@@ -48,6 +49,7 @@ export function bindHeaderEvents() {
         setWeekTransitionDir(prevWeek ? (safeVal > prevWeek ? 'left' : 'right') : null);
         renderAll();
         setWeekTransitionDir(null);
+        runAnomalyDetection();
     });
 
     document.getElementById('btn-autofill-week').addEventListener('click', () => {
@@ -58,6 +60,7 @@ export function bindHeaderEvents() {
         setWeekTransitionDir(prevWeek ? (state.weekValue > prevWeek ? 'left' : state.weekValue < prevWeek ? 'right' : null) : null);
         renderAll();
         setWeekTransitionDir(null);
+        runAnomalyDetection();
     });
 
     document.getElementById('btn-preview').addEventListener('click', openPreview);

--- a/src/renderer/modules/notifications.js
+++ b/src/renderer/modules/notifications.js
@@ -8,8 +8,13 @@ let notifications = [];
 let dropdownOpen = false;
 
 const TYPE_META = {
-    'no-ticket':   { icon: 'bi-exclamation-triangle-fill', color: 'var(--danger)' },
-    'underlogged': { icon: 'bi-clock-history',             color: 'var(--warning)' },
+    'no-ticket':        { icon: 'bi-exclamation-triangle-fill', color: 'var(--danger)'  },
+    'underlogged':      { icon: 'bi-clock-history',             color: 'var(--warning)' },
+    'unlogged-day':     { icon: 'bi-calendar-x',                color: 'var(--danger)'  },
+    'high-hours':       { icon: 'bi-graph-up-arrow',            color: 'var(--warning)' },
+    'underlogged-week': { icon: 'bi-hourglass-split',           color: 'var(--warning)' },
+    'ticket-gap':       { icon: 'bi-ticket-perforated',         color: 'var(--text-secondary)' },
+    'duplicate-entries':{ icon: 'bi-files',                     color: 'var(--text-secondary)' },
 };
 
 /* ── persistence ── */
@@ -29,8 +34,11 @@ function save() {
 
 export function pushNotification(type, message) {
     load();
-    const existing = notifications.find(n => n.type === type && !n.dismissed);
+    const now = Date.now();
+    const existing = notifications.find(n => n.type === type);
     if (existing) {
+        if (existing.dismissedUntil && now < existing.dismissedUntil) return;
+        existing.dismissedUntil = null;
         if (existing.message !== message) {
             existing.message = message;
             existing.timestamp = new Date().toISOString();
@@ -46,7 +54,7 @@ export function pushNotification(type, message) {
         message,
         timestamp: new Date().toISOString(),
         read: false,
-        dismissed: false,
+        dismissedUntil: null,
     });
     save();
     renderBadge();
@@ -80,8 +88,12 @@ export function initNotifications() {
 
 /* ── badge ── */
 
+function isDismissed(n) {
+    return n.dismissedUntil && Date.now() < n.dismissedUntil;
+}
+
 function renderBadge() {
-    const unread = notifications.filter(n => !n.read && !n.dismissed).length;
+    const unread = notifications.filter(n => !n.read && !isDismissed(n)).length;
     const badge = document.getElementById('notif-badge');
     const btn   = document.getElementById('btn-notifications');
     if (badge) {
@@ -128,12 +140,13 @@ function renderList() {
     const empty = document.getElementById('notif-empty');
     if (!list) return;
 
-    const active = notifications.filter(n => !n.dismissed);
+    const active = notifications.filter(n => !isDismissed(n));
     empty.style.display = active.length === 0 ? '' : 'none';
     list.innerHTML = '';
 
     active.forEach(n => {
-        const meta = TYPE_META[n.type] || { icon: 'bi-bell', color: 'var(--text-muted)' };
+        const typeKey = Object.keys(TYPE_META).find(k => n.type === k || n.type.startsWith(k + '-'));
+        const meta = TYPE_META[typeKey] || { icon: 'bi-bell', color: 'var(--text-secondary)' };
         const time = formatTime(n.timestamp);
         const item = document.createElement('div');
         item.className = 'notif-item';
@@ -156,7 +169,12 @@ function renderList() {
 
 function dismissOne(id) {
     const n = notifications.find(n => n.id === id);
-    if (n) { n.dismissed = true; save(); renderBadge(); renderList(); }
+    if (!n) return;
+    const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
+    n.dismissedUntil = Date.now() + SEVEN_DAYS;
+    save();
+    renderBadge();
+    renderList();
 }
 
 /* ── helpers ── */


### PR DESCRIPTION
## Summary
- Passive logging pattern analysis that surfaces findings as notification-centre entries
- Five detectors: unlogged days (14-day lookback), unusually high ticket hours (2× average), under-logged week pace, ticket gap streaks, and duplicate entries
- All detectors are rule-based; AI is used optionally only for fuzzy duplicate detection
- Dismissed notifications respect a 7-day cooldown before re-alerting

## Changes
- `src/renderer/modules/anomaly-detection.js` — new module with `runAnomalyDetection()` and all five detectors
- `src/renderer/modules/notifications.js` — added 5 new `TYPE_META` entries; replaced permanent `dismissed` with 7-day `dismissedUntil` cooldown; prefix-match for per-ticket notification keys
- `src/renderer/modules/entry-modal.js` — call `runAnomalyDetection()` after save and delete
- `src/renderer/modules/header.js` — call `runAnomalyDetection()` on week change and autofill
- `src/renderer/main.js` — call `runAnomalyDetection()` on app load

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #164

🤖 Generated with [Claude Code](https://claude.ai/claude-code)