### PR TITLE
feat(tm-183): standup notes enhancements — template, fetch previous, skip-in-notes, AI enhance with undo

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -274,11 +274,24 @@
           <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
         </div>
         <div class="modal-body">
-          <textarea id="day-notes-textarea" class="day-notes-textarea dark-input" placeholder="Add standup notes, blockers, meeting outcomes…" rows="10"></textarea>
-          <p id="day-notes-hint" class="day-notes-hint">Double-click to edit</p>
+          <textarea id="day-notes-textarea" class="day-notes-textarea dark-input" rows="10"></textarea>
+          <div class="d-flex align-items-center justify-content-between mt-1">
+            <p id="day-notes-hint" class="day-notes-hint mb-0">Double-click to edit</p>
+            <div class="d-flex gap-2">
+              <button type="button" id="btn-undo-enhance-notes" class="btn btn-outline-secondary btn-sm" style="display:none;font-size:0.78rem">
+                <i class="bi bi-arrow-counterclockwise me-1"></i>Undo
+              </button>
+              <button type="button" id="btn-enhance-notes" class="btn btn-outline-light btn-sm" style="display:none;font-size:0.78rem">
+                <i class="bi bi-stars me-1"></i>Enhance
+              </button>
+            </div>
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-outline-secondary me-auto" id="btn-fetch-prev-notes">
+            <i class="bi bi-clock-history me-1"></i> Fetch Previous
+          </button>
           <button type="button" class="btn btn-gradient" id="btn-save-day-notes" disabled>
             <i class="bi bi-check-lg me-1"></i> Save
           </button>
@@ -477,6 +490,14 @@
             <div class="col-12">
               <label class="form-label label-text">Description</label>
               <textarea id="recurring-desc" class="form-control dark-input" rows="2" placeholder="Brief description of work done..."></textarea>
+            </div>
+            <div class="col-12">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="recurring-skip-notes" />
+                <label class="form-check-label label-text" for="recurring-skip-notes">
+                  Skip in standup notes
+                </label>
+              </div>
             </div>
             <div class="col-12">
               <label class="form-label label-text d-block mb-2">Repeat on</label>

--- a/src/renderer/modules/recurring.js
+++ b/src/renderer/modules/recurring.js
@@ -154,6 +154,7 @@ function renderRecurringList() {
             <span class="entry-ticket" style="color:${rColor}">${escHtml(rule.ticket || '—')}</span>
             <span class="entry-hours">${String(rule.hh || 0).padStart(2,'0')}:${String(rule.mm || 0).padStart(2,'0')}</span>
             ${rBadge}
+            ${rule.skipInNotes ? '<span class="badge bg-secondary" title="Excluded from standup notes"><i class="bi bi-journal-x me-1"></i>Skip Notes</span>' : ''}
           </div>
           <div class="text-muted" style="font-size:0.85rem">${escHtml(rule.desc || '')}</div>
           <div class="d-flex gap-1 mt-2">
@@ -197,6 +198,7 @@ export function openRecurringForm(rule) {
     document.querySelectorAll('.recurring-day-btn').forEach(btn => {
         btn.classList.toggle('selected', rule ? rule.days.includes(btn.dataset.day) : false);
     });
+    document.getElementById('recurring-skip-notes').checked = !!(rule?.skipInNotes);
     syncAllDaysCheckbox();
 
     [document.getElementById('recurring-ticket'), document.getElementById('recurring-desc'),
@@ -215,6 +217,7 @@ function saveRecurringRule() {
     const type = document.getElementById('recurring-type').value;
     const desc = document.getElementById('recurring-desc').value.trim();
     const selectedDays = [...document.querySelectorAll('.recurring-day-btn.selected')].map(b => b.dataset.day);
+    const skipInNotes = document.getElementById('recurring-skip-notes').checked;
 
     let hasError = false;
     [document.getElementById('recurring-ticket'), document.getElementById('recurring-desc'),
@@ -234,11 +237,11 @@ function saveRecurringRule() {
     if (existingId) {
         const rule = state.recurringTasks.find(r => r.id === existingId);
         if (rule) {
-            Object.assign(rule, { ticket, hh, mm, timeRaw, type, desc, days: selectedDays });
+            Object.assign(rule, { ticket, hh, mm, timeRaw, type, desc, days: selectedDays, skipInNotes });
             updateRecurringEntriesFromToday(rule);
         }
     } else {
-        const rule = { id: 'rec_' + Date.now(), ticket, hh, mm, timeRaw, type, desc, days: selectedDays };
+        const rule = { id: 'rec_' + Date.now(), ticket, hh, mm, timeRaw, type, desc, days: selectedDays, skipInNotes };
         state.recurringTasks.push(rule);
         populateRecurringForWeek(getDateFromWeek(state.weekValue || getWeekStrFromDate(new Date())));
     }

--- a/src/renderer/modules/render.js
+++ b/src/renderer/modules/render.js
@@ -1,7 +1,8 @@
 import { state, WEEK_DAYS, ROMAN } from './state.js';
 import { saveState } from './store.js';
-import { escHtml, fmtDisplayDate, minsToHHMM } from './utils.js';
+import { escHtml, fmtDate, fmtDisplayDate, minsToHHMM } from './utils.js';
 import { calcDayTotalMins, updateSummary } from './summary.js';
+import { showToast } from './toast.js';
 // Circular imports — resolved at call time (runtime only, not load time)
 import { openEntryModal } from './entry-modal.js';
 import { showEntryContextMenu } from './context-menu.js';
@@ -10,6 +11,7 @@ import { openDayQuickView } from './report.js';
 import { showEntryQuickView } from './context-menu.js';
 import { getTypeById } from './ticket-types.js';
 import { getLeaveLabel, resolveLeaveTypeId, populateLeaveSelect } from './leave-types.js';
+import { isFeatureEnabled, ask, askWithModel, getProvider } from './ai.js';
 
 let weekTransitionDir = null;
 
@@ -297,6 +299,125 @@ export function buildDayCard(day, dayIdx) {
 let _dayNotesModal = null;
 let _dayNotesIdx = -1;
 
+function stripAiPreamble(text) {
+    const lines = text.trim().split('\n');
+    const preambleRe = /^(sure[,.]|here is|here's|certainly|of course|below is|the improved|improved version)/i;
+    // Only drop leading preamble lines; preserve blank lines that separate sections
+    let start = 0;
+    while (start < lines.length && preambleRe.test(lines[start].trim())) start++;
+    return lines.slice(start).join('\n').trim();
+}
+
+function cleanMarkdown(text) {
+    return text
+        .replace(/^#+\s*/gm, '')
+        .replace(/\*\*([^*\n]+)\*\*/g, '$1')
+        .replace(/\*([^*\n]+)\*/g, '$1')
+        .replace(/`([^`\n]+)`/g, '$1');
+}
+
+async function fixGrammarLines(text, pastTense) {
+    const trimmed = text.trim();
+    if (!trimmed) return '';
+    const prompt = pastTense
+        ? `Fix grammar and change verbs to simple past tense in these standup lines.\n` +
+          `Rules:\n` +
+          `- Each line starts with "- TICKET-ID description". Keep "- TICKET-ID" exactly, only fix the description part.\n` +
+          `- Ticket IDs (e.g. JIRA-227, TM-99) are reference codes, NOT places or people.\n` +
+          `- Use simple past tense: "Meet" → "Met", "Work on" → "Worked on". Do NOT write "In the past..." or add any extra words.\n` +
+          `- Keep descriptions short and concise — same length as input.\n` +
+          `- No markdown. Return only the corrected lines.\n\n${trimmed}`
+        : `Fix grammar only. Keep all ticket IDs and names exactly as written. ` +
+          `Keep descriptions concise. No markdown. Return only the corrected lines.\n\n${trimmed}`;
+    const raw = getProvider() === 'local'
+        ? await askWithModel(prompt, null, 'qwen2.5:0.5b')
+        : await ask(prompt, null);
+    return raw ? cleanMarkdown(stripAiPreamble(raw)) : trimmed;
+}
+
+async function enhanceStandupNotes(text) {
+    const HEADERS = ['Yesterday:', 'Today:', 'Questions/Comments:'];
+    const order = [];
+    const sections = {};
+    let cur = null;
+
+    for (const line of text.split('\n')) {
+        if (HEADERS.includes(line.trim())) {
+            cur = line.trim();
+            order.push(cur);
+            sections[cur] = [];
+        } else if (cur) {
+            sections[cur].push(line);
+        }
+    }
+
+    // No standard headers — fix grammar on the whole text as-is
+    if (order.length === 0) return fixGrammarLines(text, false);
+
+    const out = [];
+    for (const header of order) {
+        out.push(header);
+        const enhanced = await fixGrammarLines(sections[header].join('\n'), header === 'Yesterday:');
+        if (enhanced) out.push(enhanced);
+        out.push('');
+    }
+    return out.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd();
+}
+
+function getPreviousWorkday(dateStr) {
+    const d = new Date(dateStr + 'T00:00:00');
+    for (let i = 0; i < 14; i++) {
+        d.setDate(d.getDate() - 1);
+        const dow = d.getDay();
+        if (dow === 0 || dow === 6) continue; // skip weekend
+        const dStr = fmtDate(d);
+        if (state.allDaysByDate[dStr]?.isHoliday) continue; // skip holiday
+        return dStr;
+    }
+    return null;
+}
+
+function formatEntriesForStandup(entries) {
+    if (!entries || entries.length === 0) return '';
+    return entries.map(e => {
+        const ticket = e.ticket?.trim();
+        const desc = e.desc?.trim();
+        return '- ' + [ticket, desc].filter(Boolean).join(' ');
+    }).join('\n');
+}
+
+// Returns the text content of the Yesterday section, or '' if absent/empty.
+function extractYesterdayContent(text) {
+    const m = text.match(/Yesterday:\n([\s\S]*?)(?=\n(?:Today:|Questions\/Comments:)|$)/);
+    return m ? m[1].trim() : '';
+}
+
+function filterStandupEntries(entries) {
+    if (!entries) return [];
+    return entries.filter(e => {
+        if (!e.recurringId) return true;
+        const rule = state.recurringTasks?.find(r => r.id === e.recurringId);
+        return !rule?.skipInNotes;
+    });
+}
+
+function buildStandupTemplate(currentDay) {
+    const prevDayStr = getPreviousWorkday(currentDay.date);
+
+    let out = 'Yesterday:\n';
+    if (prevDayStr) {
+        const prevText = formatEntriesForStandup(filterStandupEntries(state.allDaysByDate[prevDayStr]?.entries));
+        if (prevText) out += prevText + '\n';
+    }
+    out += '\n';
+
+    const todayText = formatEntriesForStandup(filterStandupEntries(currentDay.entries));
+    out += 'Today:\n' + (todayText ? todayText + '\n' : '') + '\n';
+
+    out += 'Questions/Comments:\n';
+    return out;
+}
+
 export function openDayNotesModal(dayIdx) {
     if (!_dayNotesModal) {
         _dayNotesModal = new bootstrap.Modal(document.getElementById('dayNotesModal'));
@@ -311,21 +432,33 @@ export function openDayNotesModal(dayIdx) {
     const dirty = document.getElementById('day-notes-dirty');
     const hint = document.getElementById('day-notes-hint');
     const saveBtn = document.getElementById('btn-save-day-notes');
+    const enhanceBtn = document.getElementById('btn-enhance-notes');
+    const undoEnhanceBtn = document.getElementById('btn-undo-enhance-notes');
 
     const originalNotes = day.notes || '';
-    textarea.value = originalNotes;
+    textarea.value = originalNotes || buildStandupTemplate(day);
 
     const hasExisting = !!originalNotes;
     textarea.readOnly = hasExisting;
     hint.style.display = hasExisting ? 'block' : 'none';
     dirty.style.display = 'none';
     saveBtn.disabled = true;
+    undoEnhanceBtn.style.display = 'none';
+    let preEnhanceSnapshot = null;
 
     const markDirty = () => {
         const isDirty = textarea.value !== originalNotes;
         dirty.style.display = isDirty ? 'inline' : 'none';
         saveBtn.disabled = !isDirty;
     };
+
+    const updateEnhanceBtn = () => {
+        enhanceBtn.style.display =
+            isFeatureEnabled('suggestions') && textarea.value.trim() ? '' : 'none';
+    };
+
+    markDirty();
+    updateEnhanceBtn();
 
     textarea.ondblclick = () => {
         if (textarea.readOnly) {
@@ -337,7 +470,39 @@ export function openDayNotesModal(dayIdx) {
         }
     };
 
-    textarea.oninput = markDirty;
+    textarea.oninput = () => { markDirty(); updateEnhanceBtn(); };
+
+    enhanceBtn.onclick = async () => {
+        const current = textarea.value.trim();
+        if (!current) return;
+
+        textarea.readOnly = false;
+        hint.style.display = 'none';
+
+        const icon = enhanceBtn.querySelector('i');
+        enhanceBtn.disabled = true;
+        icon.className = 'bi bi-hourglass-split me-1';
+
+        preEnhanceSnapshot = textarea.value;
+        const improved = await enhanceStandupNotes(current);
+        if (improved) {
+            textarea.value = improved;
+            markDirty();
+            undoEnhanceBtn.style.display = '';
+        }
+
+        icon.className = 'bi bi-stars me-1';
+        enhanceBtn.disabled = false;
+    };
+
+    undoEnhanceBtn.onclick = () => {
+        if (preEnhanceSnapshot === null) return;
+        textarea.value = preEnhanceSnapshot;
+        preEnhanceSnapshot = null;
+        undoEnhanceBtn.style.display = 'none';
+        markDirty();
+        updateEnhanceBtn();
+    };
 
     saveBtn.onclick = () => {
         state.days[_dayNotesIdx].notes = textarea.value;
@@ -365,7 +530,38 @@ export function openDayNotesModal(dayIdx) {
                 existingIndicator.remove();
             }
         }
+        undoEnhanceBtn.style.display = 'none';
+        preEnhanceSnapshot = null;
         _dayNotesModal.hide();
+    };
+
+    document.getElementById('btn-fetch-prev-notes').onclick = () => {
+        const currentDay = state.days[_dayNotesIdx];
+        const currentVal = textarea.value;
+
+        if (extractYesterdayContent(currentVal)) {
+            showToast('Yesterday already filled — not overriding', 'info');
+            return;
+        }
+
+        // Template not present at all → insert full template
+        if (!currentVal.includes('Yesterday:')) {
+            const existing = currentVal.trimEnd();
+            textarea.value = existing ? existing + '\n\n' + buildStandupTemplate(currentDay) : buildStandupTemplate(currentDay);
+        } else {
+            // Template present but Yesterday is empty → inject entries after "Yesterday:\n"
+            const prevDayStr = getPreviousWorkday(currentDay.date);
+            const prevText = prevDayStr ? formatEntriesForStandup(filterStandupEntries(state.allDaysByDate[prevDayStr]?.entries)) : '';
+            if (prevText) {
+                textarea.value = currentVal.replace(/Yesterday:\n/, 'Yesterday:\n' + prevText + '\n');
+            }
+        }
+
+        textarea.readOnly = false;
+        hint.style.display = 'none';
+        markDirty();
+        textarea.focus();
+        textarea.setSelectionRange(textarea.value.length, textarea.value.length);
     };
 
     _dayNotesModal.show();


### PR DESCRIPTION
## Summary

- Auto-fills standup template with real timesheet entries on first open; Save enabled immediately
- **Fetch Previous** button populates Yesterday from the prior workday (skips weekends + holidays)
- Recurring tasks get a **Skip in standup notes** checkbox; flagged rules are excluded from templates
- **AI Enhance** processes each section independently (Yesterday in past tense) with **Undo** support

## Changes
- `src/renderer/index.html` — Fetch Previous, Enhance, Undo buttons; Skip in Notes checkbox in recurring form
- `src/renderer/modules/render.js` — template builder, workday finder, section-by-section AI enhancement
- `src/renderer/modules/recurring.js` — `skipInNotes` field persisted and shown in list

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)