### PR TITLE
feat(tm-166): add recurring task advisor with pattern detection

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -31,6 +31,7 @@ import { refreshSettings } from './modules/ai.js';
 import { initAiChat } from './modules/ai-chat.js';
 import { initWeekSummary } from './modules/week-summary.js';
 import { runAnomalyDetection } from './modules/anomaly-detection.js';
+import { runRecurringAdvisor } from './modules/recurring-advisor.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
@@ -93,6 +94,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     updateNoTicketBanner();
     updateUnderloggedBanner();
     runAnomalyDetection();
+    if (new Date().getDay() === 1) runRecurringAdvisor();
 
     // Navigate to today when triggered from tray or notification click
     if (window.tray) {

--- a/src/renderer/modules/notifications.js
+++ b/src/renderer/modules/notifications.js
@@ -2,10 +2,21 @@
    NOTIFICATION CENTRE
    ============================================================= */
 
-const STORAGE_KEY = 'tm_notifications';
+const STORAGE_KEY          = 'tm_notifications';
+const DISMISSED_RECURRING_KEY = 'tm_dismissed_recurring';
 
 let notifications = [];
 let dropdownOpen = false;
+
+// Lazily imported to avoid circular deps at module eval time
+let _openRecurringForm = null;
+async function getOpenRecurringForm() {
+    if (!_openRecurringForm) {
+        const mod = await import('./recurring.js');
+        _openRecurringForm = mod.openRecurringForm;
+    }
+    return _openRecurringForm;
+}
 
 const TYPE_META = {
     'no-ticket':        { icon: 'bi-exclamation-triangle-fill', color: 'var(--danger)'  },
@@ -15,6 +26,7 @@ const TYPE_META = {
     'underlogged-week': { icon: 'bi-hourglass-split',           color: 'var(--warning)' },
     'ticket-gap':       { icon: 'bi-ticket-perforated',         color: 'var(--text-secondary)' },
     'duplicate-entries':{ icon: 'bi-files',                     color: 'var(--text-secondary)' },
+    'recurring-advisor':{ icon: 'bi-arrow-repeat',              color: 'var(--info)'    },
 };
 
 /* ── persistence ── */
@@ -30,6 +42,25 @@ function save() {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(notifications.slice(0, 50)));
 }
 
+/* ── dismissed recurring suggestions ── */
+
+export function loadDismissedRecurring() {
+    try {
+        const raw = localStorage.getItem(DISMISSED_RECURRING_KEY);
+        return raw ? new Set(JSON.parse(raw)) : new Set();
+    } catch { return new Set(); }
+}
+
+function saveDismissedRecurring(set) {
+    localStorage.setItem(DISMISSED_RECURRING_KEY, JSON.stringify([...set]));
+}
+
+export function addDismissedRecurring(key) {
+    const set = loadDismissedRecurring();
+    set.add(key);
+    saveDismissedRecurring(set);
+}
+
 /* ── public API ── */
 
 export function pushNotification(type, message) {
@@ -38,6 +69,7 @@ export function pushNotification(type, message) {
     const existing = notifications.find(n => n.type === type);
     if (existing) {
         if (existing.dismissedUntil && now < existing.dismissedUntil) return;
+        if (existing.permanentlyDismissed) return;
         existing.dismissedUntil = null;
         if (existing.message !== message) {
             existing.message = message;
@@ -55,6 +87,40 @@ export function pushNotification(type, message) {
         timestamp: new Date().toISOString(),
         read: false,
         dismissedUntil: null,
+    });
+    save();
+    renderBadge();
+}
+
+export function pushActionableNotification(type, message, actionType, actionPayload) {
+    load();
+    const now = Date.now();
+    const existing = notifications.find(n => n.type === type);
+    if (existing) {
+        if (existing.dismissedUntil && now < existing.dismissedUntil) return;
+        if (existing.permanentlyDismissed) return;
+        existing.dismissedUntil = null;
+        if (existing.message !== message) {
+            existing.message = message;
+            existing.actionType = actionType;
+            existing.actionPayload = actionPayload;
+            existing.timestamp = new Date().toISOString();
+            existing.read = false;
+            save();
+            renderBadge();
+        }
+        return;
+    }
+    notifications.unshift({
+        id: 'n-' + Date.now(),
+        type,
+        message,
+        actionType,
+        actionPayload,
+        timestamp: new Date().toISOString(),
+        read: false,
+        dismissedUntil: null,
+        permanentlyDismissed: false,
     });
     save();
     renderBadge();
@@ -89,6 +155,7 @@ export function initNotifications() {
 /* ── badge ── */
 
 function isDismissed(n) {
+    if (n.permanentlyDismissed) return true;
     return n.dismissedUntil && Date.now() < n.dismissedUntil;
 }
 
@@ -148,30 +215,56 @@ function renderList() {
         const typeKey = Object.keys(TYPE_META).find(k => n.type === k || n.type.startsWith(k + '-'));
         const meta = TYPE_META[typeKey] || { icon: 'bi-bell', color: 'var(--text-secondary)' };
         const time = formatTime(n.timestamp);
+        const hasAction = n.actionType === 'make-recurring';
+
         const item = document.createElement('div');
         item.className = 'notif-item';
         item.innerHTML = `
             <i class="bi ${meta.icon} notif-item-icon" style="color:${meta.color}"></i>
             <div class="notif-item-body">
                 <p class="notif-item-msg">${escHtml(n.message)}</p>
+                ${hasAction ? `<div class="notif-item-actions">
+                    <button class="btn btn-sm btn-gradient notif-action-btn py-0 px-2" data-action="make-recurring" style="font-size:0.75rem">
+                        <i class="bi bi-arrow-repeat me-1"></i>Make Recurring
+                    </button>
+                </div>` : ''}
                 <span class="notif-item-time">${time}</span>
             </div>
             <button class="notif-item-dismiss" data-id="${n.id}" title="Dismiss">
                 <i class="bi bi-x"></i>
             </button>`;
+
+        if (hasAction) {
+            item.querySelector('[data-action="make-recurring"]').addEventListener('click', async (e) => {
+                e.stopPropagation();
+                closeDropdown();
+                const fn = await getOpenRecurringForm();
+                fn(n.actionPayload || null);
+            });
+        }
+
         item.querySelector('.notif-item-dismiss').addEventListener('click', (e) => {
             e.stopPropagation();
-            dismissOne(n.id);
+            dismissOne(n.id, n.actionType === 'make-recurring' ? n.actionPayload?.dismissKey : null);
         });
+
         list.appendChild(item);
     });
 }
 
-function dismissOne(id) {
+function dismissOne(id, recurringDismissKey) {
     const n = notifications.find(n => n.id === id);
     if (!n) return;
-    const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
-    n.dismissedUntil = Date.now() + SEVEN_DAYS;
+
+    if (recurringDismissKey) {
+        // Permanent dismissal for recurring advisor suggestions
+        n.permanentlyDismissed = true;
+        addDismissedRecurring(recurringDismissKey);
+    } else {
+        const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
+        n.dismissedUntil = Date.now() + SEVEN_DAYS;
+    }
+
     save();
     renderBadge();
     renderList();

--- a/src/renderer/modules/recurring-advisor.js
+++ b/src/renderer/modules/recurring-advisor.js
@@ -1,0 +1,249 @@
+/* =============================================================
+   RECURRING TASK ADVISOR
+   Detects manual logging patterns and suggests converting them
+   to recurring tasks. Runs on Monday app load only.
+   ============================================================= */
+
+import { state, RECURRING_DAY_NAMES } from './state.js';
+import { isFeatureEnabled, ask } from './ai.js';
+import { pushActionableNotification, loadDismissedRecurring } from './notifications.js';
+import { fmtDate } from './utils.js';
+
+const MAX_SUGGESTIONS = 3;
+
+/* ── helpers ── */
+
+function normaliseDesc(str) {
+    return (str || '').toLowerCase().trim().replace(/\s+/g, ' ');
+}
+
+// Returns "YYYY-Www" ISO week string for a date string
+function isoWeek(dateStr) {
+    const d = new Date(dateStr + 'T12:00:00');
+    const jan4 = new Date(d.getFullYear(), 0, 4);
+    const startOfWeek1 = new Date(jan4);
+    startOfWeek1.setDate(jan4.getDate() - ((jan4.getDay() + 6) % 7));
+    const weekNum = Math.floor((d - startOfWeek1) / 604800000) + 1;
+    return `${d.getFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+// Returns the Mon–Fri day name ('Mon'…'Fri') for a date string, or null for weekends
+function weekdayName(dateStr) {
+    const dow = new Date(dateStr + 'T12:00:00').getDay(); // 0=Sun…6=Sat
+    return RECURRING_DAY_NAMES[dow - 1] || null; // RECURRING_DAY_NAMES is [Mon,Tue,Wed,Thu,Fri]
+}
+
+// Checks whether an array of ISO week strings contains N consecutive weeks
+function hasConsecutiveWeeks(weeks, n) {
+    const sorted = [...new Set(weeks)].sort();
+    if (sorted.length < n) return false;
+    for (let i = 0; i <= sorted.length - n; i++) {
+        let streak = 1;
+        for (let j = i + 1; j < sorted.length; j++) {
+            const prev = sorted[j - 1].split('-W');
+            const cur  = sorted[j].split('-W');
+            const prevYear = parseInt(prev[0]), prevWk = parseInt(prev[1]);
+            const curYear  = parseInt(cur[0]),  curWk  = parseInt(cur[1]);
+            const diff = (curYear - prevYear) * 52 + (curWk - prevWk);
+            if (diff === 1) { streak++; if (streak >= n) return true; }
+            else break;
+        }
+    }
+    return false;
+}
+
+// Checks whether an array of date strings contains N consecutive working days
+function hasConsecutiveWorkdays(dates, n) {
+    const sorted = [...new Set(dates)].sort();
+    if (sorted.length < n) return false;
+    for (let i = 0; i <= sorted.length - n; i++) {
+        let streak = 1;
+        for (let j = i + 1; j < sorted.length; j++) {
+            const prev = new Date(sorted[j - 1] + 'T12:00:00');
+            const cur  = new Date(sorted[j]     + 'T12:00:00');
+            const diffDays = Math.round((cur - prev) / 86400000);
+            // Allow Mon after Fri (3 calendar days)
+            const isContinuous = diffDays === 1 || (diffDays === 3 && prev.getDay() === 5);
+            if (isContinuous) { streak++; if (streak >= n) return true; }
+            else break;
+        }
+    }
+    return false;
+}
+
+/* ── pattern index ── */
+
+function buildPatternIndex() {
+    // key → { ticket, normDesc, rawDescs, type, hh, mm, dates: [], weeksByDay: {Mon:[weeks], ...} }
+    const index = {};
+
+    const allDays = { ...state.allDaysByDate };
+    // Merge current week days (may not be in allDaysByDate yet)
+    state.days.forEach(d => { if (d.date && !allDays[d.date]) allDays[d.date] = d; });
+
+    for (const [dateStr, day] of Object.entries(allDays)) {
+        const dayName = weekdayName(dateStr);
+        if (!dayName) continue; // skip weekends
+        const week = isoWeek(dateStr);
+
+        (day.entries || []).forEach(e => {
+            const ticket    = (e.ticket || '').trim();
+            const normDesc  = normaliseDesc(e.desc);
+            if (!ticket && !normDesc) return;
+
+            const key = `${ticket}|${normDesc}`;
+            if (!index[key]) {
+                index[key] = {
+                    ticket,
+                    normDesc,
+                    rawDescs: new Set(),
+                    type: e.type || '',
+                    hh: e.hh || 0,
+                    mm: e.mm || 0,
+                    dates: [],
+                    weeksByDay: { Mon: [], Tue: [], Wed: [], Thu: [], Fri: [] },
+                };
+            }
+            const rec = index[key];
+            rec.rawDescs.add(e.desc || '');
+            rec.dates.push(dateStr);
+            if (rec.weeksByDay[dayName]) rec.weeksByDay[dayName].push(week);
+        });
+    }
+
+    return index;
+}
+
+/* ── pattern detection ── */
+
+function detectPatterns(index) {
+    const dismissed = loadDismissedRecurring();
+    const existingKeys = new Set(
+        (state.recurringTasks || []).map(r => `${r.ticket}|${normaliseDesc(r.desc)}`)
+    );
+
+    const hits = [];
+
+    for (const [key, rec] of Object.entries(index)) {
+        if (existingKeys.has(key)) continue; // already a recurring task
+        if (dismissed.has(key)) continue;    // user permanently dismissed
+
+        let matchedDays = [];
+        let reason = '';
+
+        // Rule 1: same weekday for 3+ consecutive weeks
+        for (const day of RECURRING_DAY_NAMES) {
+            if (hasConsecutiveWeeks(rec.weeksByDay[day], 3)) {
+                matchedDays.push(day);
+            }
+        }
+        if (matchedDays.length > 0) reason = 'weekly';
+
+        // Rule 2: daily for 5+ consecutive working days
+        if (!reason && hasConsecutiveWorkdays(rec.dates, 5)) {
+            matchedDays = [...RECURRING_DAY_NAMES];
+            reason = 'daily';
+        }
+
+        // Rule 3: every Monday for 2+ consecutive weeks
+        if (!reason && hasConsecutiveWeeks(rec.weeksByDay['Mon'], 2)) {
+            matchedDays = ['Mon'];
+            reason = 'monday';
+        }
+
+        if (!reason) continue;
+
+        hits.push({ key, rec, matchedDays, reason });
+    }
+
+    return hits;
+}
+
+/* ── AI fuzzy grouping (optional) ── */
+
+async function fuzzyGroupHits(hits) {
+    if (hits.length < 2) return hits;
+
+    const snippets = hits.map((h, i) =>
+        `${i + 1}. [${h.rec.ticket || 'no-ticket'}] "${[...h.rec.rawDescs][0] || ''}"`
+    ).join('\n');
+
+    const prompt =
+        `These are timesheet entry patterns detected as likely recurring:\n${snippets}\n\n` +
+        `Which entries (by number) describe the same task but with slightly different wording? ` +
+        `Reply with only groups like "1,3" or "2,4" on separate lines, one group per line. ` +
+        `If no duplicates, reply "none".`;
+
+    try {
+        const reply = await ask(prompt, null);
+        if (!reply || reply.trim().toLowerCase() === 'none') return hits;
+
+        // Parse groups and merge: keep the first hit, mark others as duplicates
+        const merged = new Set();
+        reply.trim().split('\n').forEach(line => {
+            const idxs = line.split(',').map(s => parseInt(s.trim()) - 1).filter(i => !isNaN(i) && i < hits.length);
+            if (idxs.length < 2) return;
+            idxs.slice(1).forEach(i => merged.add(i));
+        });
+
+        return hits.filter((_, i) => !merged.has(i));
+    } catch {
+        return hits;
+    }
+}
+
+/* ── message builder ── */
+
+function buildMessage(hit) {
+    const { rec, reason } = hit;
+    const label = [...rec.rawDescs][0] || rec.normDesc || rec.ticket;
+    const ticket = rec.ticket ? `'${rec.ticket}'` : `'${label}'`;
+
+    if (reason === 'daily') {
+        return `You've logged ${ticket} every day — want to make it a recurring task?`;
+    }
+    if (reason === 'monday') {
+        return `You've logged ${ticket} every Monday — want to make it a recurring task?`;
+    }
+    // weekly — list matched days
+    const dayList = hit.matchedDays.join('/');
+    return `You've logged ${ticket} every ${dayList} for several weeks — want to make it a recurring task?`;
+}
+
+/* ── public entry point ── */
+
+export async function runRecurringAdvisor() {
+    if (!isFeatureEnabled('recurringAdvisor')) return;
+
+    const index = buildPatternIndex();
+    let hits = detectPatterns(index);
+    if (hits.length === 0) return;
+
+    hits = await fuzzyGroupHits(hits);
+    hits = hits.slice(0, MAX_SUGGESTIONS);
+
+    hits.forEach(hit => {
+        const { key, rec, matchedDays } = hit;
+        const desc = [...rec.rawDescs][0] || rec.normDesc;
+        const message = buildMessage(hit);
+
+        // actionPayload is serialisable — openRecurringForm accepts this shape
+        const actionPayload = {
+            id: '',           // empty = new rule
+            ticket: rec.ticket,
+            hh: rec.hh,
+            mm: rec.mm,
+            type: rec.type,
+            desc,
+            days: matchedDays,
+            dismissKey: key,  // used for permanent dismissal on "X"
+        };
+
+        pushActionableNotification(
+            `recurring-advisor-${key.slice(0, 40)}`,
+            message,
+            'make-recurring',
+            actionPayload
+        );
+    });
+}

--- a/src/renderer/modules/recurring.js
+++ b/src/renderer/modules/recurring.js
@@ -183,7 +183,7 @@ function renderRecurringList() {
     });
 }
 
-function openRecurringForm(rule) {
+export function openRecurringForm(rule) {
     document.getElementById('recurring-form-id').value = rule ? rule.id : '';
     document.getElementById('recurring-ticket').value = rule ? rule.ticket : '';
     const timeEl = document.getElementById('recurring-time');
@@ -192,7 +192,7 @@ function openRecurringForm(rule) {
     populateTypeSelect(document.getElementById('recurring-type'), rule ? rule.type : (state.ticketTypes[0]?.id || 'jira'));
     document.getElementById('recurring-desc').value = rule ? rule.desc : '';
     document.getElementById('recurringFormTitle').innerHTML =
-        `<i class="bi bi-arrow-repeat me-2"></i>${rule ? 'Edit' : 'Add'} Recurring Task`;
+        `<i class="bi bi-arrow-repeat me-2"></i>${rule?.id ? 'Edit' : 'Add'} Recurring Task`;
 
     document.querySelectorAll('.recurring-day-btn').forEach(btn => {
         btn.classList.toggle('selected', rule ? rule.days.includes(btn.dataset.day) : false);


### PR DESCRIPTION
## Summary
- Detects repeated manual logging patterns (same weekday 3+ weeks, daily 5+ days, every Monday 2+ weeks) and surfaces actionable suggestions in the notification centre
- Each suggestion has a **Make Recurring** button that opens the recurring task form pre-filled with the detected ticket, description, time, and days
- Dismissed suggestions are permanently suppressed per ticket+description combination (stored in `tm_dismissed_recurring` localStorage key)
- Optional AI fuzzy dedup collapses near-identical description variants before surfacing suggestions

## Changes
| File | Change |
|------|--------|
| `src/renderer/modules/recurring-advisor.js` | New module — full pattern detection, dismissed-suggestion tracking, AI fuzzy dedup, capped at 3 suggestions |
| `src/renderer/modules/notifications.js` | Added `pushActionableNotification`, `recurring-advisor` type meta, action button rendering, permanent dismissal support |
| `src/renderer/modules/recurring.js` | Exported `openRecurringForm`; fixed title logic to show "Add" when opened from advisor |
| `src/renderer/main.js` | Import and call `runRecurringAdvisor()` on Monday app load |

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Pattern detected → notification appears with "Make Recurring" button
- [ ] "Make Recurring" opens pre-filled recurring task form
- [ ] Dismiss permanently suppresses suggestion (survives restart)
- [ ] Existing recurring task for same ticket+desc → no suggestion surfaced
- [ ] `recurringAdvisor` feature toggle in AI settings disables the advisor
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #166

🤖 Generated with [Claude Code](https://claude.ai/claude-code)