### PR TITLE
refactor(tm-178): replace per-element listeners with event delegation

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -17,7 +17,7 @@ import { initReport } from './modules/report.js';
 import { bindHeaderEvents, openWeekSwitcherModal } from './modules/header.js';
 import { initSettings, updateSheetDetailsDisplay, loadChangelog } from './modules/settings.js';
 import { loadErrorLog } from './modules/error-log.js';
-import { renderAll } from './modules/render.js';
+import { renderAll, initDaysContainer } from './modules/render.js';
 import { state } from './modules/state.js';
 import { getWeekStrFromDate, getDateFromWeek, buildWeekDays, enforceExpandedState, updateWeekDisplay } from './modules/week.js';
 import { updateSummary } from './modules/summary.js';
@@ -56,6 +56,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     initCopyTo();
     initReport();
     bindHeaderEvents();
+    initDaysContainer();
 
     const restored = await loadState();
     refreshSettings();   // cache AI feature flags; fire-and-forget

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -270,9 +270,9 @@ export function buildDayCard(day, dayIdx) {
     </div>
     <div class="day-card-body ${day.expanded ? '' : 'collapsed'}" id="day-body-${dayIdx}">
       <div class="holiday-check-wrap">
-        <input type="checkbox" id="holiday-${dayIdx}" ${day.isHoliday ? 'checked' : ''} />
+        <input type="checkbox" id="holiday-${dayIdx}" data-day="${dayIdx}" ${day.isHoliday ? 'checked' : ''} />
         <label for="holiday-${dayIdx}">Mark as Holiday / Leave</label>
-        <select id="holiday-label-${dayIdx}" class="form-select dark-input ms-2"
+        <select id="holiday-label-${dayIdx}" data-day="${dayIdx}" data-role="holiday-label" class="form-select dark-input ms-2"
           style="max-width:200px;display:${day.isHoliday ? 'block' : 'none'}">
         </select>
       </div>
@@ -280,7 +280,7 @@ export function buildDayCard(day, dayIdx) {
         <button class="add-entry-btn" data-day="${dayIdx}">
           <i class="bi bi-plus-circle"></i> Add Entry
         </button>
-        <button class="day-notes-open-btn${day.notes ? ' has-notes' : ''}" title="${day.notes ? 'View/Edit Notes' : 'Add Notes'}">
+        <button class="day-notes-open-btn${day.notes ? ' has-notes' : ''}" data-day="${dayIdx}" title="${day.notes ? 'View/Edit Notes' : 'Add Notes'}">
           Notes
         </button>
       </div>`}
@@ -289,71 +289,7 @@ export function buildDayCard(day, dayIdx) {
     </div>
   `;
 
-    wrap.querySelector('.day-card-header').addEventListener('click', (e) => {
-        if (e.target.closest('.day-quick-view-btn')) {
-            e.stopPropagation();
-            openDayQuickView(dayIdx);
-        } else {
-            toggleDay(dayIdx);
-        }
-    });
-
-    wrap.querySelector('.day-notes-open-btn')?.addEventListener('click', () => openDayNotesModal(dayIdx));
-
-    const cb = wrap.querySelector(`#holiday-${dayIdx}`);
-    const lbl = wrap.querySelector(`#holiday-label-${dayIdx}`);
-
-    // Populate leave type select dynamically
-    populateLeaveSelect(lbl, resolveLeaveTypeId(day));
-
-    cb.addEventListener('change', () => {
-        state.days[dayIdx].isHoliday = cb.checked;
-        lbl.style.display = cb.checked ? 'block' : 'none';
-        if (!cb.checked) {
-            state.days[dayIdx].leaveTypeId = '';
-        } else {
-            state.days[dayIdx].leaveTypeId = resolveLeaveTypeId(state.days[dayIdx]);
-        }
-        rerenderDayCard(dayIdx);
-        updateSummary();
-        saveState();
-    });
-    lbl.addEventListener('change', () => {
-        state.days[dayIdx].leaveTypeId = lbl.value;
-        // Keep holidayLabel in sync for backward compat fallback
-        const leaveType = state.leaveTypes?.find(t => t.id === lbl.value);
-        if (leaveType) state.days[dayIdx].holidayLabel = leaveType.label;
-        rerenderDayCard(dayIdx);
-        updateSummary();
-        saveState();
-    });
-
-    const addBtn = wrap.querySelector('.add-entry-btn');
-    if (addBtn) addBtn.addEventListener('click', () => openEntryModal(dayIdx, -1));
-
-    wrap.querySelectorAll('.entry-row').forEach(row => {
-        row.addEventListener('dblclick', e => {
-            if (e.target.closest('.drag-handle') || e.target.closest('.entry-btn-eye') || e.target.closest('.entry-btn-star') || e.target.closest('.entry-btn-logged')) return;
-            openEntryModal(parseInt(row.dataset.day), parseInt(row.dataset.entry));
-        });
-
-        row.addEventListener('contextmenu', e => {
-            e.preventDefault();
-            showEntryContextMenu(row, e.clientX, e.clientY);
-        });
-
-        row.querySelector('.entry-btn-star').addEventListener('click', e => {
-            e.stopPropagation();
-            toggleEntryStarred(parseInt(row.dataset.day), parseInt(row.dataset.entry), e.currentTarget);
-        });
-
-        row.querySelector('.entry-btn-logged').addEventListener('click', e => {
-            e.stopPropagation();
-            toggleEntryLogged(parseInt(row.dataset.day), parseInt(row.dataset.entry), e.currentTarget);
-        });
-    });
-
-    attachDragListeners(dayIdx, wrap);
+    populateLeaveSelect(wrap.querySelector(`#holiday-label-${dayIdx}`), resolveLeaveTypeId(day));
 
     return wrap;
 }
@@ -480,42 +416,60 @@ export function toggleDay(dayIdx) {
     }
 }
 
-export function attachDragListeners(dayIdx, container) {
-    const entriesList = (container || document).querySelector(`#entries-${dayIdx}`);
+function startDrag(e, row, dayIdx) {
+    const entriesList = document.getElementById(`entries-${dayIdx}`);
     if (!entriesList) return;
 
-    const rows = entriesList.querySelectorAll('.entry-row');
-
-    let draggingRow     = null;
+    let draggingRow     = row;
     let ghost           = null;
-    let dragSrcGroupIdx = null;
-    let dragSrcItemIdx  = null;
+    let dragSrcGroupIdx = parseInt(row.dataset.groupIdx);
+    let dragSrcItemIdx  = parseInt(row.dataset.itemIdx);
     let offsetX = 0, offsetY = 0;
+    let rafId = null;
+    let lastMouseX = e.clientX, lastMouseY = e.clientY;
 
-    rows.forEach(r => r.removeAttribute('draggable'));
+    const rect = row.getBoundingClientRect();
+    offsetX = e.clientX - rect.left;
+    offsetY = e.clientY - rect.top;
+
+    ghost = row.cloneNode(true);
+    ghost.classList.remove('dragging');
+    ghost.style.cssText = [
+        'position:fixed',
+        'pointer-events:none',
+        'z-index:99999',
+        'width:' + rect.width + 'px',
+        'left:' + (e.clientX - offsetX) + 'px',
+        'top:' + (e.clientY - offsetY) + 'px',
+        'opacity:0.92',
+        'background:var(--bg-card)',
+        'border:1.5px solid var(--border-accent)',
+        'border-radius:8px',
+        'box-shadow:0 16px 40px rgba(0,0,0,0.7)',
+        'transition:none',
+        'cursor:grabbing',
+        'transform:rotate(3deg) scale(1.03)'
+    ].join(';');
+    document.body.appendChild(ghost);
+    row.classList.add('dragging');
 
     function getRowAt(clientX, clientY) {
         let found = null;
         let minDist = Infinity;
         entriesList.querySelectorAll('.entry-row').forEach(r => {
             if (r === draggingRow) return;
-            const rect = r.getBoundingClientRect();
-            if (clientY >= rect.top && clientY <= rect.bottom) {
-                found = r;
-                return;
-            }
-            const dist = Math.min(Math.abs(clientY - rect.top), Math.abs(clientY - rect.bottom));
-            if (dist < 20 && dist < minDist) {
-                minDist = dist;
-                found = r;
-            }
+            const rRect = r.getBoundingClientRect();
+            if (clientY >= rRect.top && clientY <= rRect.bottom) { found = r; return; }
+            const dist = Math.min(Math.abs(clientY - rRect.top), Math.abs(clientY - rRect.bottom));
+            if (dist < 20 && dist < minDist) { minDist = dist; found = r; }
         });
         return found;
     }
 
     function cleanup() {
+        if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
         if (ghost) { ghost.remove(); ghost = null; }
-        if (draggingRow) { draggingRow.classList.remove('dragging'); }
+        if (draggingRow) draggingRow.classList.remove('dragging');
         entriesList.querySelectorAll('.entry-row').forEach(r => r.classList.remove('drag-over', 'drag-over-invalid'));
         draggingRow = null;
         dragSrcGroupIdx = null;
@@ -524,56 +478,50 @@ export function attachDragListeners(dayIdx, container) {
         document.removeEventListener('mouseup',   onMouseUp);
     }
 
-    function onMouseMove(e) {
-        if (!ghost) return;
-        ghost.style.left = (e.clientX - offsetX) + 'px';
-        ghost.style.top  = (e.clientY - offsetY) + 'px';
+    function onMouseMove(ev) {
+        lastMouseX = ev.clientX;
+        lastMouseY = ev.clientY;
+        if (rafId !== null) return;
+        rafId = requestAnimationFrame(() => {
+            rafId = null;
+            if (!ghost) return;
+            ghost.style.left = (lastMouseX - offsetX) + 'px';
+            ghost.style.top  = (lastMouseY - offsetY) + 'px';
 
-        entriesList.querySelectorAll('.entry-row').forEach(r => r.classList.remove('drag-over', 'drag-over-invalid'));
+            entriesList.querySelectorAll('.entry-row').forEach(r => r.classList.remove('drag-over', 'drag-over-invalid'));
+            const target = getRowAt(lastMouseX, lastMouseY);
+            if (!target) return;
 
-        const target = getRowAt(e.clientX, e.clientY);
-        if (!target) return;
-
-        const toGroupIdx = parseInt(target.dataset.groupIdx);
-        const toItemIdx  = parseInt(target.dataset.itemIdx);
-
-        let isValid = true;
-        if (dragSrcItemIdx > 0 && toGroupIdx !== dragSrcGroupIdx) isValid = false;
-
-        if (isValid) {
-            if (dragSrcItemIdx === 0) {
-                entriesList.querySelectorAll(`.entry-row[data-group-idx="${toGroupIdx}"]`).forEach(r => r.classList.add('drag-over'));
+            const toGroupIdx = parseInt(target.dataset.groupIdx);
+            const isValid = !(dragSrcItemIdx > 0 && toGroupIdx !== dragSrcGroupIdx);
+            if (isValid) {
+                if (dragSrcItemIdx === 0) {
+                    entriesList.querySelectorAll(`.entry-row[data-group-idx="${toGroupIdx}"]`).forEach(r => r.classList.add('drag-over'));
+                } else {
+                    target.classList.add('drag-over');
+                }
             } else {
-                target.classList.add('drag-over');
+                target.classList.add('drag-over-invalid');
             }
-        } else {
-            target.classList.add('drag-over-invalid');
-        }
+        });
     }
 
-    function onMouseUp(e) {
+    function onMouseUp(ev) {
         if (!draggingRow) { cleanup(); return; }
-
-        const target = getRowAt(e.clientX, e.clientY);
+        const target = getRowAt(ev.clientX, ev.clientY);
         const srcGrpIdx = dragSrcGroupIdx;
         const srcItmIdx = dragSrcItemIdx;
-
-        let toGrpIdx = null;
-        let toItmIdx = null;
+        let toGrpIdx = null, toItmIdx = null;
         if (target) {
             toGrpIdx = parseInt(target.getAttribute('data-group-idx'));
             toItmIdx = parseInt(target.getAttribute('data-item-idx'));
         }
-
         cleanup();
-
-        if (target === null || srcGrpIdx === null) return;
+        if (!target || srcGrpIdx === null) return;
         if (srcGrpIdx === toGrpIdx && srcItmIdx === toItmIdx) return;
-
         if (srcItmIdx > 0 && toGrpIdx !== srcGrpIdx) return;
 
         const groups = buildGroups(state.days[dayIdx].entries);
-
         if (srcGrpIdx === toGrpIdx) {
             const grp = groups[srcGrpIdx];
             const [movedItem] = grp.items.splice(srcItmIdx, 1);
@@ -585,52 +533,105 @@ export function attachDragListeners(dayIdx, container) {
             const [movedGroup] = groups.splice(srcGrpIdx, 1);
             groups.splice(toGrpIdx, 0, movedGroup);
         }
-
         const newEntries = [];
         groups.forEach(grp => grp.items.forEach(item => newEntries.push(item)));
         state.days[dayIdx].entries = newEntries;
-
         saveState();
         rerenderDayCard(dayIdx);
     }
 
-    rows.forEach(row => {
-        const handle = row.querySelector('.drag-handle');
-        handle.addEventListener('mousedown', e => {
-            if (e.button !== 0) return;
-            e.preventDefault();
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup',   onMouseUp);
+}
 
-            draggingRow     = row;
-            dragSrcGroupIdx = parseInt(row.dataset.groupIdx);
-            dragSrcItemIdx  = parseInt(row.dataset.itemIdx);
+export function initDaysContainer() {
+    const container = document.getElementById('days-container');
 
-            const rect = row.getBoundingClientRect();
-            offsetX = e.clientX - rect.left;
-            offsetY = e.clientY - rect.top;
+    container.addEventListener('click', e => {
+        const quickViewBtn = e.target.closest('.day-quick-view-btn');
+        if (quickViewBtn) {
+            openDayQuickView(parseInt(quickViewBtn.closest('.day-card-header').dataset.day));
+            return;
+        }
+        const starBtn = e.target.closest('.entry-btn-star');
+        if (starBtn) {
+            const row = starBtn.closest('.entry-row');
+            toggleEntryStarred(parseInt(row.dataset.day), parseInt(row.dataset.entry), starBtn);
+            return;
+        }
+        const loggedBtn = e.target.closest('.entry-btn-logged');
+        if (loggedBtn) {
+            const row = loggedBtn.closest('.entry-row');
+            toggleEntryLogged(parseInt(row.dataset.day), parseInt(row.dataset.entry), loggedBtn);
+            return;
+        }
+        const notesBtn = e.target.closest('.day-notes-open-btn');
+        if (notesBtn) {
+            openDayNotesModal(parseInt(notesBtn.dataset.day));
+            return;
+        }
+        const addBtn = e.target.closest('.add-entry-btn');
+        if (addBtn) {
+            openEntryModal(parseInt(addBtn.dataset.day), -1);
+            return;
+        }
+        const header = e.target.closest('.day-card-header');
+        if (header) {
+            toggleDay(parseInt(header.dataset.day));
+        }
+    });
 
-            ghost = row.cloneNode(true);
-            ghost.classList.remove('dragging');
-            ghost.style.cssText = [
-                'position:fixed',
-                'pointer-events:none',
-                'z-index:99999',
-                'width:' + rect.width + 'px',
-                'left:' + (e.clientX - offsetX) + 'px',
-                'top:' + (e.clientY - offsetY) + 'px',
-                'opacity:0.92',
-                'background:var(--bg-card)',
-                'border:1.5px solid var(--border-accent)',
-                'border-radius:8px',
-                'box-shadow:0 16px 40px rgba(0,0,0,0.7)',
-                'transition:none',
-                'cursor:grabbing',
-                'transform:rotate(3deg) scale(1.03)'
-            ].join(';');
-            document.body.appendChild(ghost);
+    container.addEventListener('dblclick', e => {
+        const row = e.target.closest('.entry-row');
+        if (!row) return;
+        if (e.target.closest('.drag-handle') || e.target.closest('.entry-btn-eye') ||
+            e.target.closest('.entry-btn-star') || e.target.closest('.entry-btn-logged')) return;
+        openEntryModal(parseInt(row.dataset.day), parseInt(row.dataset.entry));
+    });
 
-            row.classList.add('dragging');
-            document.addEventListener('mousemove', onMouseMove);
-            document.addEventListener('mouseup',   onMouseUp);
-        });
+    container.addEventListener('contextmenu', e => {
+        const row = e.target.closest('.entry-row');
+        if (!row) return;
+        e.preventDefault();
+        showEntryContextMenu(row, e.clientX, e.clientY);
+    });
+
+    container.addEventListener('change', e => {
+        const cb = e.target.closest('input[type="checkbox"][data-day]');
+        if (cb) {
+            const dayIdx = parseInt(cb.dataset.day);
+            const lbl = document.getElementById(`holiday-label-${dayIdx}`);
+            state.days[dayIdx].isHoliday = cb.checked;
+            lbl.style.display = cb.checked ? 'block' : 'none';
+            if (!cb.checked) {
+                state.days[dayIdx].leaveTypeId = '';
+            } else {
+                state.days[dayIdx].leaveTypeId = resolveLeaveTypeId(state.days[dayIdx]);
+            }
+            rerenderDayCard(dayIdx);
+            updateSummary();
+            saveState();
+            return;
+        }
+        const sel = e.target.closest('select[data-role="holiday-label"]');
+        if (sel) {
+            const dayIdx = parseInt(sel.dataset.day);
+            state.days[dayIdx].leaveTypeId = sel.value;
+            const leaveType = state.leaveTypes?.find(t => t.id === sel.value);
+            if (leaveType) state.days[dayIdx].holidayLabel = leaveType.label;
+            rerenderDayCard(dayIdx);
+            updateSummary();
+            saveState();
+        }
+    });
+
+    container.addEventListener('mousedown', e => {
+        if (e.button !== 0) return;
+        const handle = e.target.closest('.drag-handle');
+        if (!handle) return;
+        const row = handle.closest('.entry-row');
+        if (!row) return;
+        e.preventDefault();
+        startDrag(e, row, parseInt(row.dataset.day));
     });
 }


### PR DESCRIPTION
## Summary
- Replace per-element `addEventListener` calls in `buildDayCard` with a single delegated listener set on `#days-container`, attached once at startup via `initDaysContainer()`
- Convert `attachDragListeners` into a private `startDrag(e, row, dayIdx)` triggered from the delegated `mousedown` handler — no more per-row listener setup on every rerender
- Wrap drag `pointermove` logic in `requestAnimationFrame`, capping DOM reads/writes at 60fps and cancelling stale frames on cleanup
- Add `data-day` / `data-role` attributes to holiday checkbox, select, and notes button for clean delegation without DOM traversal

## Changes
- `render.js` — removed all `addEventListener` from `buildDayCard`; added `initDaysContainer()` export with 5 delegated listeners; replaced `attachDragListeners` with private `startDrag` + rAF throttling
- `main.js` — import and call `initDaysContainer()` once before first `renderAll()`

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Expand/collapse days, add/edit/delete entries, drag reorder verified
- [ ] Holiday toggle and leave type select verified
- [ ] Right-click context menu, dblclick edit, star/logged toggles verified
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #178

🤖 Generated with [Claude Code](https://claude.ai/claude-code)