### PR TITLE
feat(tm-165): AI-enhanced report export — optional AI rewrite of entry descriptions

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -232,6 +232,18 @@
           <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
         </div>
         <div class="modal-body">
+          <div id="report-ai-bar" class="report-ai-bar" style="display:none">
+            <div class="d-flex align-items-center gap-2">
+              <input class="form-check-input mt-0" type="checkbox" id="toggle-enhance-ai" role="switch">
+              <label class="form-check-label" for="toggle-enhance-ai">
+                <i class="bi bi-stars me-1"></i>Enhance with AI
+              </label>
+            </div>
+            <div id="report-ai-loading" class="report-ai-loading d-none">
+              <div class="spinner-border spinner-border-sm" role="status" style="color:var(--accent)"></div>
+              <span>Rewriting descriptions…</span>
+            </div>
+          </div>
           <pre id="txt-preview" class="txt-output"></pre>
         </div>
         <div class="modal-footer">
@@ -239,6 +251,9 @@
             <i class="bi bi-pencil me-1"></i> Edit Sheet Details
           </button>
           <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-sm btn-outline-success" id="btn-apply-enhanced" style="display:none">
+            <i class="bi bi-check2-circle me-1"></i> Apply to Entries
+          </button>
           <button type="button" class="btn btn-gradient" id="btn-copy-txt">
             <i class="bi bi-clipboard me-1"></i> Copy to Clipboard
           </button>

--- a/src/renderer/modules/report.js
+++ b/src/renderer/modules/report.js
@@ -7,15 +7,23 @@ import { minsToHHMM } from './utils.js';
 import { getTypeById } from './ticket-types.js';
 import { getLeaveLabel } from './leave-types.js';
 // Circular — resolved at call time
-import { buildGroups } from './render.js';
+import { buildGroups, renderAll } from './render.js';
+import { isFeatureEnabled, ask, refreshSettings } from './ai.js';
+import { saveState } from './store.js';
 
 let previewModal;
 let dayEntriesModal;
+let _enhancedTxt = null;
+let _enhancing = false;
+let _descMap = null;        // current enhancement map (original → enhanced)
+let _undoSnapshot = null;   // [{dayIdx, entryIdx, originalDesc}] for undo
 
 export function initReport() {
     previewModal = new bootstrap.Modal(document.getElementById('previewModal'));
     dayEntriesModal = new bootstrap.Modal(document.getElementById('dayEntriesModal'));
     document.getElementById('btn-copy-day-entries').addEventListener('click', copyDayQuickView);
+    document.getElementById('toggle-enhance-ai').addEventListener('change', onEnhanceToggle);
+    document.getElementById('btn-apply-enhanced').addEventListener('click', applyEnhancedDescs);
 
     // Strip HTML from clipboard when manually copying from preview panes.
     // Chromium includes text/html with full styling by default; Teams and
@@ -32,7 +40,7 @@ export function initReport() {
 
 const DAY_ROMAN_WIDTH = 6; // wide enough for 'viii)' + 1 space
 
-export function generateDayTxt(day, useHHMM = false) {
+export function generateDayTxt(day, useHHMM = false, descMap = null) {
     const displayDate = fmtDisplayDate(day.date);
     const lines = [];
     const indent = '\t';
@@ -71,7 +79,12 @@ export function generateDayTxt(day, useHHMM = false) {
                     const eTypeObj = getTypeById(e.type);
                     const sdTag = eTypeObj?.prefixText || '';
 
-                    let desc = e.desc || '';
+                    const rawDesc = e.desc || '';
+                    let desc = rawDesc;
+                    if (descMap && rawDesc) {
+                        const key = rawDesc.trim();
+                        if (descMap.has(key)) desc = descMap.get(key);
+                    }
                     // Legacy: strip manually typed "(Service desk)" prefix from older entries
                     if (e.type === 'servicedesk' && desc.toLowerCase().startsWith('(service desk)')) {
                         desc = desc.substring(15).trim();
@@ -122,9 +135,20 @@ export function generateTxt() {
     return lines.join('\r\n');
 }
 
-export function openPreview() {
-    const txt = generateTxt();
-    document.getElementById('txt-preview').textContent = txt;
+export async function openPreview() {
+    _enhancedTxt = null;
+    _descMap = null;
+
+    const toggle   = document.getElementById('toggle-enhance-ai');
+    const aiBar    = document.getElementById('report-ai-bar');
+    const applyBtn = document.getElementById('btn-apply-enhanced');
+    toggle.checked = false;
+    applyBtn.style.display = 'none';
+
+    await refreshSettings();
+    aiBar.style.display = isFeatureEnabled('reportEnhancement') ? '' : 'none';
+
+    document.getElementById('txt-preview').textContent = generateTxt();
     previewModal.show();
 }
 
@@ -149,7 +173,7 @@ function copyDayQuickView() {
 }
 
 export function copyTxt() {
-    const txt = generateTxt();
+    const txt = _enhancedTxt ?? generateTxt();
     navigator.clipboard.writeText(txt).then(() => {
         showToast('Copied to clipboard!', 'success');
     }).catch(() => {
@@ -158,7 +182,7 @@ export function copyTxt() {
 }
 
 export function downloadTxt() {
-    const txt = generateTxt();
+    const txt = _enhancedTxt ?? generateTxt();
     const name = state.employeeName.replace(/\s+/g, '_') || 'Employee';
     const monDt = getDateFromWeek(state.weekValue);
 
@@ -192,4 +216,165 @@ export function doPrint() {
     const printArea = document.getElementById('print-area');
     printArea.innerHTML = `<pre>${escHtml(txt)}</pre>`;
     window.print();
+}
+
+/* ── AI ENHANCEMENT ─────────────────────────────────────── */
+
+async function onEnhanceToggle(e) {
+    if (e.target.checked) {
+        await runEnhance();
+    } else {
+        _enhancedTxt = null;
+        _descMap = null;
+        document.getElementById('btn-apply-enhanced').style.display = 'none';
+        document.getElementById('txt-preview').textContent = generateTxt();
+    }
+}
+
+async function runEnhance() {
+    if (_enhancing) return;
+    _enhancing = true;
+
+    const toggle  = document.getElementById('toggle-enhance-ai');
+    const loading = document.getElementById('report-ai-loading');
+    toggle.disabled = true;
+    loading.classList.remove('d-none');
+    loading.classList.add('d-flex');
+
+    try {
+        const descMap = await buildDescMap();
+        if (!descMap) {
+            showToast('AI enhancement failed. Check your AI settings.', 'danger');
+            toggle.checked = false;
+            _enhancedTxt = null;
+            _descMap = null;
+        } else {
+            _descMap = descMap;
+            _enhancedTxt = generateEnhancedTxt(descMap);
+            document.getElementById('txt-preview').textContent = _enhancedTxt;
+            document.getElementById('btn-apply-enhanced').style.display = '';
+        }
+    } finally {
+        _enhancing = false;
+        toggle.disabled = false;
+        loading.classList.add('d-none');
+        loading.classList.remove('d-flex');
+    }
+}
+
+async function buildDescMap() {
+    const descs = [];
+    const seen  = new Set();
+
+    for (const day of state.days) {
+        if (!day.entries) continue;
+        for (const e of day.entries) {
+            const desc = (e.desc || '').trim();
+            if (desc && !seen.has(desc)) {
+                seen.add(desc);
+                descs.push(desc);
+            }
+        }
+    }
+
+    if (descs.length === 0) return new Map();
+
+    const numbered = descs.map((d, i) => `${i + 1}. ${d}`).join('\n');
+    const prompt = [
+        'You are a professional work log editor. Rewrite each numbered timesheet description into professional, concise language (under 10 words). Preserve the meaning — do not invent details. Output ONLY the numbered rewrites in the exact same format (e.g. "1. Resolved the issue"). No preamble, no extra text.',
+        '',
+        numbered,
+    ].join('\n');
+
+    const result = await ask(prompt, null);
+    if (!result) return null;
+
+    // Parse by number so preamble lines are safely ignored
+    const rewrittenByNum = {};
+    result.trim().split(/\r?\n/).forEach(l => {
+        const m = l.trim().match(/^(\d+)\.\s+(.+)/);
+        if (m) rewrittenByNum[parseInt(m[1])] = m[2].trim();
+    });
+
+    const map = new Map();
+    descs.forEach((d, i) => {
+        const enhanced = rewrittenByNum[i + 1];
+        if (enhanced) map.set(d, enhanced);
+    });
+    return map;
+}
+
+function generateEnhancedTxt(descMap) {
+    const lines = [];
+    lines.push(state.reportTitle || 'Booked hours in Jira and Service Desk');
+    lines.push(SEPARATOR);
+    state.days.forEach((day) => {
+        lines.push(generateDayTxt(day, true, descMap));
+        lines.push('');
+    });
+    return lines.join('\r\n');
+}
+
+function applyEnhancedDescs() {
+    if (!_descMap || _descMap.size === 0) return;
+
+    _undoSnapshot = [];
+    state.days.forEach((day, dayIdx) => {
+        if (!day.entries) return;
+        day.entries.forEach((e, entryIdx) => {
+            const key = (e.desc || '').trim();
+            if (key && _descMap.has(key)) {
+                _undoSnapshot.push({ dayIdx, entryIdx, originalDesc: e.desc });
+                e.desc = _descMap.get(key);
+            }
+        });
+    });
+
+    saveState();
+    previewModal.hide();
+    renderAll();
+    _showApplyUndoToast(_undoSnapshot.length);
+}
+
+function undoEnhancedDescs() {
+    if (!_undoSnapshot) return;
+    const snapshot = _undoSnapshot;
+    _undoSnapshot = null;
+
+    snapshot.forEach(({ dayIdx, entryIdx, originalDesc }) => {
+        const entry = state.days[dayIdx]?.entries?.[entryIdx];
+        if (entry) entry.desc = originalDesc;
+    });
+
+    saveState();
+    renderAll();
+    showToast('Descriptions restored.', 'success');
+}
+
+function _showApplyUndoToast(count) {
+    let container = document.querySelector('.toast-container');
+    if (!container) {
+        container = document.createElement('div');
+        container.className = 'toast-container';
+        document.body.appendChild(container);
+    }
+    const existing = document.getElementById('apply-enhanced-toast');
+    if (existing) existing.remove();
+
+    container.insertAdjacentHTML('beforeend', `
+    <div id="apply-enhanced-toast" class="toast toast-custom show align-items-center" role="alert" style="min-width:280px">
+      <div class="d-flex align-items-center gap-2 px-3 py-2">
+        <i class="bi bi-stars" style="color:#4ade80"></i>
+        <span style="font-size:0.85rem">${count} ${count === 1 ? 'description' : 'descriptions'} updated.</span>
+        <button type="button" class="btn btn-sm btn-outline-light ms-auto py-0 px-2" style="font-size:0.75rem" id="btn-undo-enhanced">Undo</button>
+      </div>
+    </div>`);
+
+    const timerId = setTimeout(() => { document.getElementById('apply-enhanced-toast')?.remove(); }, 5000);
+
+    document.getElementById('btn-undo-enhanced').addEventListener('click', () => {
+        clearTimeout(timerId);
+        document.getElementById('apply-enhanced-toast')?.remove();
+        undoEnhancedDescs();
+    });
 }

--- a/src/renderer/styles/modals.css
+++ b/src/renderer/styles/modals.css
@@ -115,3 +115,35 @@
   font-size: 0.78rem; color: var(--text-secondary); margin-top: 4px; display: none;
 }
 .time-hint-text.show { display: block; }
+
+/* ── Report AI Enhancement Bar ── */
+.report-ai-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.83rem;
+  color: var(--text-secondary);
+}
+
+.report-ai-bar .form-check-label {
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.83rem;
+  user-select: none;
+}
+
+.report-ai-bar .form-check-input:checked {
+  background-color: var(--accent);
+  border-color: var(--accent);
+}
+
+.report-ai-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}


### PR DESCRIPTION
## Summary
- Adds an optional **Enhance with AI** toggle in the TXT Preview modal (hidden when AI / `reportEnhancement` feature is disabled)
- When toggled on, all unique entry descriptions are sent to the AI in a single numbered request; the enhanced preview is shown immediately
- **Apply to Entries** button (appears after enhancement) writes the rewritten descriptions back to `state.days`, calls `saveState()` + `renderAll()`, then shows an undo toast
- **Undo** toast (5 s) fully restores original descriptions via a pre-apply snapshot
- Original descriptions are never overwritten unless the user explicitly clicks Apply
- Prompt uses a numbered format so AI preamble lines are safely ignored during parsing

## Test plan
- [ ] Open TXT Preview with AI disabled — toggle should not appear
- [ ] Enable AI + `reportEnhancement` feature in settings, reopen preview — toggle appears
- [ ] Toggle on → spinner shown → enhanced descriptions appear in preview
- [ ] Toggle off → original descriptions restored, Apply button hidden
- [ ] Toggle on, click Apply to Entries → modal closes, main cards show enhanced descriptions, undo toast appears
- [ ] Click Undo in toast → original descriptions restored in UI and persisted
- [ ] Remove enhancement and re-apply — no preamble bleed-through in descriptions

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)