### PR TITLE
perf(tm-177): debounce saveState writes and search input

### DIFF
--- a/src/renderer/modules/search.js
+++ b/src/renderer/modules/search.js
@@ -1,6 +1,6 @@
 import { state, SEARCH_PAGE_SIZE } from './state.js';
 import { saveState } from './store.js';
-import { escHtml, fmtDate, fmtSearchDate, fmtHHMM } from './utils.js';
+import { escHtml, fmtDate, fmtSearchDate, fmtHHMM, debounce } from './utils.js';
 import { getTypeLabel } from './ticket-types.js';
 import { getWeekStrFromDate, getDateFromWeek, buildWeekDays, updateWeekDisplay, enforceExpandedState } from './week.js';
 // Circular — resolved at call time
@@ -102,13 +102,19 @@ export function initSearch() {
     let lastResults = [];
     let showingAll = false;
 
-    input.addEventListener('input', () => {
+    const _runSearch = debounce(() => {
         const q = input.value.trim();
-        activeIdx = -1;
-        showingAll = false;
         if (q.length < 3) { closeSearchDropdown(); return; }
         lastResults = searchCurrentWeek(q);
         renderSearchDropdown(lastResults, q, false);
+    }, 200);
+
+    input.addEventListener('input', () => {
+        activeIdx = -1;
+        showingAll = false;
+        const q = input.value.trim();
+        if (q.length < 3) { closeSearchDropdown(); return; }
+        _runSearch();
     });
 
     input.addEventListener('keydown', (e) => {

--- a/src/renderer/modules/sidebar.js
+++ b/src/renderer/modules/sidebar.js
@@ -11,6 +11,7 @@ import { openPreview, openDayQuickView, doPrint } from './report.js';
 import { openSettings, addChangelogEntry } from './settings.js';
 import { openWeekSwitcherModal } from './header.js';
 import { logError } from './error-log.js';
+import { flushSave } from './store.js';
 
 /* ── SUMMARY PANEL COLLAPSE ─────────────────────────────── */
 export function initSummaryPanel() {
@@ -102,8 +103,9 @@ export function initSidebar() {
 
     const exitBtn = document.getElementById('menu-exit');
     if (exitBtn) {
-        exitBtn.addEventListener('click', (e) => {
+        exitBtn.addEventListener('click', async (e) => {
             e.preventDefault();
+            await flushSave();
             window.app.quit();
         });
     }

--- a/src/renderer/modules/store.js
+++ b/src/renderer/modules/store.js
@@ -1,12 +1,15 @@
 import { state, LS_KEY, DEFAULT_TICKET_TYPES, DEFAULT_LEAVE_TYPES } from './state.js';
 import { logError } from './error-log.js';
+import { debounce } from './utils.js';
 
-export async function saveState() {
+function _syncDays() {
+    state.days.forEach(d => {
+        if (d && d.date) state.allDaysByDate[d.date] = d;
+    });
+}
+
+async function _writeState() {
     try {
-        state.days.forEach(d => {
-            if (d && d.date) state.allDaysByDate[d.date] = d;
-        });
-
         const toSave = {
             reportTitle: state.reportTitle,
             employeeName: state.employeeName,
@@ -20,6 +23,19 @@ export async function saveState() {
         };
         await window.electronStore.set(LS_KEY, toSave);
     } catch (e) { console.warn('Could not save state', e); logError('store/save', e); }
+}
+
+const _debouncedWrite = debounce(_writeState, 300);
+
+export function saveState() {
+    _syncDays();
+    _debouncedWrite();
+}
+
+// Call before app quits to flush any pending debounced write.
+export async function flushSave() {
+    _debouncedWrite.flush();
+    await _writeState();
 }
 
 export async function loadState() {

--- a/src/renderer/modules/utils.js
+++ b/src/renderer/modules/utils.js
@@ -139,6 +139,19 @@ export function padTicket(ticket) {
     return ticket;
 }
 
+export function debounce(fn, delay) {
+    let timer;
+    function debounced(...args) {
+        clearTimeout(timer);
+        timer = setTimeout(() => fn.apply(this, args), delay);
+    }
+    debounced.flush = function (...args) {
+        clearTimeout(timer);
+        fn.apply(this, args);
+    };
+    return debounced;
+}
+
 export function animateCountUp(el, targetVal, isTimeFormat = false) {
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
         el.textContent = isTimeFormat ? minsToHHMM(targetVal) : targetVal;


### PR DESCRIPTION
## Summary
- Add `debounce()` utility to `utils.js` with a `.flush()` method for cancel-and-fire-immediately
- Debounce `saveState` electron-store writes at 300ms — sync state update still happens immediately, only the disk write is batched
- Flush pending write before app quits via `flushSave()` in the exit button handler
- Debounce inline search input handler at 200ms; keyboard navigation (arrows, Enter, Escape) remains synchronous

## Changes
- `utils.js` — new `debounce(fn, delay)` export with `.flush()`
- `store.js` — split into `_syncDays()` + `_writeState()` + 300ms debounced write; added `flushSave()` export
- `sidebar.js` — exit button awaits `flushSave()` before calling `window.app.quit()`
- `search.js` — input handler debounced at 200ms; immediate close/reset on keypress preserved

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #177

🤖 Generated with [Claude Code](https://claude.ai/claude-code)