### PR TITLE
perf(tm-179): lazy-initialize stats and settings modals on first open

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -15,7 +15,7 @@ import { initEntryModal } from './modules/entry-modal.js';
 import { initCopyTo } from './modules/copy-to.js';
 import { initReport } from './modules/report.js';
 import { bindHeaderEvents, openWeekSwitcherModal } from './modules/header.js';
-import { initSettings, updateSheetDetailsDisplay, loadChangelog } from './modules/settings.js';
+import { updateSheetDetailsDisplay } from './modules/settings.js';
 import { loadErrorLog } from './modules/error-log.js';
 import { renderAll, initDaysContainer } from './modules/render.js';
 import { state } from './modules/state.js';
@@ -25,7 +25,6 @@ import { initOnboarding, needsOnboarding, showOnboarding } from './modules/onboa
 import { initNoTicketBanner, updateNoTicketBanner } from './modules/no-ticket-reminder.js';
 import { initUnderloggedBanner, updateUnderloggedBanner } from './modules/underlogged-reminder.js';
 import { initNotifications } from './modules/notifications.js';
-import { initStats } from './modules/stats.js';
 import { setCurrentWeek } from './modules/week.js';
 import { refreshSettings } from './modules/ai.js';
 import { initAiChat } from './modules/ai-chat.js';
@@ -37,14 +36,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.querySelectorAll('.app-version').forEach(el => el.textContent = APP_VERSION);
     initTheme();
     initRipple();
-    initSettings();
     initOnboarding();
     initNotifications();
     initNoTicketBanner();
     initUnderloggedBanner();
     initSidebar();
     initSummaryPanel();
-    initStats();
     initAiChat();
     initWeekSummary();
     initUpdater();
@@ -61,7 +58,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const restored = await loadState();
     refreshSettings();   // cache AI feature flags; fire-and-forget
     await loadErrorLog();
-    await loadChangelog();
 
     if (needsOnboarding()) await showOnboarding();
 

--- a/src/renderer/modules/settings.js
+++ b/src/renderer/modules/settings.js
@@ -43,6 +43,8 @@ let currentSection = 'general';
 let dirtySection   = null;
 let _pendingTarget = null;   // section key or '__close__'
 let settingsModalInst = null;
+let _settingsInited   = false;
+let _changelogLoaded  = false;
 
 /* ── CHANGELOG ──────────────────────────────────────────── */
 const CHANGELOG_KEY = 'changelog_v1';
@@ -124,12 +126,12 @@ export function initSettings() {
                 doNavigate(target);
             }
         });
-
-    doNavigate('general');
 }
 
 /* ── PUBLIC API ─────────────────────────────────────────── */
 export function openSettings(section = 'general') {
+    if (!_settingsInited) { initSettings(); _settingsInited = true; }
+    if (!_changelogLoaded) { loadChangelog(); _changelogLoaded = true; }
     doNavigate(section);
     settingsModalInst.show();
 }

--- a/src/renderer/modules/stats.js
+++ b/src/renderer/modules/stats.js
@@ -2,7 +2,8 @@ import { state } from './state.js';
 import { escHtml, minsToHHMM } from './utils.js';
 import { getWeekStrFromDate, getDateFromWeek } from './week.js';
 
-let _statsModal = null;
+let _statsModal  = null;
+let _statsInited = false;
 let _currentRange = 4;
 let _currentTab = 'weekly';
 
@@ -31,6 +32,7 @@ export function initStats() {
 }
 
 export function openStatsModal() {
+    if (!_statsInited) { initStats(); _statsInited = true; }
     _currentRange = 4;
     _currentTab = 'weekly';
     document.querySelectorAll('.stats-filter-btn').forEach(b => b.classList.remove('active'));


### PR DESCRIPTION
## Summary
- Move `initStats()`, `initSettings()`, and `loadChangelog()` out of the eager startup path
- Each initialises exactly once, on first modal open, guarded by a module-level flag
- Subsequent opens reuse already-initialised state with no re-init overhead

## Changes
- `src/renderer/main.js` — removed `initStats` import and the three eager calls (`initSettings()`, `initStats()`, `await loadChangelog()`)
- `src/renderer/modules/stats.js` — added `_statsInited` flag; `openStatsModal()` calls `initStats()` on first use
- `src/renderer/modules/settings.js` — added `_settingsInited` / `_changelogLoaded` flags; `openSettings()` lazy-calls both; removed redundant `doNavigate('general')` from inside `initSettings()`

## Testing
- [ ] Tested in Electron dev mode (`npm start`)
- [ ] Stats modal opens correctly on first and subsequent opens
- [ ] Settings modal opens on correct section, nav and dirty-state overlay work
- [ ] Changelog visible in About section
- [ ] Dark mode verified
- [ ] Light mode verified
- [ ] No console errors

Closes #179

🤖 Generated with [Claude Code](https://claude.ai/claude-code)